### PR TITLE
show events on deploy.

### DIFF
--- a/service.go
+++ b/service.go
@@ -24,9 +24,19 @@ func formatDeployment(d *ecs.Deployment) string {
 	)
 }
 
-func formatEvent(e *ecs.ServiceEvent) string {
-	return fmt.Sprintf("%s: %s",
-		e.CreatedAt.In(timezone).Format(time.RFC3339),
+func formatEvent(e *ecs.ServiceEvent, chars int) []string {
+	line := fmt.Sprintf("%s %s",
+		e.CreatedAt.In(timezone).Format("2006/01/02 15:04:05"),
 		*e.Message,
 	)
+	lines := []string{}
+	n := len(line)/chars + 1
+	for i := 0; i < n; i++ {
+		if i == n-1 {
+			lines = append(lines, line[i*chars:])
+		} else {
+			lines = append(lines, line[i*chars:(i+1)*chars])
+		}
+	}
+	return lines
 }


### PR DESCRIPTION
Show events on deploy like status.

```console
2017/12/26 23:46:32 myapp/default Starting deploy
Service: myapp
Cluster: default
TaskDefinition: myapp:2
Deployments:
    PRIMARY myapp:2 desired:1 pending:0 running:1
Events:
2017/12/26 23:46:33 myapp/default desired count: 0
2017/12/26 23:46:33 myapp/default Updating service...
2017/12/26 23:46:33 myapp/default Waiting for service stable...(it will take a few minutes)
2017/12/26 23:47:14 myapp/default  PRIMARY myapp:2 desired:0 pending:0 running:1
2017/12/26 23:46:45 (service myapp) has begun draining connections on 1 tasks.
2017/12/26 23:46:45 (service myapp) deregistered 1 targets in (target-group arn:aws:
elasticloadbalancing:us-east-1:99999999999:targetgroup/myapp/ab929826e570edd5)
2017/12/26 23:47:19 myapp/default Service is stable now. Completed!
```