### PR TITLE
Load a plain task definition.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ timeout: 5m
 ecspresso works as below.
 
 - Register a new task definition from JSON file.
-  - JSON file is same format as `aws ecs describe-task-definition` output.
+  - JSON file is allowed both of formats as below.
+    - `aws ecs describe-task-definition` output.
+    - `aws ecs register-task-definition --cli-input-json` input.
   - Replace ```{{ env `FOO` `bar` }}``` syntax in the JSON file to environment variable "FOO".
     - If "FOO" is not defined, replaced by "bar"
   - Replace ```{{ must_env `FOO` }}``` syntax in the JSON file to environment variable "FOO".

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -366,7 +366,14 @@ func (d *App) LoadTaskDefinition(path string) (*ecs.TaskDefinition, error) {
 	if err := config.LoadWithEnvJSON(&c, path); err != nil {
 		return nil, err
 	}
-	return c.TaskDefinition, nil
+	if c.TaskDefinition != nil {
+		return c.TaskDefinition, nil
+	}
+	var td ecs.TaskDefinition
+	if err := config.LoadWithEnvJSON(&td, path); err != nil {
+		return nil, err
+	}
+	return &td, nil
 }
 
 func (d *App) LoadServiceDefinition(path string) (*ecs.CreateServiceInput, error) {

--- a/ecspresso_test.go
+++ b/ecspresso_test.go
@@ -1,1 +1,28 @@
 package ecspresso_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kayac/ecspresso"
+)
+
+func TestLoadTaskDefinition(t *testing.T) {
+	for _, path := range []string{"tests/td.json", "tests/td-plain.json"} {
+		c := &ecspresso.Config{
+			Region:             "ap-northeast-1",
+			Timeout:            300 * time.Second,
+			Service:            "test",
+			Cluster:            "default",
+			TaskDefinitionPath: path,
+		}
+		app, err := ecspresso.NewApp(c)
+		if err != nil {
+			t.Error(err)
+		}
+		td, err := app.LoadTaskDefinition(path)
+		if err != nil || td == nil {
+			t.Errorf("%s load failed: %s", path, err)
+		}
+	}
+}

--- a/tests/td-plain.json
+++ b/tests/td-plain.json
@@ -1,0 +1,57 @@
+{
+  "status": "ACTIVE",
+  "networkMode": "awsvpc",
+  "family": "katsubushi",
+  "placementConstraints": [],
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "volumes": [],
+  "taskRoleArn": "arn:aws:iam::999999999999:role/ecsTaskRole",
+  "executionRoleArn": "arn:aws:iam::999999999999:role/ecsTaskRole",
+  "containerDefinitions": [
+    {
+      "environment": [
+        {
+          "name": "worker_id",
+          "value": "3"
+        }
+      ],
+      "name": "katsubushi",
+      "mountPoints": [],
+      "portMappings": [
+        {
+          "protocol": "tcp",
+          "containerPort": 11212,
+          "hostPort": 11212
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "fargate",
+          "awslogs-region": "us-east-1",
+          "awslogs-stream-prefix": "katsubushi"
+        }
+      },
+      "image": "katsubushi/katsubushi:{{ env `TAG` `latest` }}",
+      "dockerLabels": {
+        "name": "katsubushi"
+      },
+      "cpu": 256,
+      "ulimits": [
+        {
+          "softLimit": 100000,
+          "name": "nofile",
+          "hardLimit": 100000
+        }
+      ],
+      "memory": 16,
+      "essential": true,
+      "volumesFrom": []
+    }
+  ],
+  "revision": 1,
+  "cpu": "1024",
+  "memory": "2048"
+}

--- a/tests/td.json
+++ b/tests/td.json
@@ -1,0 +1,59 @@
+{
+  "taskDefinition": {
+    "status": "ACTIVE",
+    "networkMode": "awsvpc",
+    "family": "katsubushi",
+    "placementConstraints": [],
+    "requiresCompatibilities": [
+      "FARGATE"
+    ],
+    "volumes": [],
+    "taskRoleArn": "arn:aws:iam::999999999999:role/ecsTaskRole",
+    "executionRoleArn": "arn:aws:iam::999999999999:role/ecsTaskRole",
+    "containerDefinitions": [
+      {
+        "environment": [
+          {
+            "name": "worker_id",
+            "value": "3"
+          }
+        ],
+        "name": "katsubushi",
+        "mountPoints": [],
+        "portMappings": [
+          {
+            "protocol": "tcp",
+            "containerPort": 11212,
+            "hostPort": 11212
+          }
+        ],
+        "logConfiguration": {
+          "logDriver": "awslogs",
+          "options": {
+            "awslogs-group": "fargate",
+            "awslogs-region": "us-east-1",
+            "awslogs-stream-prefix": "katsubushi"
+          }
+        },
+        "image": "katsubushi/katsubushi:{{ env `TAG` `latest` }}",
+        "dockerLabels": {
+          "name": "katsubushi"
+        },
+        "cpu": 256,
+        "ulimits": [
+          {
+            "softLimit": 100000,
+            "name": "nofile",
+            "hardLimit": 100000
+          }
+        ],
+        "memory": 16,
+        "essential": true,
+        "volumesFrom": []
+      }
+    ],
+    "revision": 1,
+    "cpu": "1024",
+    "memory": "2048"
+  }
+}


### PR DESCRIPTION
Accept a plain task definition JSON.
At first, load JSON as complex format(for compatibility), and then fallback to plain format.
