### PR TITLE
add --deregister-task-definition to rollback command

### DIFF
--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -38,6 +38,7 @@ func _main() int {
 	rollback := kingpin.Command("rollback", "rollback service")
 	rollbackOption := ecspresso.RollbackOption{
 		DryRun: rollback.Flag("dry-run", "dry-run").Bool(),
+		DeregisterTaskDefinition: rollback.Flag("dereginster-task-definition", "deregister rolled back task definition").Bool(),
 	}
 
 	sub := kingpin.Parse()

--- a/options.go
+++ b/options.go
@@ -17,5 +17,6 @@ type StatusOption struct {
 }
 
 type RollbackOption struct {
-	DryRun *bool
+	DryRun                   *bool
+	DeregisterTaskDefinition *bool
 }


### PR DESCRIPTION
Deregister a rolled back task definition when rollback is over successfully.