### PR TITLE
configurable desiredCount on service creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,21 @@ vendor/
 pkg/
 
 *~
+### https://raw.github.com/github/gitignore/9da1b5d8ce4e009ff627c4fe49a4488b2a3f60d4/Global/Vim.gitignore
+
+# Swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-v][a-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+
+# Temporary
+.netrwhist
+*~
+# Auto-generated tag files
+tags
+
+

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ example of service.json below.
 ```json
 {
   "role": "ecsServiceRole",
+  "desiredCount": 2,
   "loadBalancers": [
     {
       "containerName": "myLoadbalancer",

--- a/config.go
+++ b/config.go
@@ -25,6 +25,7 @@ type ServiceDefinition struct {
 	PlacementConstraints    []*ecs.PlacementConstraint   `json:"placementConstraints"`
 	PlacementStrategy       []*ecs.PlacementStrategy     `json:"placementStrategy"`
 	Role                    *string                      `json:"role"`
+	DesiredCount            *int64                       `json:"desiredCount"`
 }
 
 func (c *Config) Validate() error {

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -139,7 +139,10 @@ func (d *App) Create(opt CreateOption) error {
 	if err != nil {
 		return errors.Wrap(err, "create failed")
 	}
-	svd.DesiredCount = opt.DesiredCount
+
+	if *opt.DesiredCount != 1 {
+                svd.DesiredCount= opt.DesiredCount
+        }
 
 	if *opt.DryRun {
 		d.Log("task definition:", td.String())
@@ -403,9 +406,17 @@ func (d *App) LoadServiceDefinition(path string) (*ecs.CreateServiceInput, error
 	if err := config.LoadWithEnvJSON(&c, path); err != nil {
 		return nil, err
 	}
+
+	var count *int64
+	if c.DesiredCount == nil {
+		count = aws.Int64(1)
+	} else {
+		count = c.DesiredCount
+	}
+
 	return &ecs.CreateServiceInput{
 		Cluster:                 aws.String(d.config.Cluster),
-		DesiredCount:            aws.Int64(1),
+		DesiredCount:            count,
 		ServiceName:             aws.String(d.config.Service),
 		DeploymentConfiguration: c.DeploymentConfiguration,
 		LaunchType:              c.LaunchType,


### PR DESCRIPTION
- enable setting `desiredCount` in service_definition json
- only override `desiredCount` when option (--tasks) is specified
