### PR TITLE
Update to aws-sdk-go v1.14.5

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -41,12 +41,15 @@
     "aws/credentials/ec2rolecreds",
     "aws/credentials/endpointcreds",
     "aws/credentials/stscreds",
+    "aws/csm",
     "aws/defaults",
     "aws/ec2metadata",
     "aws/endpoints",
     "aws/request",
     "aws/session",
     "aws/signer/v4",
+    "internal/sdkio",
+    "internal/sdkrand",
     "internal/shareddefaults",
     "private/protocol",
     "private/protocol/json/jsonutil",
@@ -55,11 +58,12 @@
     "private/protocol/query/queryutil",
     "private/protocol/rest",
     "private/protocol/xml/xmlutil",
+    "service/cloudwatchlogs",
     "service/ecs",
     "service/sts"
   ]
-  revision = "82ad808f2307df0776c038bfd7ea85440a35c02e"
-  version = "v1.12.53"
+  revision = "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219"
+  version = "v1.14.5"
 
 [[projects]]
   name = "github.com/go-ini/ini"
@@ -126,6 +130,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "90f5256a7f8c45c8e24bb4fc0d16de7eb3bb3284269cf0cbd667f5b35bf7734b"
+  inputs-digest = "5dc70bcc0dc4a10bad0475a0333d17e4e201cc5bc150d73a8dc93071572d5d20"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -32,4 +32,4 @@
 
 [[constraint]]
   name = "github.com/aws/aws-sdk-go"
-  version = "v1.12.53"
+  version = "v1.14.5"

--- a/config.go
+++ b/config.go
@@ -18,14 +18,17 @@ type Config struct {
 }
 
 type ServiceDefinition struct {
-	DeploymentConfiguration *ecs.DeploymentConfiguration `json:"deploymentConfiguration"`
-	LaunchType              *string                      `json:"launchType"`
-	LoadBalancers           []*ecs.LoadBalancer          `json:"loadBalancers"`
-	NetworkConfiguration    *ecs.NetworkConfiguration    `json:"networkConfiguration"`
-	PlacementConstraints    []*ecs.PlacementConstraint   `json:"placementConstraints"`
-	PlacementStrategy       []*ecs.PlacementStrategy     `json:"placementStrategy"`
-	Role                    *string                      `json:"role"`
-	DesiredCount            *int64                       `json:"desiredCount"`
+	DeploymentConfiguration       *ecs.DeploymentConfiguration `json:"deployment_configuration"`
+	DesiredCount                  *int64                       `json:"desired_count"`
+	HealthCheckGracePeriodSeconds *int64                       `json:"health_check_grace_period_seconds"`
+	LaunchType                    *string                      `json:"launch_type"`
+	LoadBalancers                 []*ecs.LoadBalancer          `json:"load_balancers"`
+	NetworkConfiguration          *ecs.NetworkConfiguration    `json:"network_configuration"`
+	PlacementConstraints          []*ecs.PlacementConstraint   `json:"placement_constraints"`
+	PlacementStrategy             []*ecs.PlacementStrategy     `json:"placement_strategy"`
+	PlatformVersion               *string                      `json:"platform_version"`
+	Role                          *string                      `json:"role"`
+	SchedulingStrategy            *string                      `json:"scheduling_strategy"`
 }
 
 func (c *Config) Validate() error {

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -506,12 +506,14 @@ func (d *App) UpdateService(ctx context.Context, taskDefinitionArn string, count
 	_, err := d.ecs.UpdateServiceWithContext(
 		ctx,
 		&ecs.UpdateServiceInput{
-			Service:              aws.String(d.Service),
-			Cluster:              aws.String(d.Cluster),
-			TaskDefinition:       aws.String(taskDefinitionArn),
-			DesiredCount:         &count,
-			ForceNewDeployment:   &force,
-			NetworkConfiguration: sv.NetworkConfiguration,
+			Service:                       aws.String(d.Service),
+			Cluster:                       aws.String(d.Cluster),
+			TaskDefinition:                aws.String(taskDefinitionArn),
+			DesiredCount:                  &count,
+			ForceNewDeployment:            &force,
+			NetworkConfiguration:          sv.NetworkConfiguration,
+			HealthCheckGracePeriodSeconds: sv.HealthCheckGracePeriodSeconds,
+			PlatformVersion:               sv.PlatformVersion,
 		},
 	)
 	return err
@@ -574,16 +576,19 @@ func (d *App) LoadServiceDefinition(path string) (*ecs.CreateServiceInput, error
 	}
 
 	return &ecs.CreateServiceInput{
-		Cluster:                 aws.String(d.config.Cluster),
-		DesiredCount:            count,
-		ServiceName:             aws.String(d.config.Service),
-		DeploymentConfiguration: c.DeploymentConfiguration,
-		LaunchType:              c.LaunchType,
-		LoadBalancers:           c.LoadBalancers,
-		NetworkConfiguration:    c.NetworkConfiguration,
-		PlacementConstraints:    c.PlacementConstraints,
-		PlacementStrategy:       c.PlacementStrategy,
-		Role:                    c.Role,
+		Cluster:                       aws.String(d.config.Cluster),
+		DesiredCount:                  count,
+		ServiceName:                   aws.String(d.config.Service),
+		DeploymentConfiguration:       c.DeploymentConfiguration,
+		HealthCheckGracePeriodSeconds: c.HealthCheckGracePeriodSeconds,
+		LaunchType:                    c.LaunchType,
+		LoadBalancers:                 c.LoadBalancers,
+		NetworkConfiguration:          c.NetworkConfiguration,
+		PlatformVersion:               c.PlatformVersion,
+		PlacementConstraints:          c.PlacementConstraints,
+		PlacementStrategy:             c.PlacementStrategy,
+		Role:                          c.Role,
+		SchedulingStrategy:            c.SchedulingStrategy,
 	}, nil
 }
 


### PR DESCRIPTION
Supports HealthCheckGracePeriodSeconds, PlatformVersion and SchedulingStrategy for service attributes.