### PR TITLE
Fix/0.6.0

### DIFF
--- a/config.go
+++ b/config.go
@@ -18,17 +18,17 @@ type Config struct {
 }
 
 type ServiceDefinition struct {
-	DeploymentConfiguration       *ecs.DeploymentConfiguration `json:"deployment_configuration"`
-	DesiredCount                  *int64                       `json:"desired_count"`
-	HealthCheckGracePeriodSeconds *int64                       `json:"health_check_grace_period_seconds"`
-	LaunchType                    *string                      `json:"launch_type"`
-	LoadBalancers                 []*ecs.LoadBalancer          `json:"load_balancers"`
-	NetworkConfiguration          *ecs.NetworkConfiguration    `json:"network_configuration"`
-	PlacementConstraints          []*ecs.PlacementConstraint   `json:"placement_constraints"`
-	PlacementStrategy             []*ecs.PlacementStrategy     `json:"placement_strategy"`
-	PlatformVersion               *string                      `json:"platform_version"`
+	DeploymentConfiguration       *ecs.DeploymentConfiguration `json:"deploymentConfiguration"`
+	DesiredCount                  *int64                       `json:"desiredCount"`
+	HealthCheckGracePeriodSeconds *int64                       `json:"healthCheckGracePeriod_seconds"`
+	LaunchType                    *string                      `json:"launchType"`
+	LoadBalancers                 []*ecs.LoadBalancer          `json:"loadBalancers"`
+	NetworkConfiguration          *ecs.NetworkConfiguration    `json:"networkConfiguration"`
+	PlacementConstraints          []*ecs.PlacementConstraint   `json:"placementConstraints"`
+	PlacementStrategy             []*ecs.PlacementStrategy     `json:"placementStrategy"`
+	PlatformVersion               *string                      `json:"platformVersion"`
 	Role                          *string                      `json:"role"`
-	SchedulingStrategy            *string                      `json:"scheduling_strategy"`
+	SchedulingStrategy            *string                      `json:"schedulingStrategy"`
 }
 
 func (c *Config) Validate() error {

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,30 @@
+package ecspresso_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kayac/ecspresso"
+)
+
+func TestLoadServiceDefinition(t *testing.T) {
+	path := "tests/sv.json"
+	c := &ecspresso.Config{
+		Region:             "ap-northeast-1",
+		Timeout:            300 * time.Second,
+		Service:            "test",
+		Cluster:            "default",
+		TaskDefinitionPath: "tests/td.json",
+	}
+	app, err := ecspresso.NewApp(c)
+	if err != nil {
+		t.Error(err)
+	}
+	sv, err := app.LoadServiceDefinition(path)
+	if err != nil || sv == nil {
+		t.Errorf("%s load failed: %s", path, err)
+	}
+	if *sv.SchedulingStrategy != "REPLICA" {
+		t.Errorf("unexpected SchedulingStrategy: %s", *sv.SchedulingStrategy)
+	}
+}

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -569,7 +569,8 @@ func (d *App) LoadServiceDefinition(path string) (*ecs.CreateServiceInput, error
 	}
 
 	var count *int64
-	if c.DesiredCount == nil {
+	if c.SchedulingStrategy == nil || *c.SchedulingStrategy == "REPLICA" && c.DesiredCount == nil {
+		// set default desired count to 1 only when SchedulingStrategy is REPLICA(default)
 		count = aws.Int64(1)
 	} else {
 		count = c.DesiredCount

--- a/tests/sv.json
+++ b/tests/sv.json
@@ -1,0 +1,25 @@
+{
+  "desiredCount": 2,
+  "loadBalancers": [
+    {
+      "containerName": "test",
+      "containerPort": 9999,
+      "targetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:1111111111:targetgroup/test/12345678"
+    }
+  ],
+  "launchType": "EC2",
+  "schedulingStrategy": "REPLICA",
+  "networkConfiguration": {
+    "awsvpcConfiguration": {
+      "subnets": [
+        "subnet-abcdef00",
+        "subnet-abcdef01"
+      ],
+      "securityGroups": [
+        "sg-12345678",
+        "sg-23456789"
+      ],
+      "assignPublicIp": "ENABLED"
+    }
+  }
+}


### PR DESCRIPTION
0.6.0 is broken...

When schedulingStrategy is "DAEMON", Do not set desiredCount into ecs.CreateServiceInput.

ECS API says
> The daemon scheduling strategy does not support a desired count for services. Remove the desired count value and try again