### PR TITLE
Change config.Load to config.LoadWithEnv

### DIFF
--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -65,7 +65,7 @@ func _main() int {
 	}
 
 	c := ecspresso.NewDefaultConfig()
-	if err := config.Load(c, *conf); err != nil {
+	if err := config.LoadWithEnv(c, *conf); err != nil {
 		log.Println("Cloud not load config file", conf, err)
 		kingpin.Usage()
 		return 1


### PR DESCRIPTION
In order to dynamically change the setting of ECS cluster, Changed to use environment variable in config.yaml as well.
In my case I am deploying from CircleCI(e.g. push to deploy/`develpment` branch -> deploy to xxx-`development` cluster).
