### PR TITLE
update to aws-sdk-go v1.19.26

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Songmu/prompter v0.0.0-20150725163906-b5721e8d5566
 	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc
 	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf
-	github.com/aws/aws-sdk-go v1.17.13
+	github.com/aws/aws-sdk-go v1.19.26
 	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
 	github.com/kayac/go-config v0.0.1
 	github.com/mattn/go-isatty v0.0.3

--- a/go.mod
+++ b/go.mod
@@ -3,18 +3,23 @@ module github.com/kayac/ecspresso
 go 1.12
 
 require (
-	github.com/BurntSushi/toml v0.3.0
+	github.com/BurntSushi/toml v0.3.0 // indirect
 	github.com/Songmu/prompter v0.0.0-20150725163906-b5721e8d5566
-	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc
-	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf
+	github.com/alecthomas/assert v0.0.0-20170929043011-405dbfeb8e38 // indirect
+	github.com/alecthomas/colour v0.0.0-20160524082231-60882d9e2721 // indirect
+	github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1 // indirect
+	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc // indirect
+	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
 	github.com/aws/aws-sdk-go v1.19.26
-	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
 	github.com/kayac/go-config v0.0.1
+	github.com/kr/pretty v0.1.0 // indirect
 	github.com/mattn/go-isatty v0.0.3
 	github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c
 	github.com/pkg/errors v0.8.0
-	golang.org/x/crypto v0.0.0-20180322175230-88942b9c40a4
-	golang.org/x/sys v0.0.0-20171130163741-8b4580aae2a0
+	github.com/sergi/go-diff v1.0.0 // indirect
+	github.com/stretchr/testify v1.3.0 // indirect
+	golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c // indirect
 	gopkg.in/alecthomas/kingpin.v2 v2.2.5
-	gopkg.in/yaml.v2 v2.0.0-20171116090243-287cf08546ab
+	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
+	gopkg.in/yaml.v2 v2.0.0-20171116090243-287cf08546ab // indirect
 )


### PR DESCRIPTION
- https://github.com/aws/aws-sdk-go/releases/tag/v1.19.3
   > This release of Amazon Elastic Container Service (Amazon ECS) introduces support for external deployment controllers for ECS services with the launch of task set management APIs. Task sets are a new primitive for controlled management of application deployments within a single ECS service.
- https://github.com/aws/aws-sdk-go/releases/tag/v1.19.22
   > This release of Amazon Elastic Container Service (Amazon ECS) introduces additional task definition parameters that enable you to define secret options for Docker log configuration, a per-container list contains secrets stored in AWS Systems Manager Parameter Store or AWS Secrets Manager.

