### PR TITLE
add --no-wait to run command.

### DIFF
--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -56,6 +56,7 @@ func _main() int {
 	runOption := ecspresso.RunOption{
 		DryRun:         run.Flag("dry-run", "dry-run").Bool(),
 		TaskDefinition: run.Flag("task-def", "task definition json for run task").String(),
+		NoWait:         run.Flag("no-wait", "exit ecspresso after task run").Bool(),
 	}
 
 	sub := kingpin.Parse()

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -320,6 +320,10 @@ func (d *App) Run(opt RunOption) error {
 	if err != nil {
 		return errors.Wrap(err, "run failed")
 	}
+	if *opt.NoWait {
+		d.Log("Run task invoked")
+		return nil
+	}
 	if err := d.WaitRunTask(ctx, task, lc, time.Now()); err != nil {
 		return errors.Wrap(err, "run failed")
 	}

--- a/options.go
+++ b/options.go
@@ -29,4 +29,5 @@ type DeleteOption struct {
 type RunOption struct {
 	DryRun         *bool
 	TaskDefinition *string
+	NoWait         *bool
 }


### PR DESCRIPTION
This options is useful to invoke a long term task and exit immediately.