### PR TITLE
Add --overrides, --count and --skip-task-definition to run command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,9 @@ Keys are same format as `aws ecs describe-services` output.
 ```console
 $ ecspresso run --config config.yaml --task-def=db-migrate.json
 ```
+
+When `--task-def` is not set, use a task definition included in a service.
+
 # Notes
 
 ## Deploy to Fargate

--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -59,6 +59,7 @@ func _main() int {
 		NoWait:             run.Flag("no-wait", "exit ecspresso after task run").Bool(),
 		TaskOverrideStr:    run.Flag("overrides", "task overrides JSON string").Default("").String(),
 		SkipTaskDefinition: run.Flag("skip-task-definition", "skip register a new task definition").Bool(),
+		Count:              run.Flag("count", "the number of tasks (max 10)").Default("1").Int64(),
 	}
 
 	sub := kingpin.Parse()

--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -54,9 +54,11 @@ func _main() int {
 
 	run := kingpin.Command("run", "run task")
 	runOption := ecspresso.RunOption{
-		DryRun:         run.Flag("dry-run", "dry-run").Bool(),
-		TaskDefinition: run.Flag("task-def", "task definition json for run task").String(),
-		NoWait:         run.Flag("no-wait", "exit ecspresso after task run").Bool(),
+		DryRun:             run.Flag("dry-run", "dry-run").Bool(),
+		TaskDefinition:     run.Flag("task-def", "task definition json for run task").String(),
+		NoWait:             run.Flag("no-wait", "exit ecspresso after task run").Bool(),
+		TaskOverrideStr:    run.Flag("overrides", "task overrides JSON string").Default("").String(),
+		SkipTaskDefinition: run.Flag("skip-task-definition", "skip register a new task definition").Bool(),
 	}
 
 	sub := kingpin.Parse()

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -348,7 +348,7 @@ func (d *App) Run(opt RunOption) error {
 		return nil
 	}
 
-	task, err := d.RunTask(ctx, tdArn, sv, &ov)
+	task, err := d.RunTask(ctx, tdArn, sv, &ov, *opt.Count)
 	if err != nil {
 		return errors.Wrap(err, "run failed")
 	}
@@ -653,7 +653,7 @@ func (d *App) GetLogInfo(task *ecs.Task, lc *ecs.LogConfiguration) (string, stri
 	return logGroup, logStream
 }
 
-func (d *App) RunTask(ctx context.Context, tdArn string, sv *ecs.Service, ov *ecs.TaskOverride) (*ecs.Task, error) {
+func (d *App) RunTask(ctx context.Context, tdArn string, sv *ecs.Service, ov *ecs.TaskOverride, count int64) (*ecs.Task, error) {
 	d.Log("Running task")
 
 	out, err := d.ecs.RunTaskWithContext(
@@ -664,6 +664,7 @@ func (d *App) RunTask(ctx context.Context, tdArn string, sv *ecs.Service, ov *ec
 			NetworkConfiguration: sv.NetworkConfiguration,
 			LaunchType:           sv.LaunchType,
 			Overrides:            ov,
+			Count:                aws.Int64(count),
 		},
 	)
 	if err != nil {

--- a/options.go
+++ b/options.go
@@ -32,4 +32,5 @@ type RunOption struct {
 	NoWait             *bool
 	TaskOverrideStr    *string
 	SkipTaskDefinition *bool
+	Count              *int64
 }

--- a/options.go
+++ b/options.go
@@ -27,7 +27,9 @@ type DeleteOption struct {
 }
 
 type RunOption struct {
-	DryRun         *bool
-	TaskDefinition *string
-	NoWait         *bool
+	DryRun             *bool
+	TaskDefinition     *string
+	NoWait             *bool
+	TaskOverrideStr    *string
+	SkipTaskDefinition *bool
 }


### PR DESCRIPTION
I don't hope to register a new task definition every time run tasks.
When --skip-task-definition is set, run tasks using the task definition set in the service.