### PR TITLE
Update to aws-sdk-go-v1.23.13

### DIFF
--- a/ecspresso.go
+++ b/ecspresso.go
@@ -12,10 +12,10 @@ import (
 
 	"github.com/Songmu/prompter"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go/service/ecs"
-	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/kayac/go-config"
 	"github.com/mattn/go-isatty"
 	"github.com/morikuni/aec"
@@ -536,7 +536,10 @@ func (d *App) WaitServiceStable(ctx context.Context, startedAt time.Time) error 
 		}
 	}()
 
-	return d.ecs.WaitUntilServicesStableWithContext(ctx, d.DescribeServicesInput(), request.WithWaiterMaxAttempts(int(d.config.Timeout.Seconds() / 15)))
+	// Add an option request.WithWaiterMaxAttempts for a long timeout.
+	// SDK Default is 10 min (MaxAttempts=40 * Delay=15sec).
+	// https://github.com/aws/aws-sdk-go/blob/d57c8d96f72d9475194ccf18d2ba70ac294b0cb3/service/ecs/waiters.go#L82-L83
+	return d.ecs.WaitUntilServicesStableWithContext(ctx, d.DescribeServicesInput(), request.WithWaiterMaxAttempts(int(d.config.Timeout.Seconds()/15)))
 }
 
 func (d *App) UpdateService(ctx context.Context, taskDefinitionArn string, count *int64, force bool, sv *ecs.Service) error {

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1 // indirect
 	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc // indirect
 	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
-	github.com/aws/aws-sdk-go v1.19.45
+	github.com/aws/aws-sdk-go v1.23.13
 	github.com/kayac/go-config v0.0.1
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/mattn/go-isatty v0.0.3


### PR DESCRIPTION
Add comment for #34

https://github.com/aws/aws-sdk-go/blob/master/CHANGELOG.md

> v1.23.13 (2019-08-30)
> - This release of Amazon Elastic Container Service (Amazon ECS) introduces support for modifying the cluster settings for existing clusters, which enables you to toggle whether Container Insights is enabled or not. Support is also introduced for custom log routing using the ECS FireLens integration.

> v1.23.3 (2019-08-16)
> - This release of Amazon Elastic Container Service (Amazon ECS) introduces support for controlling the usage of swap space on a per-container basis for Linux containers.

> v1.21.0 (2019-07-18)
> - This release of Amazon Elastic Container Service (Amazon ECS) introduces support for cluster settings. Cluster settings specify whether CloudWatch Container Insights is enabled or disabled for the cluster.

> v1.19.45 (2019-06-06)
> - This release of Amazon Elastic Container Service (Amazon ECS) introduces support for launching container instances using supported Amazon EC2 instance types that have increased elastic network interface density. Using these instance types and opting in to the awsvpcTrunking account setting provides increased elastic network interface (ENI) density on newly launched container instances which allows you to place more tasks on each container instance.
