### PR TITLE
fix calculation way of attempts

### DIFF
--- a/ecspresso.go
+++ b/ecspresso.go
@@ -536,10 +536,14 @@ func (d *App) WaitServiceStable(ctx context.Context, startedAt time.Time) error 
 		}
 	}()
 
-	// Add an option request.WithWaiterMaxAttempts for a long timeout.
+	// Add an option WithWaiterDelay and request.WithWaiterMaxAttempts for a long timeout.
 	// SDK Default is 10 min (MaxAttempts=40 * Delay=15sec).
 	// https://github.com/aws/aws-sdk-go/blob/d57c8d96f72d9475194ccf18d2ba70ac294b0cb3/service/ecs/waiters.go#L82-L83
-	return d.ecs.WaitUntilServicesStableWithContext(ctx, d.DescribeServicesInput(), request.WithWaiterMaxAttempts(int(d.config.Timeout.Seconds()/15)))
+	return d.ecs.WaitUntilServicesStableWithContext(
+		ctx, d.DescribeServicesInput(),
+		request.WithWaiterDelay(request.ConstantWaiterDelay(15*time.Second)),
+		request.WithWaiterMaxAttempts(int(d.config.Timeout.Seconds()/15)),
+	)
 }
 
 func (d *App) UpdateService(ctx context.Context, taskDefinitionArn string, count *int64, force bool, sv *ecs.Service) error {

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -537,12 +537,18 @@ func (d *App) WaitServiceStable(ctx context.Context, startedAt time.Time) error 
 	}()
 
 	// Add an option WithWaiterDelay and request.WithWaiterMaxAttempts for a long timeout.
-	// SDK Default is 10 min (MaxAttempts=40 * Delay=15sec).
-	// https://github.com/aws/aws-sdk-go/blob/d57c8d96f72d9475194ccf18d2ba70ac294b0cb3/service/ecs/waiters.go#L82-L83
+	// SDK Default is 10 min (MaxAttempts=40 * Delay=15sec) at now.
+	// ref. https://github.com/aws/aws-sdk-go/blob/d57c8d96f72d9475194ccf18d2ba70ac294b0cb3/service/ecs/waiters.go#L82-L83
+	// Explicitly set these options so not being affected by the default setting.
+	const delay = 15 * time.Second
+	attempts := int((d.config.Timeout / delay)) + 1
+	if (d.config.Timeout % delay) > 0 {
+		attempts++
+	}
 	return d.ecs.WaitUntilServicesStableWithContext(
 		ctx, d.DescribeServicesInput(),
-		request.WithWaiterDelay(request.ConstantWaiterDelay(15*time.Second)),
-		request.WithWaiterMaxAttempts(int(d.config.Timeout.Seconds()/15)),
+		request.WithWaiterDelay(request.ConstantWaiterDelay(delay)),
+		request.WithWaiterMaxAttempts(attempts),
 	)
 }
 


### PR DESCRIPTION
This fix is around timeout attempts introduced in #34, that change is insufficient due to the boundary value problem. Due to this problem, the timeout occurs earlier than the setting value.

We should calculate the value of attempts by dividing, rounding up and adding 1. The reason for adding 1 is that the first attempt is performed without waiting for the delay.

It is difficult to explain, so here are some examples:

| timeout sec | attempts now (problem) | attempts desired (fixed) |
|-------------|--------------|-----------------|
| 14          |  0           |     2           |  
| 15          |  1           |     2           |
| 16          |  1           |     3           |