### PR TITLE
add `wait` subcommand and add `--no-wait` option to `deploy`, `create` and `rollback` subcommands

### DIFF
--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -27,12 +27,14 @@ func _main() int {
 		DesiredCount:       deploy.Flag("tasks", "desired count of tasks").Default("-1").Int64(),
 		SkipTaskDefinition: deploy.Flag("skip-task-definition", "skip register a new task definition").Bool(),
 		ForceNewDeployment: deploy.Flag("force-new-deployment", "force a new deployment of the service").Bool(),
+		NoWait:             deploy.Flag("no-wait", "exit ecspresso immediately after just deployed without waiting for service stable").Bool(),
 	}
 
 	create := kingpin.Command("create", "create service")
 	createOption := ecspresso.CreateOption{
 		DryRun:       create.Flag("dry-run", "dry-run").Bool(),
 		DesiredCount: create.Flag("tasks", "desired count of tasks").Default("1").Int64(),
+		NoWait:       create.Flag("no-wait", "exit ecspresso immediately after just created without waiting for service stable").Bool(),
 	}
 
 	status := kingpin.Command("status", "show status of service")
@@ -44,6 +46,7 @@ func _main() int {
 	rollbackOption := ecspresso.RollbackOption{
 		DryRun:                   rollback.Flag("dry-run", "dry-run").Bool(),
 		DeregisterTaskDefinition: rollback.Flag("deregister-task-definition", "deregister rolled back task definition").Bool(),
+		NoWait:                   rollback.Flag("no-wait", "exit ecspresso immediately after just rollbacked without waiting for service stable").Bool(),
 	}
 
 	delete := kingpin.Command("delete", "delete service")

--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -42,7 +42,7 @@ func _main() int {
 
 	rollback := kingpin.Command("rollback", "rollback service")
 	rollbackOption := ecspresso.RollbackOption{
-		DryRun: rollback.Flag("dry-run", "dry-run").Bool(),
+		DryRun:                   rollback.Flag("dry-run", "dry-run").Bool(),
 		DeregisterTaskDefinition: rollback.Flag("deregister-task-definition", "deregister rolled back task definition").Bool(),
 	}
 
@@ -60,6 +60,11 @@ func _main() int {
 		TaskOverrideStr:    run.Flag("overrides", "task overrides JSON string").Default("").String(),
 		SkipTaskDefinition: run.Flag("skip-task-definition", "skip register a new task definition").Bool(),
 		Count:              run.Flag("count", "the number of tasks (max 10)").Default("1").Int64(),
+	}
+
+	wait := kingpin.Command("wait", "wait until service stable")
+	waitOption := ecspresso.WaitOption{
+		DesiredCount: wait.Flag("tasks", "desired count of tasks").Default("-1").Int64(),
 	}
 
 	sub := kingpin.Parse()
@@ -93,6 +98,8 @@ func _main() int {
 		err = app.Delete(deleteOption)
 	case "run":
 		err = app.Run(runOption)
+	case "wait":
+		err = app.Wait(waitOption)
 	default:
 		kingpin.Usage()
 		return 1

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -241,6 +241,10 @@ func (d *App) Create(opt CreateOption) error {
 	}
 	d.Log("Service is created")
 
+	if *opt.NoWait {
+		return nil
+	}
+
 	start := time.Now()
 	time.Sleep(delayForServiceChanged) // wait for service created
 	if err := d.WaitServiceStable(ctx, start); err != nil {
@@ -416,6 +420,12 @@ func (d *App) Deploy(opt DeployOption) error {
 	if err := d.UpdateService(ctx, tdArn, count, *opt.ForceNewDeployment, sv); err != nil {
 		return errors.Wrap(err, "deploy failed")
 	}
+
+	if *opt.NoWait {
+		d.Log("Service is deployed.")
+		return nil
+	}
+
 	time.Sleep(delayForServiceChanged) // wait for service updated
 	if err := d.WaitServiceStable(ctx, time.Now()); err != nil {
 		return errors.Wrap(err, "deploy failed")
@@ -448,6 +458,12 @@ func (d *App) Rollback(opt RollbackOption) error {
 	if err := d.UpdateService(ctx, targetArn, sv.DesiredCount, false, sv); err != nil {
 		return errors.Wrap(err, "rollback failed")
 	}
+
+	if *opt.NoWait {
+		d.Log("Service is rollbacked.")
+		return nil
+	}
+
 	time.Sleep(delayForServiceChanged) // wait for service updated
 	if err := d.WaitServiceStable(ctx, time.Now()); err != nil {
 		return errors.Wrap(err, "rollback failed")

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -475,8 +475,29 @@ func (d *App) Rollback(opt RollbackOption) error {
 func (d *App) Wait(opt WaitOption) error {
 	ctx, cancel := d.Start()
 	defer cancel()
-	_ = ctx
 
+	d.Log("Waiting for the service stable")
+	sv, err := d.DescribeServiceStatus(ctx, 0)
+	if err != nil {
+		return errors.Wrap(err, "wait failed")
+	}
+
+	var count *int64
+	if sv.SchedulingStrategy != nil && *sv.SchedulingStrategy == "DAEMON" {
+		count = nil
+	} else if *opt.DesiredCount == KeepDesiredCount {
+		count = sv.DesiredCount
+	} else {
+		count = opt.DesiredCount
+	}
+	if count != nil {
+		d.Log("desired count:", *count)
+	}
+	if err := d.WaitServiceStable(ctx, time.Now()); err != nil {
+		return errors.Wrap(err, "the service still unstable")
+	}
+
+	d.Log("Service is stable now. Completed!")
 	return nil
 }
 

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -472,6 +472,14 @@ func (d *App) Rollback(opt RollbackOption) error {
 	return nil
 }
 
+func (d *App) Wait(opt WaitOption) error {
+	ctx, cancel := d.Start()
+	defer cancel()
+	_ = ctx
+
+	return nil
+}
+
 func (d *App) FindRollbackTarget(ctx context.Context, taskDefinitionArn string) (string, error) {
 	var found bool
 	var nextToken *string

--- a/options.go
+++ b/options.go
@@ -3,6 +3,7 @@ package ecspresso
 type CreateOption struct {
 	DryRun       *bool
 	DesiredCount *int64
+	NoWait       *bool
 }
 
 type DeployOption struct {
@@ -10,6 +11,7 @@ type DeployOption struct {
 	DesiredCount       *int64
 	SkipTaskDefinition *bool
 	ForceNewDeployment *bool
+	NoWait             *bool
 }
 
 type StatusOption struct {
@@ -19,6 +21,7 @@ type StatusOption struct {
 type RollbackOption struct {
 	DryRun                   *bool
 	DeregisterTaskDefinition *bool
+	NoWait                   *bool
 }
 
 type DeleteOption struct {

--- a/options.go
+++ b/options.go
@@ -34,3 +34,7 @@ type RunOption struct {
 	SkipTaskDefinition *bool
 	Count              *int64
 }
+
+type WaitOption struct {
+	DesiredCount *int64
+}


### PR DESCRIPTION
The `ecspresso` will wait for the service to stabilize after deployed. However, sometimes we want the `ecspresso` to finish as soon as a service update request is issued.

With this change, the `--no-wait` option has been added so that the `ecspresso` will be terminated as soon as a service update request is issued. Instead, we can use the new `wait` subcommand to wait for service stability.