### PR TITLE
Add -suspend-auto-scaling option to deply sub command.

### DIFF
--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -29,7 +29,7 @@ func _main() int {
 		SkipTaskDefinition: deploy.Flag("skip-task-definition", "skip register a new task definition").Bool(),
 		ForceNewDeployment: deploy.Flag("force-new-deployment", "force a new deployment of the service").Bool(),
 		NoWait:             deploy.Flag("no-wait", "exit ecspresso immediately after just deployed without waiting for service stable").Bool(),
-		SuspendAutoScaling: deploy.Flag("suspend-auto-scaling", "suspend auto-scaling").Bool(),
+		SuspendAutoScaling: deploy.Flag("suspend-auto-scaling", "set suspend to auto-scaling attached to the ECS service").Bool(),
 	}
 
 	create := kingpin.Command("create", "create service")

--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -20,6 +20,7 @@ func _main() int {
 	kingpin.Command("version", "show version")
 
 	conf := kingpin.Flag("config", "config file").String()
+	debug := kingpin.Flag("debug", "enable debug log").Bool()
 
 	deploy := kingpin.Command("deploy", "deploy service")
 	deployOption := ecspresso.DeployOption{
@@ -28,6 +29,7 @@ func _main() int {
 		SkipTaskDefinition: deploy.Flag("skip-task-definition", "skip register a new task definition").Bool(),
 		ForceNewDeployment: deploy.Flag("force-new-deployment", "force a new deployment of the service").Bool(),
 		NoWait:             deploy.Flag("no-wait", "exit ecspresso immediately after just deployed without waiting for service stable").Bool(),
+		SuspendAutoScaling: deploy.Flag("suspend-auto-scaling", "suspend auto-scaling").Bool(),
 	}
 
 	create := kingpin.Command("create", "create service")
@@ -86,11 +88,13 @@ func _main() int {
 		kingpin.Usage()
 		return 1
 	}
+
 	app, err := ecspresso.NewApp(c)
 	if err != nil {
 		log.Println(err)
 		return 1
 	}
+	app.Debug = *debug
 
 	switch sub {
 	case "deploy":

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -877,7 +877,7 @@ func (d *App) suspendAutoScaling(suspend bool) error {
 			},
 		)
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("failed to register scalable target %s set suspend to %s", *target.ResourceId, suspend))
+			return errors.Wrap(err, fmt.Sprintf("failed to register scalable target %s set suspend to %t", *target.ResourceId, suspend))
 		}
 	}
 	return nil

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/applicationautoscaling"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/kayac/go-config"
@@ -33,11 +34,13 @@ func taskDefinitionName(t *ecs.TaskDefinition) string {
 }
 
 type App struct {
-	ecs     *ecs.ECS
-	cwl     *cloudwatchlogs.CloudWatchLogs
-	Service string
-	Cluster string
-	config  *Config
+	ecs         *ecs.ECS
+	autoScaling *applicationautoscaling.ApplicationAutoScaling
+	cwl         *cloudwatchlogs.CloudWatchLogs
+	Service     string
+	Cluster     string
+	config      *Config
+	Debug       bool
 }
 
 func (d *App) DescribeServicesInput() *ecs.DescribeServicesInput {
@@ -76,8 +79,29 @@ func (d *App) DescribeServiceStatus(ctx context.Context, events int) (*ecs.Servi
 	fmt.Println("TaskDefinition:", arnToName(*s.TaskDefinition))
 	fmt.Println("Deployments:")
 	for _, dep := range s.Deployments {
-		fmt.Println("  ", formatDeployment(dep))
+		fmt.Println(formatDeployment(dep))
 	}
+
+	{
+		resouceId := fmt.Sprintf("service/%s/%s", arnToName(*s.ClusterArn), *s.ServiceName)
+		out, err := d.autoScaling.DescribeScalableTargets(
+			&applicationautoscaling.DescribeScalableTargetsInput{
+				ResourceIds:       []*string{&resouceId},
+				ServiceNamespace:  aws.String("ecs"),
+				ScalableDimension: aws.String("ecs:service:DesiredCount"),
+			},
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to describe scalable targets")
+		}
+		if len(out.ScalableTargets) > 0 {
+			fmt.Println("AutoScaling:")
+			for _, target := range out.ScalableTargets {
+				fmt.Println(formatScalableTargets(target))
+			}
+		}
+	}
+
 	fmt.Println("Events:")
 	for i, event := range s.Events {
 		if i >= events {
@@ -179,11 +203,12 @@ func NewApp(conf *Config) (*App, error) {
 		&aws.Config{Region: aws.String(conf.Region)},
 	))
 	d := &App{
-		Service: conf.Service,
-		Cluster: conf.Cluster,
-		ecs:     ecs.New(sess),
-		cwl:     cloudwatchlogs.New(sess),
-		config:  conf,
+		Service:     conf.Service,
+		Cluster:     conf.Cluster,
+		ecs:         ecs.New(sess),
+		autoScaling: applicationautoscaling.New(sess),
+		cwl:         cloudwatchlogs.New(sess),
+		config:      conf,
 	}
 	return d, nil
 }
@@ -417,6 +442,10 @@ func (d *App) Deploy(opt DeployOption) error {
 		return nil
 	}
 
+	if err := d.manageAutoScaling(*opt.SuspendAutoScaling); err != nil {
+		return err
+	}
+
 	if err := d.UpdateService(ctx, tdArn, count, *opt.ForceNewDeployment, sv); err != nil {
 		return errors.Wrap(err, "failed to update service")
 	}
@@ -541,6 +570,13 @@ func (d *App) Log(v ...interface{}) {
 	args := []interface{}{d.Name()}
 	args = append(args, v...)
 	log.Println(args...)
+}
+
+func (d *App) DebugLog(v ...interface{}) {
+	if !d.Debug {
+		return
+	}
+	d.Log(v...)
 }
 
 func (d *App) WaitServiceStable(ctx context.Context, startedAt time.Time) error {
@@ -784,6 +820,44 @@ func (d *App) Register(opt RegisterOption) error {
 
 	if *opt.Output {
 		fmt.Println(newTd.String())
+	}
+	return nil
+}
+
+func (d *App) manageAutoScaling(suspend bool) error {
+	resouceId := fmt.Sprintf("service/%s/%s", d.Cluster, d.Service)
+
+	out, err := d.autoScaling.DescribeScalableTargets(
+		&applicationautoscaling.DescribeScalableTargetsInput{
+			ResourceIds:       []*string{&resouceId},
+			ServiceNamespace:  aws.String("ecs"),
+			ScalableDimension: aws.String("ecs:service:DesiredCount"),
+		},
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to describe scalable targets")
+	}
+	if len(out.ScalableTargets) == 0 {
+		d.DebugLog(fmt.Sprintf("no scalable target for %s", resouceId))
+		return nil
+	}
+	for _, target := range out.ScalableTargets {
+		d.DebugLog(fmt.Sprintf("register scalable target %s set suspend to %t", *target.ResourceId, suspend))
+		_, err := d.autoScaling.RegisterScalableTarget(
+			&applicationautoscaling.RegisterScalableTargetInput{
+				ServiceNamespace:  target.ServiceNamespace,
+				ScalableDimension: target.ScalableDimension,
+				ResourceId:        target.ResourceId,
+				SuspendedState: &applicationautoscaling.SuspendedState{
+					DynamicScalingInSuspended:  &suspend,
+					DynamicScalingOutSuspended: &suspend,
+					ScheduledScalingSuspended:  &suspend,
+				},
+			},
+		)
+		if err != nil {
+			return errors.Wrap(err, fmt.Sprintf("failed to register scalable target %s set suspend to %s", *target.ResourceId, suspend))
+		}
 	}
 	return nil
 }

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -463,7 +463,7 @@ func (d *App) Deploy(opt DeployOption) error {
 		return nil
 	}
 
-	if err := d.manageAutoScaling(*opt.SuspendAutoScaling); err != nil {
+	if err := d.suspendAutoScaling(*opt.SuspendAutoScaling); err != nil {
 		return err
 	}
 
@@ -845,7 +845,7 @@ func (d *App) Register(opt RegisterOption) error {
 	return nil
 }
 
-func (d *App) manageAutoScaling(suspend bool) error {
+func (d *App) suspendAutoScaling(suspend bool) error {
 	resouceId := fmt.Sprintf("service/%s/%s", d.Cluster, d.Service)
 
 	out, err := d.autoScaling.DescribeScalableTargets(

--- a/options.go
+++ b/options.go
@@ -12,6 +12,7 @@ type DeployOption struct {
 	SkipTaskDefinition *bool
 	ForceNewDeployment *bool
 	NoWait             *bool
+	SuspendAutoScaling *bool
 }
 
 type StatusOption struct {

--- a/service.go
+++ b/service.go
@@ -61,18 +61,22 @@ func formatLogEvent(e *cloudwatchlogs.OutputLogEvent, chars int) []string {
 	return lines
 }
 
-func formatScalableTargets(t *applicationautoscaling.ScalableTarget) string {
+func formatScalableTarget(t *applicationautoscaling.ScalableTarget) string {
 	return strings.Join([]string{
 		fmt.Sprintf(
-			"    capacity min:%d, max:%d",
+			spcIndent+"Capacity min:%d max:%d",
 			*t.MinCapacity,
 			*t.MaxCapacity,
 		),
 		fmt.Sprintf(
-			"    suspended DynamicScalingIn:%t DynamicScalingOut:%t  ScheduledScaling:%t",
+			spcIndent+"Suspended in:%t out:%t scheduled:%t",
 			*t.SuspendedState.DynamicScalingInSuspended,
 			*t.SuspendedState.DynamicScalingOutSuspended,
 			*t.SuspendedState.ScheduledScalingSuspended,
 		),
 	}, "\n")
+}
+
+func formatScalingPolicy(p *applicationautoscaling.ScalingPolicy) string {
+	return fmt.Sprintf("  Policy name:%s type:%s", *p.PolicyName, *p.PolicyType)
 }

--- a/service.go
+++ b/service.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go/service/applicationautoscaling"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go/service/ecs"
 )
@@ -58,4 +59,20 @@ func formatLogEvent(e *cloudwatchlogs.OutputLogEvent, chars int) []string {
 		}
 	}
 	return lines
+}
+
+func formatScalableTargets(t *applicationautoscaling.ScalableTarget) string {
+	return strings.Join([]string{
+		fmt.Sprintf(
+			"    capacity min:%d, max:%d",
+			*t.MinCapacity,
+			*t.MaxCapacity,
+		),
+		fmt.Sprintf(
+			"    suspended DynamicScalingIn:%t DynamicScalingOut:%t  ScheduledScaling:%t",
+			*t.SuspendedState.DynamicScalingInSuspended,
+			*t.SuspendedState.DynamicScalingOutSuspended,
+			*t.SuspendedState.ScheduledScalingSuspended,
+		),
+	}, "\n")
 }


### PR DESCRIPTION
When auto-scaling settings are attached to ECS service, set --tasks=0 for deploy command will be canceled by application auto-scaling.

To avoid that behavior, We can set a "suspendState" to the scalableTarget.

`ecspresso deploy --suspend-auto-scaling` resisters "suspendState" to true only when "scalableTarget" is available.