### PR TITLE
Keep compatibility with v0.9.0.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,21 +5,15 @@ go 1.12
 require (
 	github.com/BurntSushi/toml v0.3.0 // indirect
 	github.com/Songmu/prompter v0.0.0-20150725163906-b5721e8d5566
-	github.com/alecthomas/assert v0.0.0-20170929043011-405dbfeb8e38 // indirect
-	github.com/alecthomas/colour v0.0.0-20160524082231-60882d9e2721 // indirect
-	github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1 // indirect
-	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc // indirect
-	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
+	github.com/alecthomas/kingpin v1.3.8-0.20190930021037-0a108b7f5563
 	github.com/aws/aws-sdk-go v1.23.13
 	github.com/kayac/go-config v0.0.1
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/mattn/go-isatty v0.0.3
 	github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c
 	github.com/pkg/errors v0.8.0
-	github.com/sergi/go-diff v1.0.0 // indirect
 	github.com/stretchr/testify v1.3.0 // indirect
 	golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c // indirect
-	gopkg.in/alecthomas/kingpin.v2 v2.2.5
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v2 v2.0.0-20171116090243-287cf08546ab // indirect
 )


### PR DESCRIPTION
When ecspresso have insufficient IAM permissions for auto-scaling,
"status" and "deploy" sub command ignore errors at access to auto-scaling.

deploy --(no-)suspend-auto-scaling options becomes to work only when specified explicitly.

v0.10.0 failed to "status" and "deploy" when lack of permissions for "application-autoscaling".