### PR TITLE
feature: register proxy configuration

### DIFF
--- a/ecspresso.go
+++ b/ecspresso.go
@@ -549,6 +549,7 @@ func (d *App) RegisterTaskDefinition(ctx context.Context, td *ecs.TaskDefinition
 			PlacementConstraints:    td.PlacementConstraints,
 			RequiresCompatibilities: td.RequiresCompatibilities,
 			TaskRoleArn:             td.TaskRoleArn,
+			ProxyConfiguration:      td.ProxyConfiguration,
 			Volumes:                 td.Volumes,
 		},
 	)

--- a/tests/td-plain.json
+++ b/tests/td-plain.json
@@ -53,5 +53,39 @@
   ],
   "revision": 1,
   "cpu": "1024",
-  "memory": "2048"
+  "memory": "2048",
+  "proxyConfiguration": {
+    "type": "APPMESH",
+    "containerName": "envoy",
+    "properties": [
+      {
+        "name": "IgnoredUID",
+        "value": "1337"
+      },
+      {
+        "name": "IgnoredGID",
+        "value": ""
+      },
+      {
+        "name": "AppPorts",
+        "value": "26571"
+      },
+      {
+        "name": "ProxyIngressPort",
+        "value": "15000"
+      },
+      {
+        "name": "ProxyEgressPort",
+        "value": "15001"
+      },
+      {
+        "name": "EgressIgnoredIPs",
+        "value": "169.254.170.2,169.254.169.254"
+      },
+      {
+        "name": "EgressIgnoredPorts",
+        "value": ""
+      }
+    ]
+  }
 }

--- a/tests/td.json
+++ b/tests/td.json
@@ -54,6 +54,40 @@
     ],
     "revision": 1,
     "cpu": "1024",
-    "memory": "2048"
+    "memory": "2048",
+    "proxyConfiguration": {
+      "type": "APPMESH",
+      "containerName": "envoy",
+      "properties": [
+        {
+          "name": "IgnoredUID",
+          "value": "1337"
+        },
+        {
+          "name": "IgnoredGID",
+          "value": ""
+        },
+        {
+          "name": "AppPorts",
+          "value": "26571"
+        },
+        {
+          "name": "ProxyIngressPort",
+          "value": "15000"
+        },
+        {
+          "name": "ProxyEgressPort",
+          "value": "15001"
+        },
+        {
+          "name": "EgressIgnoredIPs",
+          "value": "169.254.170.2,169.254.169.254"
+        },
+        {
+          "name": "EgressIgnoredPorts",
+          "value": ""
+        }
+      ]
+    }
   }
 }


### PR DESCRIPTION
ProxyConfiguration is required to use AppMesh integration at ECS.

https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ProxyConfiguration.html