### PR TITLE
Enable sharedConfig

### DIFF
--- a/ecspresso.go
+++ b/ecspresso.go
@@ -236,9 +236,10 @@ func NewApp(conf *Config) (*App, error) {
 	if err := conf.Validate(); err != nil {
 		return nil, errors.Wrap(err, "invalid configuration")
 	}
-	sess := session.Must(session.NewSession(
-		&aws.Config{Region: aws.String(conf.Region)},
-	))
+	sess := session.Must(session.NewSessionWithOptions(session.Options{
+		Config:            aws.Config{Region: aws.String(conf.Region)},
+		SharedConfigState: session.SharedConfigEnable,
+	}))
 	d := &App{
 		Service:     conf.Service,
 		Cluster:     conf.Cluster,


### PR DESCRIPTION
Hi. 

I'd like to swtich profile without AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY.

So, enabled sharedConfig. 
see reference https://docs.aws.amazon.com/sdk-for-go/api/aws/session/#SharedConfigState

## How to switch profile

```
$ AWS_PROFILE=hogehoge go run cmd/ecspresso/main.go init --region ap-northeast-1 --cluster test-cluster --service test-service --config config.yml 
```
