### PR TITLE
Fix the deployment by CODE_DEPLOY

### DIFF
--- a/deploy.go
+++ b/deploy.go
@@ -178,7 +178,7 @@ func (d *App) UpdateServiceAttributes(ctx context.Context, opt DeployOption) (*e
 }
 
 func (d *App) DeployByCodeDeploy(ctx context.Context, taskDefinitionArn string, count *int64, sv *ecs.Service, opt DeployOption) error {
-	if *sv.DesiredCount != *count {
+	if count != nil && *sv.DesiredCount != *count {
 		d.Log("updating desired count to", *count)
 		_, err := d.ecs.UpdateServiceWithContext(
 			ctx,


### PR DESCRIPTION
`deploy` command is crashed when deploying service having `CODE_DEPLOY` deployment controller without `--tasks` option.

```
$ ecspresso deploy --config dev_api_config.yml --rollback-events DEPLOYMENT_FAILURE
2020/02/07 16:44:43 xxxxxx/xxxxxx Starting deploy
Service: xxxxxx
Cluster: xxxxxx
TaskDefinition: xxxxxx:5
TaskSets:
   PRIMARY xxxxxx:5 desired:1 pending:0 running:1
Events:
2020/02/07 16:44:45 xxxxxx/xxxxxx Creating a new task definition by ecs-task-def.json
2020/02/07 16:44:45 xxxxxx/xxxxxx Registering a new task definition...
2020/02/07 16:44:45 xxxxxx/xxxxxx Task definition is registered xxxxxx:8
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1650108]

goroutine 1 [running]:
github.com/kayac/ecspresso.(*App).DeployByCodeDeploy(0xc0000ac6e0, 0x19eed00, 0xc000020de0, 0xc000500280, 0x48, 0x0, 0xc0004c6300, 0xc00002b288, 0xc00002b290, 0xc00002b298, ...)
	/Users/minoru.takase/src/github.com/kayac/ecspresso/deploy.go:181 +0x48
github.com/kayac/ecspresso.(*App).Deploy(0xc0000ac6e0, 0xc00002b288, 0xc00002b290, 0xc00002b298, 0xc00002b299, 0xc00002b29a, 0x0, 0xc000069af0, 0xc00002b29c, 0x0, ...)
	/Users/minoru.takase/src/github.com/kayac/ecspresso/deploy.go:102 +0x3d1
main._main(0xc00002c0b8)
	/Users/minoru.takase/src/github.com/kayac/ecspresso/cmd/ecspresso/main.go:135 +0x41dd
main.main()
	/Users/minoru.takase/src/github.com/kayac/ecspresso/cmd/ecspresso/main.go:17 +0x22
```