### PR TITLE
To check the "exit codes" of multiple containers in the executed task definition

### DIFF
--- a/ecspresso.go
+++ b/ecspresso.go
@@ -191,16 +191,17 @@ func (d *App) DescribeTask(ctx context.Context, task *ecs.Task) error {
 		return errors.New(*f.Reason)
 	}
 
-	c := out.Tasks[0].Containers[0]
-	if c.Reason != nil {
-		return errors.New(*c.Reason)
-	}
-	if c.ExitCode != nil && *c.ExitCode != 0 {
-		msg := "Exit Code: " + strconv.FormatInt(*c.ExitCode, 10)
-		if c.Reason != nil {
-			msg += ", Reason: " + *c.Reason
+	for _, c := range out.Tasks[0].Containers {
+		if c.Name != nil && c.Reason != nil {
+			return errors.New(fmt.Sprintf("App: %v, Exit Code: %v", *c.Name, *c.Reason))
 		}
-		return errors.New(msg)
+		if c.Name != nil && c.ExitCode != nil && *c.ExitCode != 0 {
+			msg := fmt.Sprintf("App: %v, Exit Code: %v", *c.Name, strconv.FormatInt(*c.ExitCode, 10))
+			if c.Reason != nil {
+				msg += ", Reason: " + *c.Reason
+			}
+			return errors.New(msg)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Sometimes, I set task definition like below, that has multiple containers.
then, I execute ecspresso run.
Command "./app1" failed, but ecspresso could not catch the error.
Because ecspresso only got the "describe task" of one container (name: app2) 

```
{
  "containerDefinitions": [
    {
      "command": [
        "./app1"
      ],
      "environment": [],
      "image": "app1/xxxxxxxxxxxxxxx",
      "name": "app1",
      .....
    },
    {
      "image": "app2/xxxxxxxxxxxxxxx",
      "name": "app2",
      .....
    }
  ],
  "cpu": "256",
  "volumes": []
  .....
}
```