### PR TITLE
add diff command

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ Commands:
     
   init --region=REGION --service=SERVICE [<flags>]
     create service/task definition files by existing ECS service
+
+  diff [<flags>]
+    display diff for task definition compared with latest one on ECS
 ```
 
 For more options for sub-commands, See `ecspresso sub-command --help`.

--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -99,6 +99,9 @@ func _main() int {
 		ServiceDefinitionPath: init.Flag("service-definition-path", "output service definition file path").Default("ecs-service-def.json").String(),
 	}
 
+	_ = kingpin.Command("diff", "display diff for task definition compared with latest one on ECS")
+	diffOption := ecspresso.DiffOption{}
+
 	sub := kingpin.Parse()
 	if sub == "version" {
 		fmt.Println("ecspresso", Version)
@@ -152,6 +155,8 @@ func _main() int {
 		err = app.Register(registerOption)
 	case "init":
 		err = app.Init(initOption)
+	case "diff":
+		err = app.Diff(diffOption)
 	default:
 		kingpin.Usage()
 		return 1

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -577,19 +577,7 @@ func (d *App) RegisterTaskDefinition(ctx context.Context, td *ecs.TaskDefinition
 
 	out, err := d.ecs.RegisterTaskDefinitionWithContext(
 		ctx,
-		&ecs.RegisterTaskDefinitionInput{
-			ContainerDefinitions:    td.ContainerDefinitions,
-			Cpu:                     td.Cpu,
-			ExecutionRoleArn:        td.ExecutionRoleArn,
-			Family:                  td.Family,
-			Memory:                  td.Memory,
-			NetworkMode:             td.NetworkMode,
-			PlacementConstraints:    td.PlacementConstraints,
-			RequiresCompatibilities: td.RequiresCompatibilities,
-			TaskRoleArn:             td.TaskRoleArn,
-			ProxyConfiguration:      td.ProxyConfiguration,
-			Volumes:                 td.Volumes,
-		},
+		tdToRegisterTaskDefinitionInput(td),
 	)
 	if err != nil {
 		return nil, err
@@ -808,4 +796,20 @@ func (d *App) suspendAutoScaling(suspend bool) error {
 		}
 	}
 	return nil
+}
+
+func tdToRegisterTaskDefinitionInput(td *ecs.TaskDefinition) *ecs.RegisterTaskDefinitionInput {
+	return &ecs.RegisterTaskDefinitionInput{
+		ContainerDefinitions:    td.ContainerDefinitions,
+		Cpu:                     td.Cpu,
+		ExecutionRoleArn:        td.ExecutionRoleArn,
+		Family:                  td.Family,
+		Memory:                  td.Memory,
+		NetworkMode:             td.NetworkMode,
+		PlacementConstraints:    td.PlacementConstraints,
+		RequiresCompatibilities: td.RequiresCompatibilities,
+		TaskRoleArn:             td.TaskRoleArn,
+		ProxyConfiguration:      td.ProxyConfiguration,
+		Volumes:                 td.Volumes,
+	}
 }

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -851,16 +851,32 @@ func tdToRegisterTaskDefinitionInput(td *ecs.TaskDefinition) *ecs.RegisterTaskDe
 
 func sortTaskDefinitionForDiff(td *ecs.TaskDefinition) {
 	sort.Slice(td.ContainerDefinitions, func(i, j int) bool {
-		return strings.Compare(*td.ContainerDefinitions[i].Name, *td.ContainerDefinitions[j].Name) < 0
+		return strings.Compare(td.ContainerDefinitions[i].String(), td.ContainerDefinitions[j].String()) < 0
 	})
 
 	for _, cd := range td.ContainerDefinitions {
 		sort.Slice(cd.Environment, func(i, j int) bool {
-			return strings.Compare(*cd.Environment[i].Name, *cd.Environment[j].Name) < 0
+			return strings.Compare(cd.Environment[i].String(), cd.Environment[j].String()) < 0
+		})
+
+		sort.Slice(cd.MountPoints, func(i, j int) bool {
+			return strings.Compare(cd.MountPoints[i].String(), cd.MountPoints[j].String()) < 0
+		})
+
+		sort.Slice(cd.PortMappings, func(i, j int) bool {
+			return strings.Compare(cd.PortMappings[i].String(), cd.PortMappings[j].String()) < 0
+		})
+
+		sort.Slice(cd.Volumes, func(i, j int) bool {
+			return strings.Compare(cd.Volumes[i].String(), cd.Volumes[j].String()) < 0
+		})
+
+		sort.Slice(cd.VolumesFrom, func(i, j int) bool {
+			return strings.Compare(cd.VolumesFrom[i].String(), cd.VolumesFrom[j].String()) < 0
 		})
 
 		sort.Slice(cd.Secrets, func(i, j int) bool {
-			return strings.Compare(*cd.Secrets[i].Name, *cd.Secrets[j].Name) < 0
+			return strings.Compare(cd.Secrets[i].String(), cd.Secrets[j].String()) < 0
 		})
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go v1.31.0
 	github.com/kayac/go-config v0.3.2
 	github.com/kayac/go-config/tfstate v0.0.0-20200526163631-723a9d864f5f
+	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-isatty v0.0.12
 	github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
+github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lestrrat-go/envload v0.0.0-20180220234015-a3eb8ddeffcc h1:RKf14vYWi2ttpEmkA4aQ3j4u9dStX2t4M8UM6qqNsG8=
 github.com/lestrrat-go/envload v0.0.0-20180220234015-a3eb8ddeffcc/go.mod h1:kopuH9ugFRkIXf3YoqHKyrJ9YfUFsckUU9S7B+XP+is=
 github.com/lestrrat-go/strftime v1.0.1 h1:o7qz5pmLzPDLyGW4lG6JvTKPUfTFXwe+vOamIYWtnVU=

--- a/options.go
+++ b/options.go
@@ -106,3 +106,6 @@ type InitOption struct {
 	ServiceDefinitionPath *string
 	ConfigFilePath        *string
 }
+
+type DiffOption struct {
+}


### PR DESCRIPTION
## Feature

add `diff` command.

```console
$ ecspresso diff --config=path/to/config.yml
2020/06/17 17:44:38 app/cluster Creating a new task definition by task-definition/service.json
 {
   "containerDefinitions": [
     {
       "command": [
         "agent"
       ],
-      "cpu": 0,
       "dockerLabels": {
         "name": "app"
       },
       "environment": [
         {
           "name": "AWS_REGION",
           "value": "ap-northeast-1"
+        },
+        {
+          "name": "FOO",
+          "value": "this is foo"
         }
       ],
       "essential": true,
-      "image": "path/to/image/app:1234",
+      "image": "path/to/image/app:abcd",
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
           "awslogs-group": "/service",
           "awslogs-region": "ap-northeast-1",
           "awslogs-stream-prefix": ""
         }
       },
-      "mountPoints": [],
       "name": "app",
-      "portMappings": [],
       "secrets": [
         {
           "name": "SECRET_KEY",
           "valueFrom": "/secret_key"
         }
-      ],
-      "volumesFrom": []
+      ]
     }
   ],
-  "cpu": "256",
+  "cpu": "0.25 vCPU",
   "executionRoleArn": "arn:aws:iam::99999:role/ecs-execution",
   "family": "app",
   "memory": "512",
   "networkMode": "awsvpc",
-  "placementConstraints": [],
   "requiresCompatibilities": [
     "FARGATE"
   ],
-  "taskRoleArn": "arn:aws:iam::99999:role/ecs-task",
-  "volumes": []
+  "taskRoleArn": "arn:aws:iam::99999:role/ecs-task"
 }
```

## Motivation

want know difference of Task Definition between local and remote one before deploy it.

## Considering

Is good or not to add `-diff` flag to `deploy` command.