### PR TITLE
Fix --dry-run output format

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -28,8 +28,7 @@ func TestLoadServiceDefinition(t *testing.T) {
 		t.Errorf("%s load failed: %s", path, err)
 	}
 
-	if *sv.Cluster != "default2" ||
-		*sv.ServiceName != "test" ||
+	if *sv.ServiceName != "test" ||
 		*sv.DesiredCount != 2 ||
 		*sv.LoadBalancers[0].TargetGroupArn != "arn:aws:elasticloadbalancing:us-east-1:1111111111:targetgroup/test/12345678" ||
 		*sv.LaunchType != "EC2" ||

--- a/deploy.go
+++ b/deploy.go
@@ -147,23 +147,28 @@ func (d *App) UpdateServiceTasks(ctx context.Context, taskDefinitionArn string, 
 	return nil
 }
 
+func svToUpdateServiceInput(sv *ecs.Service) *ecs.UpdateServiceInput {
+	return &ecs.UpdateServiceInput{
+		CapacityProviderStrategy:      sv.CapacityProviderStrategy,
+		DeploymentConfiguration:       sv.DeploymentConfiguration,
+		HealthCheckGracePeriodSeconds: sv.HealthCheckGracePeriodSeconds,
+		NetworkConfiguration:          sv.NetworkConfiguration,
+		PlacementConstraints:          sv.PlacementConstraints,
+		PlacementStrategy:             sv.PlacementStrategy,
+		PlatformVersion:               sv.PlatformVersion,
+	}
+}
+
 func (d *App) UpdateServiceAttributes(ctx context.Context, opt DeployOption) (*ecs.Service, error) {
 	svd, err := d.LoadServiceDefinition(d.config.ServiceDefinitionPath)
 	if err != nil {
 		return nil, err
 	}
-	in := &ecs.UpdateServiceInput{
-		Service:                       aws.String(d.Service),
-		Cluster:                       aws.String(d.Cluster),
-		DeploymentConfiguration:       svd.DeploymentConfiguration,
-		CapacityProviderStrategy:      svd.CapacityProviderStrategy,
-		NetworkConfiguration:          svd.NetworkConfiguration,
-		HealthCheckGracePeriodSeconds: svd.HealthCheckGracePeriodSeconds,
-		PlatformVersion:               svd.PlatformVersion,
-		ForceNewDeployment:            opt.ForceNewDeployment,
-		PlacementConstraints:          svd.PlacementConstraints,
-		PlacementStrategy:             svd.PlacementStrategy,
-	}
+	in := svToUpdateServiceInput(svd)
+	in.Service = aws.String(d.Service)
+	in.Cluster = aws.String(d.Cluster)
+	in.ForceNewDeployment = opt.ForceNewDeployment
+
 	if *opt.DryRun {
 		d.Log("update service input:", in.String())
 		return nil, nil

--- a/deploy.go
+++ b/deploy.go
@@ -65,7 +65,8 @@ func (d *App) Deploy(opt DeployOption) error {
 			return errors.Wrap(err, "failed to load task definition")
 		}
 		if *opt.DryRun {
-			d.Log("task definition:", td.String())
+			d.Log("task definition:")
+			d.LogJSON(td)
 		} else {
 			newTd, err := d.RegisterTaskDefinition(ctx, td)
 			if err != nil {
@@ -170,7 +171,8 @@ func (d *App) UpdateServiceAttributes(ctx context.Context, opt DeployOption) (*e
 	in.ForceNewDeployment = opt.ForceNewDeployment
 
 	if *opt.DryRun {
-		d.Log("update service input:", in.String())
+		d.Log("update service input:")
+		d.LogJSON(in)
 		return nil, nil
 	}
 	d.Log("Updating service attributes...")

--- a/diff.go
+++ b/diff.go
@@ -1,0 +1,205 @@
+package ecspresso
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/kylelemons/godebug/diff"
+	"github.com/pkg/errors"
+)
+
+func (d *App) Diff(opt DiffOption) error {
+	ctx, cancel := d.Start()
+	defer cancel()
+
+	// service definition
+	newSv, err := d.LoadServiceDefinition(d.config.ServiceDefinitionPath)
+	if err != nil {
+		return errors.Wrap(err, "failed to load service definition")
+	}
+
+	remoteSv, err := d.DescribeService(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to describe service")
+	}
+
+	sortServiceDefinitionForDiff(newSv)
+	sortServiceDefinitionForDiff(remoteSv)
+
+	newSvBytes, err := MarshalJSON(svToUpdateServiceInput(newSv))
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal new service definition")
+	}
+
+	remoteSvBytes, err := MarshalJSON(svToUpdateServiceInput(remoteSv))
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal remote service definition")
+	}
+
+	if ds := diff.Diff(string(remoteSvBytes), string(newSvBytes)); ds != "" {
+		fmt.Println("---", *remoteSv.ServiceArn)
+		fmt.Println("+++", d.config.ServiceDefinitionPath)
+		fmt.Println(ds)
+	}
+
+	// task definition
+	newTd, err := d.LoadTaskDefinition(d.config.TaskDefinitionPath)
+	if err != nil {
+		return errors.Wrap(err, "failed to load task definition")
+	}
+
+	remoteTd, err := d.DescribeTaskDefinition(ctx, *newTd.Family)
+	if err != nil {
+		return errors.Wrap(err, "failed to describe task definition")
+	}
+
+	// sort lists in task definition
+	sortTaskDefinitionForDiff(newTd)
+	sortTaskDefinitionForDiff(remoteTd)
+
+	newTdBytes, err := MarshalJSON(tdToRegisterTaskDefinitionInput(newTd))
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal new task definition")
+	}
+
+	remoteTdBytes, err := MarshalJSON(tdToRegisterTaskDefinitionInput(remoteTd))
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal remote task definition")
+	}
+
+	if ds := diff.Diff(string(remoteTdBytes), string(newTdBytes)); ds != "" {
+		fmt.Println("---", *remoteTd.TaskDefinitionArn)
+		fmt.Println("+++", d.config.TaskDefinitionPath)
+		fmt.Println(ds)
+	}
+	return nil
+}
+
+func tdToRegisterTaskDefinitionInput(td *ecs.TaskDefinition) *ecs.RegisterTaskDefinitionInput {
+	return &ecs.RegisterTaskDefinitionInput{
+		ContainerDefinitions:    td.ContainerDefinitions,
+		Cpu:                     td.Cpu,
+		ExecutionRoleArn:        td.ExecutionRoleArn,
+		Family:                  td.Family,
+		Memory:                  td.Memory,
+		NetworkMode:             td.NetworkMode,
+		PlacementConstraints:    td.PlacementConstraints,
+		RequiresCompatibilities: td.RequiresCompatibilities,
+		TaskRoleArn:             td.TaskRoleArn,
+		ProxyConfiguration:      td.ProxyConfiguration,
+		Volumes:                 td.Volumes,
+	}
+}
+
+var stringerType = reflect.TypeOf((*fmt.Stringer)(nil)).Elem()
+
+func sortSlicesInDefinition(t reflect.Type, v reflect.Value, fieldNames ...string) {
+	isSortableField := func(name string) bool {
+		for _, n := range fieldNames {
+			if n == name {
+				return true
+			}
+		}
+		return false
+	}
+	for i := 0; i < t.NumField(); i++ {
+		fv, field := v.Field(i), t.Field(i)
+		if fv.Kind() != reflect.Slice || !fv.CanSet() {
+			continue
+		}
+		if !isSortableField(field.Name) {
+			continue
+		}
+		if size := fv.Len(); size == 0 {
+			fv.Set(reflect.MakeSlice(fv.Type(), 0, 0))
+		} else {
+			slice := make([]reflect.Value, size, size)
+			for i := 0; i < size; i++ {
+				slice[i] = fv.Index(i)
+			}
+			sort.Slice(slice, func(i, j int) bool {
+				iv, jv := reflect.Indirect(slice[i]), reflect.Indirect(slice[j])
+				var is, js string
+				if iv.Kind() == reflect.String && jv.Kind() == reflect.String {
+					is, js = iv.Interface().(string), jv.Interface().(string)
+				} else if iv.Type().Implements(stringerType) && jv.Type().Implements(stringerType) {
+					is, js = iv.Interface().(fmt.Stringer).String(), jv.Interface().(fmt.Stringer).String()
+				}
+				return strings.Compare(is, js) < 0
+			})
+			sorted := reflect.MakeSlice(fv.Type(), size, size)
+			for i := 0; i < size; i++ {
+				sorted.Index(i).Set(slice[i])
+			}
+			fv.Set(sorted)
+		}
+	}
+}
+
+func sortServiceDefinitionForDiff(sv *ecs.Service) {
+	sortSlicesInDefinition(
+		reflect.TypeOf(*sv), reflect.Indirect(reflect.ValueOf(sv)),
+		"PlacementConstraints",
+		"PlacementStrategy",
+		"RequiresCompatibilities",
+	)
+	if sv.LaunchType != nil && *sv.LaunchType == ecs.LaunchTypeFargate && sv.PlatformVersion == nil {
+		sv.PlatformVersion = aws.String("LATEST")
+	}
+	if sv.SchedulingStrategy == nil && sv.DeploymentConfiguration == nil {
+		sv.DeploymentConfiguration = &ecs.DeploymentConfiguration{
+			MaximumPercent:        aws.Int64(200),
+			MinimumHealthyPercent: aws.Int64(100),
+		}
+	} else if sv.SchedulingStrategy != nil && *sv.SchedulingStrategy == ecs.SchedulingStrategyDaemon && sv.DeploymentConfiguration == nil {
+		sv.DeploymentConfiguration = &ecs.DeploymentConfiguration{
+			MaximumPercent:        aws.Int64(100),
+			MinimumHealthyPercent: aws.Int64(0),
+		}
+	}
+
+	if sv.HealthCheckGracePeriodSeconds == nil {
+		sv.HealthCheckGracePeriodSeconds = aws.Int64(0)
+	}
+	if nc := sv.NetworkConfiguration; nc != nil {
+		if ac := nc.AwsvpcConfiguration; ac != nil {
+			if ac.AssignPublicIp == nil {
+				ac.AssignPublicIp = aws.String(ecs.AssignPublicIpDisabled)
+			}
+			sortSlicesInDefinition(
+				reflect.TypeOf(*ac),
+				reflect.Indirect(reflect.ValueOf(ac)),
+				"SecurityGroups",
+				"Subnets",
+			)
+		}
+	}
+}
+
+func sortTaskDefinitionForDiff(td *ecs.TaskDefinition) {
+	sortSlicesInDefinition(
+		reflect.TypeOf(*td), reflect.Indirect(reflect.ValueOf(td)),
+		"ContainerDefinitions",
+		"PlacementConstraints",
+		"RequiresCompatibilities",
+		"Volumes",
+	)
+
+	for _, cd := range td.ContainerDefinitions {
+		if cd.Cpu == nil {
+			cd.Cpu = aws.Int64(0)
+		}
+		sortSlicesInDefinition(
+			reflect.TypeOf(*cd), reflect.Indirect(reflect.ValueOf(cd)),
+			"Environment",
+			"MountPoints",
+			"PortMappings",
+			"VolumesFrom",
+			"Secrets",
+		)
+	}
+}

--- a/diff.go
+++ b/diff.go
@@ -199,6 +199,9 @@ func sortTaskDefinitionForDiff(td *ecs.TaskDefinition) {
 	if td.Cpu != nil {
 		td.Cpu = toNumberCPU(*td.Cpu)
 	}
+	if td.Memory != nil {
+		td.Memory = toNumberMemory(*td.Memory)
+	}
 
 	for _, cd := range td.ContainerDefinitions {
 		if cd.Cpu == nil {
@@ -225,4 +228,16 @@ func toNumberCPU(cpu string) *string {
 		}
 	}
 	return &cpu
+}
+
+func toNumberMemory(memory string) *string {
+	if i := strings.Index(memory, "GB"); i > 0 {
+		if ns, err := strconv.ParseFloat(strings.Trim(memory[0:i], " "), 64); err != nil {
+			return nil
+		} else {
+			nn := fmt.Sprintf("%d", int(ns*1024))
+			return &nn
+		}
+	}
+	return &memory
 }

--- a/diff.go
+++ b/diff.go
@@ -141,6 +141,13 @@ func sortSlicesInDefinition(t reflect.Type, v reflect.Value, fieldNames ...strin
 	}
 }
 
+func equalString(a *string, b string) bool {
+	if a == nil {
+		return b == ""
+	}
+	return *a == b
+}
+
 func sortServiceDefinitionForDiff(sv *ecs.Service) {
 	sortSlicesInDefinition(
 		reflect.TypeOf(*sv), reflect.Indirect(reflect.ValueOf(sv)),
@@ -148,7 +155,7 @@ func sortServiceDefinitionForDiff(sv *ecs.Service) {
 		"PlacementStrategy",
 		"RequiresCompatibilities",
 	)
-	if sv.LaunchType != nil && *sv.LaunchType == ecs.LaunchTypeFargate && sv.PlatformVersion == nil {
+	if equalString(sv.LaunchType, ecs.LaunchTypeFargate) && sv.PlatformVersion == nil {
 		sv.PlatformVersion = aws.String("LATEST")
 	}
 	if sv.SchedulingStrategy == nil && sv.DeploymentConfiguration == nil {
@@ -156,7 +163,7 @@ func sortServiceDefinitionForDiff(sv *ecs.Service) {
 			MaximumPercent:        aws.Int64(200),
 			MinimumHealthyPercent: aws.Int64(100),
 		}
-	} else if sv.SchedulingStrategy != nil && *sv.SchedulingStrategy == ecs.SchedulingStrategyDaemon && sv.DeploymentConfiguration == nil {
+	} else if equalString(sv.SchedulingStrategy, ecs.SchedulingStrategyDaemon) && sv.DeploymentConfiguration == nil {
 		sv.DeploymentConfiguration = &ecs.DeploymentConfiguration{
 			MaximumPercent:        aws.Int64(100),
 			MinimumHealthyPercent: aws.Int64(0),

--- a/diff_test.go
+++ b/diff_test.go
@@ -1,0 +1,133 @@
+package ecspresso_test
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/kayac/ecspresso"
+)
+
+var testSuiteToNumberCPU = [][]string{
+	{"256", "256"},
+	{"0.25 vCPU", "256"},
+	{"0.5vcpu", "512"},
+	{"4 vcpu", "4096"},
+}
+
+func TestToNumberCPU(t *testing.T) {
+	for _, s := range testSuiteToNumberCPU {
+		cpu := ecspresso.ToNumberCPU(s[0])
+		if !ecspresso.EqualString(cpu, s[1]) {
+			t.Errorf("unexpected vcpu convertion %s => %s expected %s", s[0], *cpu, s[1])
+		}
+	}
+}
+
+var testTaskDefinition1 = &ecs.TaskDefinition{
+	Cpu: aws.String("0.25 vCPU"),
+	ContainerDefinitions: []*ecs.ContainerDefinition{
+		{
+			Name:  aws.String("app"),
+			Image: aws.String("debian:buster"),
+			Environment: []*ecs.KeyValuePair{
+				{
+					Name:  aws.String("TZ"),
+					Value: aws.String("UTC"),
+				},
+				{
+					Name:  aws.String("LANG"),
+					Value: aws.String("en_US"),
+				},
+			},
+		},
+		{
+			Name:  aws.String("web"),
+			Image: aws.String("nginx:latest"),
+		},
+	},
+}
+
+var testTaskDefinition2 = &ecs.TaskDefinition{
+	Cpu: aws.String("256"),
+	ContainerDefinitions: []*ecs.ContainerDefinition{
+		{
+			Name:  aws.String("web"),
+			Image: aws.String("nginx:latest"),
+		},
+		{
+			Cpu:   aws.Int64(0),
+			Name:  aws.String("app"),
+			Image: aws.String("debian:buster"),
+			Environment: []*ecs.KeyValuePair{
+				{
+					Name:  aws.String("LANG"),
+					Value: aws.String("en_US"),
+				},
+				{
+					Name:  aws.String("TZ"),
+					Value: aws.String("UTC"),
+				},
+			},
+		},
+	},
+	Volumes: []*ecs.Volume{},
+}
+
+func TestTaskDefinitionDiffer(t *testing.T) {
+	ecspresso.SortTaskDefinitionForDiff(testTaskDefinition1)
+	ecspresso.SortTaskDefinitionForDiff(testTaskDefinition2)
+	if ecspresso.MarshalJSONString(testTaskDefinition1) != ecspresso.MarshalJSONString(testTaskDefinition2) {
+		t.Error("failed to sortTaskDefinitionForDiff")
+		t.Log(testTaskDefinition1.String())
+		t.Log(testTaskDefinition2.String())
+	}
+}
+
+var testServiceDefinition1 = &ecs.Service{
+	LaunchType: aws.String("FARGATE"),
+	NetworkConfiguration: &ecs.NetworkConfiguration{
+		AwsvpcConfiguration: &ecs.AwsVpcConfiguration{
+			Subnets: []*string{
+				aws.String("subnet-876543210"),
+				aws.String("subnet-012345678"),
+			},
+			SecurityGroups: []*string{
+				aws.String("sg-99999999"),
+				aws.String("sg-11111111"),
+			},
+		},
+	},
+}
+
+var testServiceDefinition2 = &ecs.Service{
+	DeploymentConfiguration: &ecs.DeploymentConfiguration{
+		MaximumPercent:        aws.Int64(200),
+		MinimumHealthyPercent: aws.Int64(100),
+	},
+	NetworkConfiguration: &ecs.NetworkConfiguration{
+		AwsvpcConfiguration: &ecs.AwsVpcConfiguration{
+			Subnets: []*string{
+				aws.String("subnet-012345678"),
+				aws.String("subnet-876543210"),
+			},
+			SecurityGroups: []*string{
+				aws.String("sg-11111111"),
+				aws.String("sg-99999999"),
+			},
+			AssignPublicIp: aws.String("DISABLED"),
+		},
+	},
+	LaunchType:      aws.String("FARGATE"),
+	PlatformVersion: aws.String("LATEST"),
+}
+
+func TestServiceDefinitionDiffer(t *testing.T) {
+	ecspresso.SortServiceDefinitionForDiff(testServiceDefinition1)
+	ecspresso.SortServiceDefinitionForDiff(testServiceDefinition2)
+	if ecspresso.MarshalJSONString(testServiceDefinition1) != ecspresso.MarshalJSONString(testServiceDefinition2) {
+		t.Error("failed to SortTaskDefinitionForDiff")
+		t.Log(testServiceDefinition1.String())
+		t.Log(testServiceDefinition2.String())
+	}
+}

--- a/diff_test.go
+++ b/diff_test.go
@@ -25,7 +25,8 @@ func TestToNumberCPU(t *testing.T) {
 }
 
 var testTaskDefinition1 = &ecs.TaskDefinition{
-	Cpu: aws.String("0.25 vCPU"),
+	Cpu:    aws.String("0.25 vCPU"),
+	Memory: aws.String("1 GB"),
 	ContainerDefinitions: []*ecs.ContainerDefinition{
 		{
 			Name:  aws.String("app"),
@@ -49,7 +50,8 @@ var testTaskDefinition1 = &ecs.TaskDefinition{
 }
 
 var testTaskDefinition2 = &ecs.TaskDefinition{
-	Cpu: aws.String("256"),
+	Cpu:    aws.String("256"),
+	Memory: aws.String("1024"),
 	ContainerDefinitions: []*ecs.ContainerDefinition{
 		{
 			Name:  aws.String("web"),

--- a/diff_test.go
+++ b/diff_test.go
@@ -15,11 +15,26 @@ var testSuiteToNumberCPU = [][]string{
 	{"4 vcpu", "4096"},
 }
 
+var testSuiteToNumberMemory = [][]string{
+	{"512", "512"},
+	{"0.5 GB", "512"},
+	{"4GB", "4096"},
+}
+
 func TestToNumberCPU(t *testing.T) {
 	for _, s := range testSuiteToNumberCPU {
 		cpu := ecspresso.ToNumberCPU(s[0])
 		if !ecspresso.EqualString(cpu, s[1]) {
 			t.Errorf("unexpected vcpu convertion %s => %s expected %s", s[0], *cpu, s[1])
+		}
+	}
+}
+
+func TestToNumberMemory(t *testing.T) {
+	for _, s := range testSuiteToNumberMemory {
+		cpu := ecspresso.ToNumberMemory(s[0])
+		if !ecspresso.EqualString(cpu, s[1]) {
+			t.Errorf("unexpected memory convertion %s => %s expected %s", s[0], *cpu, s[1])
 		}
 	}
 }

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -851,16 +851,32 @@ func tdToRegisterTaskDefinitionInput(td *ecs.TaskDefinition) *ecs.RegisterTaskDe
 
 func sortTaskDefinitionForDiff(td *ecs.TaskDefinition) {
 	sort.Slice(td.ContainerDefinitions, func(i, j int) bool {
-		return strings.Compare(*td.ContainerDefinitions[i].Name, *td.ContainerDefinitions[j].Name) < 0
+		return strings.Compare(td.ContainerDefinitions[i].String(), td.ContainerDefinitions[j].String()) < 0
 	})
 
 	for _, cd := range td.ContainerDefinitions {
 		sort.Slice(cd.Environment, func(i, j int) bool {
-			return strings.Compare(*cd.Environment[i].Name, *cd.Environment[j].Name) < 0
+			return strings.Compare(cd.Environment[i].String(), cd.Environment[j].String()) < 0
+		})
+
+		sort.Slice(cd.MountPoints, func(i, j int) bool {
+			return strings.Compare(cd.MountPoints[i].String(), cd.MountPoints[j].String()) < 0
+		})
+
+		sort.Slice(cd.PortMappings, func(i, j int) bool {
+			return strings.Compare(cd.PortMappings[i].String(), cd.PortMappings[j].String()) < 0
+		})
+
+		sort.Slice(cd.Volumes, func(i, j int) bool {
+			return strings.Compare(cd.Volumes[i].String(), cd.Volumes[j].String()) < 0
+		})
+
+		sort.Slice(cd.VolumesFrom, func(i, j int) bool {
+			return strings.Compare(cd.VolumesFrom[i].String(), cd.VolumesFrom[j].String()) < 0
 		})
 
 		sort.Slice(cd.Secrets, func(i, j int) bool {
-			return strings.Compare(*cd.Secrets[i].Name, *cd.Secrets[j].Name) < 0
+			return strings.Compare(cd.Secrets[i].String(), cd.Secrets[j].String()) < 0
 		})
 	}
 

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -312,8 +312,10 @@ func (d *App) Create(opt CreateOption) error {
 	}
 
 	if *opt.DryRun {
-		d.Log("task definition:", td.String())
-		d.Log("service definition:", svd.String())
+		d.Log("task definition:")
+		d.LogJSON(td)
+		d.Log("service definition:")
+		d.LogJSON(svd)
 		d.Log("DRY RUN OK")
 		return nil
 	}
@@ -438,7 +440,8 @@ func (d *App) Run(opt RunOption) error {
 		tdArn = *(td.TaskDefinitionArn)
 		watchContainer = containerOf(td, opt.WatchContainer)
 		if *opt.DryRun {
-			d.Log("task definition:", td.String())
+			d.Log("task definition:")
+			d.LogJSON(td)
 		}
 	} else {
 		td, err := d.LoadTaskDefinition(d.config.TaskDefinitionPath)
@@ -459,7 +462,8 @@ func (d *App) Run(opt RunOption) error {
 		_ = newTd
 
 		if *opt.DryRun {
-			d.Log("task definition:", td.String())
+			d.Log("task definition:")
+			d.LogJSON(td)
 		} else {
 			newTd, err = d.RegisterTaskDefinition(ctx, td)
 			if err != nil {
@@ -557,6 +561,10 @@ func (d *App) DebugLog(v ...interface{}) {
 		return
 	}
 	d.Log(v...)
+}
+
+func (d *App) LogJSON(v interface{}) {
+	fmt.Print(MarshalJSONString(v))
 }
 
 func (d *App) WaitServiceStable(ctx context.Context, startedAt time.Time) error {
@@ -769,7 +777,8 @@ func (d *App) Register(opt RegisterOption) error {
 		return errors.Wrap(err, "failed to load task definition")
 	}
 	if *opt.DryRun {
-		d.Log("task definition:", td.String())
+		d.Log("task definition:")
+		d.LogJSON(td)
 		d.Log("DRY RUN OK")
 		return nil
 	}
@@ -780,7 +789,7 @@ func (d *App) Register(opt RegisterOption) error {
 	}
 
 	if *opt.Output {
-		fmt.Println(newTd.String())
+		d.LogJSON(newTd)
 	}
 	return nil
 }

--- a/export_test.go
+++ b/export_test.go
@@ -1,0 +1,8 @@
+package ecspresso
+
+var (
+	SortTaskDefinitionForDiff    = sortTaskDefinitionForDiff
+	SortServiceDefinitionForDiff = sortServiceDefinitionForDiff
+	EqualString                  = equalString
+	ToNumberCPU                  = toNumberCPU
+)

--- a/export_test.go
+++ b/export_test.go
@@ -5,4 +5,5 @@ var (
 	SortServiceDefinitionForDiff = sortServiceDefinitionForDiff
 	EqualString                  = equalString
 	ToNumberCPU                  = toNumberCPU
+	ToNumberMemory               = toNumberMemory
 )

--- a/util.go
+++ b/util.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/private/protocol/json/jsonutil"
 )
 
-func MarshalJSON(s interface{}) ([]byte, error) {
+func marshalJSON(s interface{}) (*bytes.Buffer, error) {
 	var buf bytes.Buffer
 	b, err := jsonutil.BuildJSON(s)
 	if err != nil {
@@ -15,5 +15,18 @@ func MarshalJSON(s interface{}) ([]byte, error) {
 	}
 	json.Indent(&buf, b, "", "  ")
 	buf.WriteString("\n")
-	return buf.Bytes(), nil
+	return &buf, nil
+}
+
+func MarshalJSON(s interface{}) ([]byte, error) {
+	b, err := marshalJSON(s)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), err
+}
+
+func MarshalJSONString(s interface{}) string {
+	b, _ := marshalJSON(s)
+	return b.String()
 }


### PR DESCRIPTION
- Fix --dry-run output format from `.String()` to JSON.
- Reduce `diff` elements which essentially the same thing.
  - for example, "0.25 vCPU" equals to "256" in taskDefinition.cpu.
- Sort elements in (task|container)Definitions by reflect package.
- (internal changes) `LoadServiceDefinition` returns `*ecs.Service` instead of `*ecs.CreateServiceInput`