### PR TITLE
sort containerDefinitions after default values injected

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -189,20 +189,6 @@ func sortServiceDefinitionForDiff(sv *ecs.Service) {
 }
 
 func sortTaskDefinitionForDiff(td *ecs.TaskDefinition) {
-	sortSlicesInDefinition(
-		reflect.TypeOf(*td), reflect.Indirect(reflect.ValueOf(td)),
-		"ContainerDefinitions",
-		"PlacementConstraints",
-		"RequiresCompatibilities",
-		"Volumes",
-	)
-	if td.Cpu != nil {
-		td.Cpu = toNumberCPU(*td.Cpu)
-	}
-	if td.Memory != nil {
-		td.Memory = toNumberMemory(*td.Memory)
-	}
-
 	for _, cd := range td.ContainerDefinitions {
 		if cd.Cpu == nil {
 			cd.Cpu = aws.Int64(0)
@@ -215,6 +201,19 @@ func sortTaskDefinitionForDiff(td *ecs.TaskDefinition) {
 			"VolumesFrom",
 			"Secrets",
 		)
+	}
+	sortSlicesInDefinition(
+		reflect.TypeOf(*td), reflect.Indirect(reflect.ValueOf(td)),
+		"ContainerDefinitions",
+		"PlacementConstraints",
+		"RequiresCompatibilities",
+		"Volumes",
+	)
+	if td.Cpu != nil {
+		td.Cpu = toNumberCPU(*td.Cpu)
+	}
+	if td.Memory != nil {
+		td.Memory = toNumberMemory(*td.Memory)
 	}
 }
 

--- a/diff_test.go
+++ b/diff_test.go
@@ -58,6 +58,7 @@ var testTaskDefinition1 = &ecs.TaskDefinition{
 			},
 		},
 		{
+			Cpu:   aws.Int64(0),
 			Name:  aws.String("web"),
 			Image: aws.String("nginx:latest"),
 		},
@@ -73,7 +74,6 @@ var testTaskDefinition2 = &ecs.TaskDefinition{
 			Image: aws.String("nginx:latest"),
 		},
 		{
-			Cpu:   aws.Int64(0),
 			Name:  aws.String("app"),
 			Image: aws.String("debian:buster"),
 			Environment: []*ecs.KeyValuePair{


### PR DESCRIPTION
Currently, 

1. Sort containerDefinitions in taskDefinition.
2. Inject default values into each containerDefinitions.

But the sort order was effected by injected default values.

This PR sorts after default values injected for stable sort order.