### PR TITLE
Apply desired count in service def

### DIFF
--- a/deploy.go
+++ b/deploy.go
@@ -21,19 +21,19 @@ const (
 	CodeDeployConsoleURLFmt = "https://%s.console.aws.amazon.com/codesuite/codedeploy/deployments/%s?region=%s"
 )
 
-func calcDesiredCount(sv *ecs.Service, opt DeployOption) (count *int64) {
+func calcDesiredCount(sv *ecs.Service, opt optWithDesiredCount) (count *int64) {
 	count = sv.DesiredCount // default
 	if sv.SchedulingStrategy != nil && *sv.SchedulingStrategy == "DAEMON" {
 		count = nil
 		return
 	}
-	if opt.DesiredCount != nil && *opt.DesiredCount == KeepDesiredCount {
+	if opt.getDesiredCount() != nil && *opt.getDesiredCount() == KeepDesiredCount {
 		// unchanged
 		count = nil
 		return
 	}
-	if opt.DesiredCount != nil {
-		count = opt.DesiredCount
+	if opt.getDesiredCount() != nil {
+		count = opt.getDesiredCount()
 	}
 
 	return

--- a/deploy.go
+++ b/deploy.go
@@ -21,6 +21,24 @@ const (
 	CodeDeployConsoleURLFmt = "https://%s.console.aws.amazon.com/codesuite/codedeploy/deployments/%s?region=%s"
 )
 
+func calcDesiredCount(sv *ecs.Service, opt DeployOption) (count *int64) {
+	count = sv.DesiredCount // default
+	if sv.SchedulingStrategy != nil && *sv.SchedulingStrategy == "DAEMON" {
+		count = nil
+		return
+	}
+	if opt.DesiredCount != nil && *opt.DesiredCount == KeepDesiredCount {
+		// unchanged
+		count = nil
+		return
+	}
+	if opt.DesiredCount != nil {
+		count = opt.DesiredCount
+	}
+
+	return
+}
+
 func (d *App) Deploy(opt DeployOption) error {
 	ctx, cancel := d.Start()
 	defer cancel()
@@ -29,16 +47,6 @@ func (d *App) Deploy(opt DeployOption) error {
 	sv, err := d.DescribeServiceStatus(ctx, 0)
 	if err != nil {
 		return errors.Wrap(err, "failed to describe service status")
-	}
-
-	var count *int64
-	if sv.SchedulingStrategy != nil && *sv.SchedulingStrategy == "DAEMON" {
-		count = nil
-	} else if opt.DesiredCount == nil || *opt.DesiredCount == KeepDesiredCount {
-		// unchanged
-		count = nil
-	} else {
-		count = opt.DesiredCount
 	}
 
 	var tdArn string
@@ -60,9 +68,6 @@ func (d *App) Deploy(opt DeployOption) error {
 			tdArn = *newTd.TaskDefinitionArn
 		}
 	}
-	if count != nil {
-		d.Log("desired count:", *count)
-	}
 	if opt.UpdateService != nil && *opt.UpdateService {
 		sv, err = d.UpdateServiceAttributes(ctx, opt)
 		if err != nil {
@@ -80,6 +85,13 @@ func (d *App) Deploy(opt DeployOption) error {
 		if err := d.suspendAutoScaling(*suspend); err != nil {
 			return err
 		}
+	}
+
+	count := calcDesiredCount(sv, opt)
+	if count != nil {
+		d.Log("desired count:", *count)
+	} else {
+		d.Log("desired count: unchanged")
 	}
 
 	// detect controller
@@ -187,7 +199,7 @@ func (d *App) UpdateServiceAttributes(ctx context.Context, opt DeployOption) (*e
 }
 
 func (d *App) DeployByCodeDeploy(ctx context.Context, taskDefinitionArn string, count *int64, sv *ecs.Service, opt DeployOption) error {
-	if count != nil && *sv.DesiredCount != *count {
+	if count != nil {
 		d.Log("updating desired count to", *count)
 		_, err := d.ecs.UpdateServiceWithContext(
 			ctx,

--- a/deploy.go
+++ b/deploy.go
@@ -27,15 +27,13 @@ func calcDesiredCount(sv *ecs.Service, opt optWithDesiredCount) (count *int64) {
 		count = nil
 		return
 	}
-	if opt.getDesiredCount() != nil && *opt.getDesiredCount() == KeepDesiredCount {
-		// unchanged
-		count = nil
+	if opt.getDesiredCount() != nil && *opt.getDesiredCount() == DefaultDesiredCount {
+		// default
 		return
 	}
 	if opt.getDesiredCount() != nil {
 		count = opt.getDesiredCount()
 	}
-
 	return
 }
 
@@ -44,14 +42,18 @@ func (d *App) Deploy(opt DeployOption) error {
 	defer cancel()
 
 	d.Log("Starting deploy", opt.DryRunString())
-	sv, err := d.DescribeServiceStatus(ctx, 0)
+	sv, err := d.LoadServiceDefinition(d.config.ServiceDefinitionPath)
 	if err != nil {
 		return errors.Wrap(err, "failed to describe service status")
 	}
 
 	var tdArn string
 	if *opt.SkipTaskDefinition {
-		tdArn = *sv.TaskDefinition
+		currentSv, err := d.DescribeServiceStatus(ctx, 0)
+		if err != nil {
+			return errors.Wrap(err, "failed to describe service status")
+		}
+		tdArn = *currentSv.TaskDefinition
 	} else {
 		td, err := d.LoadTaskDefinition(d.config.TaskDefinitionPath)
 		if err != nil {
@@ -68,9 +70,16 @@ func (d *App) Deploy(opt DeployOption) error {
 			tdArn = *newTd.TaskDefinitionArn
 		}
 	}
+
+	count := calcDesiredCount(sv, opt)
+	if count != nil {
+		d.Log("desired count:", *count)
+	} else {
+		d.Log("desired count: unchanged")
+	}
+
 	if opt.UpdateService != nil && *opt.UpdateService {
-		sv, err = d.UpdateServiceAttributes(ctx, opt)
-		if err != nil {
+		if err = d.UpdateServiceAttributes(ctx, sv, opt); err != nil {
 			return errors.Wrap(err, "failed to update service attributes")
 		}
 
@@ -85,13 +94,6 @@ func (d *App) Deploy(opt DeployOption) error {
 		if err := d.suspendAutoScaling(*suspend); err != nil {
 			return err
 		}
-	}
-
-	count := calcDesiredCount(sv, opt)
-	if count != nil {
-		d.Log("desired count:", *count)
-	} else {
-		d.Log("desired count: unchanged")
 	}
 
 	// detect controller
@@ -158,13 +160,9 @@ func svToUpdateServiceInput(sv *ecs.Service) *ecs.UpdateServiceInput {
 	}
 }
 
-func (d *App) UpdateServiceAttributes(ctx context.Context, opt DeployOption) (*ecs.Service, error) {
-	svd, err := d.LoadServiceDefinition(d.config.ServiceDefinitionPath)
-	if err != nil {
-		return nil, err
-	}
-	in := svToUpdateServiceInput(svd)
-	if isCodeDeploy(svd.DeploymentController) {
+func (d *App) UpdateServiceAttributes(ctx context.Context, sv *ecs.Service, opt DeployOption) error {
+	in := svToUpdateServiceInput(sv)
+	if isCodeDeploy(sv.DeploymentController) {
 		// unable to update attributes below with a CODE_DEPLOY deployment controller.
 		in.NetworkConfiguration = nil
 		in.PlatformVersion = nil
@@ -178,24 +176,16 @@ func (d *App) UpdateServiceAttributes(ctx context.Context, opt DeployOption) (*e
 	if *opt.DryRun {
 		d.Log("update service input:")
 		d.LogJSON(in)
-		return nil, nil
+		return nil
 	}
 	d.Log("Updating service attributes...")
 	d.DebugLog(in.String())
 
-	out, err := d.ecs.UpdateServiceWithContext(ctx, in)
-	if err != nil {
-		return nil, err
+	if _, err := d.ecs.UpdateServiceWithContext(ctx, in); err != nil {
+		return err
 	}
 	time.Sleep(delayForServiceChanged) // wait for service updated
-	sv := out.Service
-
-	if isCodeDeploy(sv.DeploymentController) {
-		// restore service attributes for CodeDeploy deployment
-		sv.NetworkConfiguration = svd.NetworkConfiguration
-		sv.PlatformVersion = svd.PlatformVersion
-	}
-	return sv, nil
+	return nil
 }
 
 func (d *App) DeployByCodeDeploy(ctx context.Context, taskDefinitionArn string, count *int64, sv *ecs.Service, opt DeployOption) error {

--- a/deploy.go
+++ b/deploy.go
@@ -27,12 +27,11 @@ func calcDesiredCount(sv *ecs.Service, opt optWithDesiredCount) (count *int64) {
 		count = nil
 		return
 	}
-	if opt.getDesiredCount() != nil && *opt.getDesiredCount() == DefaultDesiredCount {
-		// default
-		return
-	}
-	if opt.getDesiredCount() != nil {
-		count = opt.getDesiredCount()
+	if oc := opt.getDesiredCount(); oc != nil {
+		if *oc == DefaultDesiredCount {
+			return
+		}
+		count = oc // --tasks
 	}
 	return
 }

--- a/deploy_test.go
+++ b/deploy_test.go
@@ -37,13 +37,18 @@ var desiredCountTestSuite = []desiredCountTestCase{
 	},
 	{
 		sv:       &ecs.Service{DesiredCount: aws.Int64(1)},
-		opt:      ecspresso.DeployOption{DesiredCount: aws.Int64(ecspresso.KeepDesiredCount)},
-		expected: nil,
+		opt:      ecspresso.DeployOption{DesiredCount: aws.Int64(ecspresso.DefaultDesiredCount)},
+		expected: aws.Int64(1),
 	},
 	{
 		sv:       &ecs.Service{DesiredCount: nil},
 		opt:      ecspresso.DeployOption{DesiredCount: aws.Int64(5)},
 		expected: aws.Int64(5),
+	},
+	{
+		sv:       &ecs.Service{DesiredCount: nil},
+		opt:      ecspresso.DeployOption{DesiredCount: aws.Int64(ecspresso.DefaultDesiredCount)},
+		expected: nil,
 	},
 }
 

--- a/deploy_test.go
+++ b/deploy_test.go
@@ -1,0 +1,65 @@
+package ecspresso_test
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/kayac/ecspresso"
+)
+
+type desiredCountTestCase struct {
+	sv       *ecs.Service
+	opt      ecspresso.DeployOption
+	expected *int64
+}
+
+var desiredCountTestSuite = []desiredCountTestCase{
+	{
+		sv:       &ecs.Service{DesiredCount: nil},
+		opt:      ecspresso.DeployOption{DesiredCount: nil},
+		expected: nil,
+	},
+	{
+		sv:       &ecs.Service{DesiredCount: nil, SchedulingStrategy: aws.String("DAEMON")},
+		opt:      ecspresso.DeployOption{DesiredCount: aws.Int64(10)},
+		expected: nil,
+	},
+	{
+		sv:       &ecs.Service{DesiredCount: aws.Int64(2)},
+		opt:      ecspresso.DeployOption{DesiredCount: nil},
+		expected: aws.Int64(2),
+	},
+	{
+		sv:       &ecs.Service{DesiredCount: aws.Int64(1)},
+		opt:      ecspresso.DeployOption{DesiredCount: aws.Int64(3)},
+		expected: aws.Int64(3),
+	},
+	{
+		sv:       &ecs.Service{DesiredCount: aws.Int64(1)},
+		opt:      ecspresso.DeployOption{DesiredCount: aws.Int64(ecspresso.KeepDesiredCount)},
+		expected: nil,
+	},
+	{
+		sv:       &ecs.Service{DesiredCount: nil},
+		opt:      ecspresso.DeployOption{DesiredCount: aws.Int64(5)},
+		expected: aws.Int64(5),
+	},
+}
+
+func TestCalcDesiredCount(t *testing.T) {
+	for _, c := range desiredCountTestSuite {
+		count := ecspresso.CalcDesiredCount(c.sv, c.opt)
+		if count == nil && c.expected == nil {
+			// ok
+		} else if count != nil && c.expected == nil {
+			t.Errorf("unexpected desired count:%d expected:nil", *count)
+		} else if count == nil && c.expected != nil {
+			t.Errorf("unexpected desired count:nil expected:%d", *c.expected)
+		} else if *count != *c.expected {
+			t.Errorf("unexpected desired count:%d expected:%d", *count, *c.expected)
+		} else {
+			// ok
+		}
+	}
+}

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -25,7 +25,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-const KeepDesiredCount = -1
+const DefaultDesiredCount = -1
 
 var isTerminal = isatty.IsTerminal(os.Stdout.Fd())
 var TerminalWidth = 90

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -307,9 +307,7 @@ func (d *App) Create(opt CreateOption) error {
 		return errors.Wrap(err, "failed to load task definition")
 	}
 
-	if *opt.DesiredCount != 1 {
-		svd.DesiredCount = opt.DesiredCount
-	}
+	count := calcDesiredCount(svd, opt)
 
 	if *opt.DryRun {
 		d.Log("task definition:")
@@ -329,7 +327,7 @@ func (d *App) Create(opt CreateOption) error {
 		CapacityProviderStrategy:      svd.CapacityProviderStrategy,
 		DeploymentConfiguration:       svd.DeploymentConfiguration,
 		DeploymentController:          svd.DeploymentController,
-		DesiredCount:                  svd.DesiredCount,
+		DesiredCount:                  count,
 		EnableECSManagedTags:          svd.EnableECSManagedTags,
 		HealthCheckGracePeriodSeconds: svd.HealthCheckGracePeriodSeconds,
 		LaunchType:                    svd.LaunchType,
@@ -648,18 +646,7 @@ func (d *App) LoadServiceDefinition(path string) (*ecs.Service, error) {
 		return nil, err
 	}
 
-	var count *int64
-	if c.SchedulingStrategy == nil || *c.SchedulingStrategy == "REPLICA" && c.DesiredCount == nil {
-		// set default desired count to 1 only when SchedulingStrategy is REPLICA(default)
-		count = aws.Int64(1)
-	} else if *c.SchedulingStrategy == "DAEMON" {
-		count = nil
-	} else {
-		count = c.DesiredCount
-	}
-
 	c.ServiceName = aws.String(d.config.Service)
-	c.DesiredCount = count
 
 	return &c, nil
 }

--- a/export_test.go
+++ b/export_test.go
@@ -6,4 +6,5 @@ var (
 	EqualString                  = equalString
 	ToNumberCPU                  = toNumberCPU
 	ToNumberMemory               = toNumberMemory
+	CalcDesiredCount             = calcDesiredCount
 )

--- a/options.go
+++ b/options.go
@@ -6,10 +6,18 @@ type DryRunnable interface {
 	DryRunString() bool
 }
 
+type optWithDesiredCount interface {
+	getDesiredCount() *int64
+}
+
 type CreateOption struct {
 	DryRun       *bool
 	DesiredCount *int64
 	NoWait       *bool
+}
+
+func (opt CreateOption) getDesiredCount() *int64 {
+	return opt.DesiredCount
 }
 
 func (opt CreateOption) DryRunString() string {
@@ -28,6 +36,10 @@ type DeployOption struct {
 	SuspendAutoScaling *bool
 	RollbackEvents     *string
 	UpdateService      *bool
+}
+
+func (opt DeployOption) getDesiredCount() *int64 {
+	return opt.DesiredCount
 }
 
 func (opt DeployOption) DryRunString() string {


### PR DESCRIPTION
Fix for #131 

At deploy, ecspresso sets a desiredCount to ECS service by the following priority.

1. --tasks CLI option.
1. `desiredCount` in a service definition if defined.
1. (Unchanged)

