### PR TITLE
resolve task/service def with relpath from a config file.

### DIFF
--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/alecthomas/kingpin"
 	"github.com/kayac/ecspresso"
-
-	config "github.com/kayac/go-config"
 )
 
 var Version = "current"
@@ -117,8 +115,8 @@ func _main() int {
 		c.ServiceDefinitionPath = *initOption.ServiceDefinitionPath
 		initOption.ConfigFilePath = conf
 	} else {
-		if err := config.LoadWithEnv(c, *conf); err != nil {
-			log.Println("Cloud not load config file", conf, err)
+		if err := c.Load(*conf); err != nil {
+			log.Println("Cloud not load config file", *conf, err)
 			kingpin.Usage()
 			return 1
 		}

--- a/config_test.go
+++ b/config_test.go
@@ -4,28 +4,23 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/kayac/ecspresso"
-	"github.com/kayac/go-config"
 )
 
 func TestLoadServiceDefinition(t *testing.T) {
-	path := "tests/sv.json"
-	c := &ecspresso.Config{
-		Region:             "ap-northeast-1",
-		Timeout:            300 * time.Second,
-		Service:            "test",
-		Cluster:            "default2",
-		TaskDefinitionPath: "tests/td.json",
+	c := &ecspresso.Config{}
+	err := c.Load("tests/test.yaml")
+	if err != nil {
+		t.Error(err)
 	}
 	app, err := ecspresso.NewApp(c)
 	if err != nil {
 		t.Error(err)
 	}
-	sv, err := app.LoadServiceDefinition(path)
+	sv, err := app.LoadServiceDefinition(c.ServiceDefinitionPath)
 	if err != nil || sv == nil {
-		t.Errorf("%s load failed: %s", path, err)
+		t.Errorf("%s load failed: %s", c.ServiceDefinitionPath, err)
 	}
 
 	if *sv.ServiceName != "test" ||
@@ -44,12 +39,12 @@ func TestLoadConfigWithPlugin(t *testing.T) {
 	os.Setenv("TAG", "testing")
 	os.Setenv("JSON", `{"foo":"bar"}`)
 
-	var conf ecspresso.Config
-	err := config.LoadWithEnv(&conf, "config.yaml")
+	conf := &ecspresso.Config{}
+	err := conf.Load("config.yaml")
 	if err != nil {
 		t.Error(err)
 	}
-	app, err := ecspresso.NewApp(&conf)
+	app, err := ecspresso.NewApp(conf)
 	if err != nil {
 		t.Error(err)
 	}

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -252,9 +252,6 @@ func (d *App) GetLogEvents(ctx context.Context, logGroup string, logStream strin
 
 func NewApp(conf *Config) (*App, error) {
 	loader := config.New()
-	if err := conf.Validate(); err != nil {
-		return nil, errors.Wrap(err, "invalid configuration")
-	}
 	for _, f := range conf.templateFuncs {
 		loader.Funcs(f)
 	}

--- a/ecspresso_test.go
+++ b/ecspresso_test.go
@@ -16,6 +16,9 @@ func TestLoadTaskDefinition(t *testing.T) {
 			Cluster:            "default",
 			TaskDefinitionPath: path,
 		}
+		if err := c.Restrict(); err != nil {
+			t.Error(err)
+		}
 		app, err := ecspresso.NewApp(c)
 		if err != nil {
 			t.Error(err)

--- a/tests/ci/config.yaml
+++ b/tests/ci/config.yaml
@@ -1,10 +1,10 @@
 region: ap-northeast-1
 cluster: ecspresso-test
 service: 'nginx-{{env `CIRCLE_BRANCH` `local`}}'
-service_definition: '{{ env `SERVICE_DEF` `ecs-service-definition` }}.json'
+service_definition: '{{ env `SERVICE_DEF` `ecs-service-def` }}.json'
 task_definition: ecs-task-def.json
 timeout: 10m0s
-plugins:
-- name: tfstate
-  config:
-    path: terraform.tfstate
+#plugins:
+#- name: tfstate
+#  config:
+#    path: terraform.tfstate

--- a/tests/test.yaml
+++ b/tests/test.yaml
@@ -1,0 +1,6 @@
+region: ap-northeast-1
+timeout: 300
+service: test
+cluster: default2
+service_definition: sv.json
+task_definition: td.json


### PR DESCRIPTION
fixes #140

Load task/service-definition files based on the relative path from a config file.
At v0, resolved from a current (ecspresso running) path.