### PR TITLE
add --latest-task-definition option to deploy with latest task definition

### DIFF
--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -26,17 +26,18 @@ func _main() int {
 	var isSetSuspendAutoScaling bool
 	deploy := kingpin.Command("deploy", "deploy service")
 	deployOption := ecspresso.DeployOption{
-		DryRun:             deploy.Flag("dry-run", "dry-run").Bool(),
-		DesiredCount:       deploy.Flag("tasks", "desired count of tasks").Default("-1").Int64(),
-		SkipTaskDefinition: deploy.Flag("skip-task-definition", "skip register a new task definition").Bool(),
-		ForceNewDeployment: deploy.Flag("force-new-deployment", "force a new deployment of the service").Bool(),
-		NoWait:             deploy.Flag("no-wait", "exit ecspresso immediately after just deployed without waiting for service stable").Bool(),
-		SuspendAutoScaling: deploy.Flag("suspend-auto-scaling", "set suspend to auto-scaling attached with the ECS service").IsSetByUser(&isSetSuspendAutoScaling).Bool(),
-		RollbackEvents:     deploy.Flag("rollback-events", " rollback when specified events happened (DEPLOYMENT_FAILURE,DEPLOYMENT_STOP_ON_ALARM,DEPLOYMENT_STOP_ON_REQUEST,...) CodeDeploy only.").String(),
-		UpdateService:      deploy.Flag("update-service", "update service attributes by service definition").Bool(),
+		DryRun:               deploy.Flag("dry-run", "dry-run").Bool(),
+		DesiredCount:         deploy.Flag("tasks", "desired count of tasks").Default("-1").Int64(),
+		SkipTaskDefinition:   deploy.Flag("skip-task-definition", "skip register a new task definition").Bool(),
+		ForceNewDeployment:   deploy.Flag("force-new-deployment", "force a new deployment of the service").Bool(),
+		NoWait:               deploy.Flag("no-wait", "exit ecspresso immediately after just deployed without waiting for service stable").Bool(),
+		SuspendAutoScaling:   deploy.Flag("suspend-auto-scaling", "set suspend to auto-scaling attached with the ECS service").IsSetByUser(&isSetSuspendAutoScaling).Bool(),
+		RollbackEvents:       deploy.Flag("rollback-events", " rollback when specified events happened (DEPLOYMENT_FAILURE,DEPLOYMENT_STOP_ON_ALARM,DEPLOYMENT_STOP_ON_REQUEST,...) CodeDeploy only.").String(),
+		UpdateService:        deploy.Flag("update-service", "update service attributes by service definition").Bool(),
+		LatestTaskDefinition: deploy.Flag("latest-task-definition", "deploy with latest task definition without registering new task definition").Bool(),
 	}
 
-	refresh := kingpin.Command("refresh", "refresh service. equivalent to deploy --skip-task-definiton --force-new-deployment")
+	refresh := kingpin.Command("refresh", "refresh service. equivalent to deploy --skip-task-definition --force-new-deployment")
 	refreshOption := ecspresso.DeployOption{
 		DryRun:             refresh.Flag("dry-run", "dry-run").Bool(),
 		SkipTaskDefinition: boolp(true),

--- a/deploy.go
+++ b/deploy.go
@@ -42,7 +42,14 @@ func (d *App) Deploy(opt DeployOption) error {
 	}
 
 	var tdArn string
-	if *opt.SkipTaskDefinition {
+	if *opt.LatestTaskDefinition {
+		family := strings.Split(arnToName(*sv.TaskDefinition), ":")[0]
+		var err error
+		tdArn, err = d.findLatestTaskDefinitionArn(ctx, family)
+		if err != nil {
+			return errors.Wrap(err, "failed to load latest task definition")
+		}
+	} else if *opt.SkipTaskDefinition {
 		tdArn = *sv.TaskDefinition
 	} else {
 		td, err := d.LoadTaskDefinition(d.config.TaskDefinitionPath)

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -546,6 +546,23 @@ func (d *App) FindRollbackTarget(ctx context.Context, taskDefinitionArn string) 
 	}
 }
 
+func (d *App) findLatestTaskDefinitionArn(ctx context.Context, family string) (string, error) {
+	out, err := d.ecs.ListTaskDefinitionsWithContext(ctx,
+		&ecs.ListTaskDefinitionsInput{
+			FamilyPrefix: aws.String(family),
+			MaxResults:   aws.Int64(1),
+			Sort:         aws.String("DESC"),
+		},
+	)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to list taskdefinitions")
+	}
+	if len(out.TaskDefinitionArns) == 0 {
+		return "", errors.New("no task definitions are found")
+	}
+	return *out.TaskDefinitionArns[0], nil
+}
+
 func (d *App) Name() string {
 	return fmt.Sprintf("%s/%s", d.Service, d.Cluster)
 }

--- a/options.go
+++ b/options.go
@@ -20,14 +20,15 @@ func (opt CreateOption) DryRunString() string {
 }
 
 type DeployOption struct {
-	DryRun             *bool
-	DesiredCount       *int64
-	SkipTaskDefinition *bool
-	ForceNewDeployment *bool
-	NoWait             *bool
-	SuspendAutoScaling *bool
-	RollbackEvents     *string
-	UpdateService      *bool
+	DryRun               *bool
+	DesiredCount         *int64
+	SkipTaskDefinition   *bool
+	ForceNewDeployment   *bool
+	NoWait               *bool
+	SuspendAutoScaling   *bool
+	RollbackEvents       *string
+	UpdateService        *bool
+	LatestTaskDefinition *bool
 }
 
 func (opt DeployOption) DryRunString() string {


### PR DESCRIPTION
This option is useful when we have registered a new task definition by running `ecspresso run` before `ecspresso deploy`, or when we want to deploy multiple services with the same task definition.