### PR TITLE
Allow no service_definition in config.

### DIFF
--- a/config.go
+++ b/config.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/kayac/ecspresso/appspec"
 	gc "github.com/kayac/go-config"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -47,15 +46,13 @@ func (c *Config) Restrict() error {
 	if c.dir == "" {
 		c.dir = "."
 	}
-	c.ServiceDefinitionPath = filepath.Join(c.dir, c.ServiceDefinitionPath)
-	if _, err := os.Stat(c.ServiceDefinitionPath); err != nil {
-		return errors.Wrapf(err, "service_definition:%s is not found", c.ServiceDefinitionPath)
+	if c.ServiceDefinitionPath != "" {
+		c.ServiceDefinitionPath = filepath.Join(c.dir, c.ServiceDefinitionPath)
+	}
+	if c.TaskDefinitionPath != "" {
+		c.TaskDefinitionPath = filepath.Join(c.dir, c.TaskDefinitionPath)
 	}
 
-	c.TaskDefinitionPath = filepath.Join(c.dir, c.TaskDefinitionPath)
-	if _, err := os.Stat(c.TaskDefinitionPath); err != nil {
-		return errors.Wrapf(err, "task_definition:%s is not found", c.TaskDefinitionPath)
-	}
 	for _, p := range c.Plugins {
 		if err := p.Setup(c); err != nil {
 			return err

--- a/diff.go
+++ b/diff.go
@@ -13,6 +13,40 @@ import (
 	"github.com/pkg/errors"
 )
 
+func diffServices(local, remote *ecs.Service) (string, error) {
+	sortServiceDefinitionForDiff(local)
+	sortServiceDefinitionForDiff(remote)
+
+	newSvBytes, err := MarshalJSON(svToUpdateServiceInput(local))
+	if err != nil {
+		return "", errors.Wrap(err, "failed to marshal new service definition")
+	}
+
+	remoteSvBytes, err := MarshalJSON(svToUpdateServiceInput(remote))
+	if err != nil {
+		return "", errors.Wrap(err, "failed to marshal remote service definition")
+	}
+
+	return diff.Diff(string(remoteSvBytes), string(newSvBytes)), nil
+}
+
+func diffTaskDefs(local, remote *ecs.TaskDefinition) (string, error) {
+	sortTaskDefinitionForDiff(local)
+	sortTaskDefinitionForDiff(remote)
+
+	newTdBytes, err := MarshalJSON(tdToRegisterTaskDefinitionInput(local))
+	if err != nil {
+		return "", errors.Wrap(err, "failed to marshal new task definition")
+	}
+
+	remoteTdBytes, err := MarshalJSON(tdToRegisterTaskDefinitionInput(remote))
+	if err != nil {
+		return "", errors.Wrap(err, "failed to marshal remote task definition")
+	}
+
+	return diff.Diff(string(remoteTdBytes), string(newTdBytes)), nil
+}
+
 func (d *App) Diff(opt DiffOption) error {
 	ctx, cancel := d.Start()
 	defer cancel()
@@ -22,26 +56,14 @@ func (d *App) Diff(opt DiffOption) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to load service definition")
 	}
-
 	remoteSv, err := d.DescribeService(ctx)
 	if err != nil {
 		return errors.Wrap(err, "failed to describe service")
 	}
 
-	sortServiceDefinitionForDiff(newSv)
-	sortServiceDefinitionForDiff(remoteSv)
-
-	newSvBytes, err := MarshalJSON(svToUpdateServiceInput(newSv))
-	if err != nil {
-		return errors.Wrap(err, "failed to marshal new service definition")
-	}
-
-	remoteSvBytes, err := MarshalJSON(svToUpdateServiceInput(remoteSv))
-	if err != nil {
-		return errors.Wrap(err, "failed to marshal remote service definition")
-	}
-
-	if ds := diff.Diff(string(remoteSvBytes), string(newSvBytes)); ds != "" {
+	if ds, err := diffServices(newSv, remoteSv); err != nil {
+		return err
+	} else if ds != "" {
 		fmt.Println("---", *remoteSv.ServiceArn)
 		fmt.Println("+++", d.config.ServiceDefinitionPath)
 		fmt.Println(ds)
@@ -52,31 +74,19 @@ func (d *App) Diff(opt DiffOption) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to load task definition")
 	}
-
 	remoteTd, err := d.DescribeTaskDefinition(ctx, *newTd.Family)
 	if err != nil {
 		return errors.Wrap(err, "failed to describe task definition")
 	}
 
-	// sort lists in task definition
-	sortTaskDefinitionForDiff(newTd)
-	sortTaskDefinitionForDiff(remoteTd)
-
-	newTdBytes, err := MarshalJSON(tdToRegisterTaskDefinitionInput(newTd))
-	if err != nil {
-		return errors.Wrap(err, "failed to marshal new task definition")
-	}
-
-	remoteTdBytes, err := MarshalJSON(tdToRegisterTaskDefinitionInput(remoteTd))
-	if err != nil {
-		return errors.Wrap(err, "failed to marshal remote task definition")
-	}
-
-	if ds := diff.Diff(string(remoteTdBytes), string(newTdBytes)); ds != "" {
+	if ds, err := diffTaskDefs(newTd, remoteTd); err != nil {
+		return err
+	} else if ds != "" {
 		fmt.Println("---", *remoteTd.TaskDefinitionArn)
 		fmt.Println("+++", d.config.TaskDefinitionPath)
 		fmt.Println(ds)
 	}
+
 	return nil
 }
 

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -643,7 +643,6 @@ func (d *App) RegisterTaskDefinition(ctx context.Context, td *ecs.TaskDefinition
 }
 
 func (d *App) LoadTaskDefinition(path string) (*ecs.TaskDefinition, error) {
-	d.Log("Creating a new task definition by", path)
 	c := struct {
 		TaskDefinition *ecs.TaskDefinition
 	}{}

--- a/tests/ci/Makefile
+++ b/tests/ci/Makefile
@@ -49,3 +49,6 @@ delete:
 run-task:
 	ecspresso --config config.yaml run \
 	--overrides '{"containerOverrides":[{"name":"nginx", "command":["nginx", "-V"]}]}'
+
+wait:
+	ecspresso --config config.yaml wait


### PR DESCRIPTION
At v0.x, service_definition is not necessarily in config. But v0.99.x required service_definition. Fix it.

Updating service attributes runs only when service_definition file exists and a difference exists between service_definition and ECS service.