### PR TITLE
add appspec sub command

### DIFF
--- a/appspec.go
+++ b/appspec.go
@@ -1,0 +1,46 @@
+package ecspresso
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kayac/ecspresso/appspec"
+	"github.com/pkg/errors"
+)
+
+func (d *App) AppSpec(opt AppSpecOption) error {
+	ctx, cancel := d.Start()
+	defer cancel()
+	var taskDefinitionArn string
+
+	sv, err := d.DescribeService(ctx)
+	if err != nil {
+		return err
+	}
+	switch *opt.TaskDefinition {
+	case "current":
+		taskDefinitionArn = *sv.TaskDefinition
+	case "latest":
+		family := strings.Split(arnToName(*sv.TaskDefinition), ":")[0]
+		taskDefinitionArn, err = d.findLatestTaskDefinitionArn(ctx, family)
+		if err != nil {
+			return err
+		}
+	default:
+		taskDefinitionArn = *opt.TaskDefinition
+		if !strings.HasPrefix(taskDefinitionArn, "arn:aws:ecs:") {
+			return errors.New("--task-definition requires current, latest or a valid task definition arn")
+		}
+	}
+
+	spec, err := appspec.NewWithService(sv, taskDefinitionArn)
+	if err != nil {
+		return errors.Wrap(err, "failed to create appspec")
+	}
+	if d.config.AppSpec != nil {
+		spec.Hooks = d.config.AppSpec.Hooks
+	}
+
+	fmt.Print(spec.String())
+	return nil
+}

--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -103,6 +103,11 @@ func _main() int {
 	_ = kingpin.Command("diff", "display diff for task definition compared with latest one on ECS")
 	diffOption := ecspresso.DiffOption{}
 
+	appspec := kingpin.Command("appspec", "output AppSpec YAML for CodeDeploy to STDOUT")
+	appspecOption := ecspresso.AppSpecOption{
+		TaskDefinition: appspec.Flag("task-definition", "use task definition arn in AppSpec (latest, current or Arn)").Default("latest").String(),
+	}
+
 	sub := kingpin.Parse()
 	if sub == "version" {
 		fmt.Println("ecspresso", Version)
@@ -158,6 +163,8 @@ func _main() int {
 		err = app.Init(initOption)
 	case "diff":
 		err = app.Diff(diffOption)
+	case "appspec":
+		err = app.AppSpec(appspecOption)
 	default:
 		kingpin.Usage()
 		return 1

--- a/options.go
+++ b/options.go
@@ -125,5 +125,4 @@ type DiffOption struct {
 
 type AppSpecOption struct {
 	TaskDefinition *string
-	Output         *string
 }

--- a/options.go
+++ b/options.go
@@ -122,3 +122,8 @@ type InitOption struct {
 
 type DiffOption struct {
 }
+
+type AppSpecOption struct {
+	TaskDefinition *string
+	Output         *string
+}


### PR DESCRIPTION
output AppSpec YAML to STDOUT.

```
$ ecspresso --config config.yaml appspec --help
usage: ecspresso appspec [<flags>]

output AppSpec YAML for CodeDeploy to STDOUT

Flags:
  --help                      Show context-sensitive help (also try --help-long and --help-man).
  --config=CONFIG             config file
  --debug                     enable debug log
  --task-definition="latest"  use task definition arn in AppSpec (latest, current or Arn)
```

```
$ ecspresso --config config.yaml appspec
version: "0.0"
Resources:
- TargetService:
    Type: AWS::ECS::Service
    Properties:
      TaskDefinition: arn:aws:ecs:ap-northeast-1:123456789012:task-definition/ecspresso-test:123
      LoadBalancerInfo:
        ContainerName: nginx
        ContainerPort: 80
      PlatformVersion: LATEST
      NetworkConfiguration:
        AwsvpcConfiguration:
          AssignPublicIp: ENABLED
          SecurityGroups:
          - sg-0aaaaaaa
          Subnets:
          - subnet-0111111
          - subnet-0222222
          - subnet-0333333

$ ecspresso --config config.yaml appspec --task-definition current
version: "0.0"
Resources:
- TargetService:
    Type: AWS::ECS::Service
    Properties:
      TaskDefinition: arn:aws:ecs:ap-northeast-1:12345789012:task-definition/ecspresso-test:122
      LoadBalancerInfo:
        ContainerName: nginx
        ContainerPort: 80
      PlatformVersion: LATEST
      NetworkConfiguration:
        AwsvpcConfiguration:
          AssignPublicIp: ENABLED
          SecurityGroups:
          - sg-0aaaaaaa
          Subnets:
          - subnet-0111111
          - subnet-0222222
          - subnet-0333333

$ ecspresso --config config.yaml appspec --task-definition=arn:aws:ecs:ap-northeast-1:123456789012:task-definition/ecspresso-test:99
version: "0.0"
Resources:
- TargetService:
    Type: AWS::ECS::Service
    Properties:
      TaskDefinition: arn:aws:ecs:ap-northeast-1:12345789012:task-definition/ecspresso-test:99
      LoadBalancerInfo:
        ContainerName: nginx
        ContainerPort: 80
      PlatformVersion: LATEST
      NetworkConfiguration:
        AwsvpcConfiguration:
          AssignPublicIp: ENABLED
          SecurityGroups:
          - sg-0aaaaaaa
          Subnets:
          - subnet-0111111
          - subnet-0222222
          - subnet-0333333
```
