### PR TITLE
Add latest task definition option to run command

### DIFF
--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -73,13 +73,14 @@ func _main() int {
 
 	run := kingpin.Command("run", "run task")
 	runOption := ecspresso.RunOption{
-		DryRun:             run.Flag("dry-run", "dry-run").Bool(),
-		TaskDefinition:     run.Flag("task-def", "task definition json for run task").String(),
-		NoWait:             run.Flag("no-wait", "exit ecspresso after task run").Bool(),
-		TaskOverrideStr:    run.Flag("overrides", "task overrides JSON string").Default("").String(),
-		SkipTaskDefinition: run.Flag("skip-task-definition", "skip register a new task definition").Bool(),
-		Count:              run.Flag("count", "the number of tasks (max 10)").Default("1").Int64(),
-		WatchContainer:     run.Flag("watch-container", "the container name to watch exit code").String(),
+		DryRun:               run.Flag("dry-run", "dry-run").Bool(),
+		TaskDefinition:       run.Flag("task-def", "task definition json for run task").String(),
+		NoWait:               run.Flag("no-wait", "exit ecspresso after task run").Bool(),
+		TaskOverrideStr:      run.Flag("overrides", "task overrides JSON string").Default("").String(),
+		SkipTaskDefinition:   run.Flag("skip-task-definition", "skip register a new task definition").Bool(),
+		Count:                run.Flag("count", "the number of tasks (max 10)").Default("1").Int64(),
+		WatchContainer:       run.Flag("watch-container", "the container name to watch exit code").String(),
+		LatestTaskDefinition: run.Flag("latest-task-definition", "run with latest task definition without registering new task definition").Default("false").Bool(),
 	}
 
 	register := kingpin.Command("register", "register task definition")

--- a/options.go
+++ b/options.go
@@ -80,13 +80,14 @@ func (opt DeleteOption) DryRunString() string {
 }
 
 type RunOption struct {
-	DryRun             *bool
-	TaskDefinition     *string
-	NoWait             *bool
-	TaskOverrideStr    *string
-	SkipTaskDefinition *bool
-	Count              *int64
-	WatchContainer     *string
+	DryRun               *bool
+	TaskDefinition       *string
+	NoWait               *bool
+	TaskOverrideStr      *string
+	SkipTaskDefinition   *bool
+	Count                *int64
+	WatchContainer       *string
+	LatestTaskDefinition *bool
 }
 
 func (opt RunOption) DryRunString() string {


### PR DESCRIPTION
This adds the `--latest-task-definition` flag to the `run` command, the goal is to have it function identically to how it does for the `deploy` command.

We needed this to support our application deployment flow of:

1. Registering a new task definition:
   `$ ecspresso register`
2. Running database migrations using the newly registered task definition:
    `$ ecspresso run --latest-task-definition --overrides '{...}'`
3. Deploying and updating our service using the latest definition:
    `$ ecspresso deploy --latest-task-definition --update-service`