### PR TITLE
resolve tfstate path relatively from config.yml

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -3,6 +3,7 @@ package ecspresso
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
 
 	"github.com/fujiwara/tfstate-lookup/tfstate"
 )
@@ -27,7 +28,7 @@ func setupPluginTFState(p ConfigPlugin, c *Config) error {
 	if !ok {
 		return errors.New("tfstate plugin requires path for tfstate file as string")
 	}
-	funcs, err := tfstate.FuncMap(path)
+	funcs, err := tfstate.FuncMap(filepath.Join(c.dir, path))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This patch makes ecspresso resolve tfstate config path relatively from config.yml

### motivation
In v1, ecspresso was changed to resolve task definition file path relatively (https://github.com/kayac/ecspresso/issues/140) but it does not resolve path relatively for tfstate config path. It is a bit confusing, so I fixed. 


Please review :bow: