### PR TITLE
fix: not join dir and path when path is absolut

### DIFF
--- a/config.go
+++ b/config.go
@@ -46,10 +46,10 @@ func (c *Config) Restrict() error {
 	if c.dir == "" {
 		c.dir = "."
 	}
-	if c.ServiceDefinitionPath != "" {
+	if c.ServiceDefinitionPath != "" && !filepath.IsAbs(c.ServiceDefinitionPath) {
 		c.ServiceDefinitionPath = filepath.Join(c.dir, c.ServiceDefinitionPath)
 	}
-	if c.TaskDefinitionPath != "" {
+	if c.TaskDefinitionPath != "" && !filepath.IsAbs(c.TaskDefinitionPath) {
 		c.TaskDefinitionPath = filepath.Join(c.dir, c.TaskDefinitionPath)
 	}
 

--- a/plugin.go
+++ b/plugin.go
@@ -28,7 +28,10 @@ func setupPluginTFState(p ConfigPlugin, c *Config) error {
 	if !ok {
 		return errors.New("tfstate plugin requires path for tfstate file as string")
 	}
-	funcs, err := tfstate.FuncMap(filepath.Join(c.dir, path))
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(c.dir, path)
+	}
+	funcs, err := tfstate.FuncMap(path)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The config file could not be read because the absolute path is set in config.yml.

this pull request is not join dir and path when path is absolut.

example
```yaml
# service/app.yml
region: ap-northeast-1
task_definition: "../task-definition/foo.json"
plugins:
  - name: tfstate
    config:
      path: /path/to/terraform.tfstate
```