### PR TITLE
Add tests for deploymentCircuitBreaker

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/kayac/ecspresso"
 )
 
@@ -68,6 +69,13 @@ func testLoadConfigWithPlugin(t *testing.T, path string) {
 	}
 	if subnetID != "subnet-07ac54af5e41a4fc4" {
 		t.Errorf("unexpected subnet id got:%s", subnetID)
+	}
+	cb := *svd.DeploymentConfiguration.DeploymentCircuitBreaker
+	if !aws.BoolValue(cb.Enable) {
+		t.Errorf("unexpected deploymentCircuitBreaker.enable got:%v", *cb.Enable)
+	}
+	if !aws.BoolValue(cb.Rollback) {
+		t.Errorf("unexpected deploymentCircuitBreaker.rollback got:%v", *cb.Rollback)
 	}
 
 	td, err := app.LoadTaskDefinition(conf.TaskDefinitionPath)

--- a/tests/ecs-service-def.json
+++ b/tests/ecs-service-def.json
@@ -1,7 +1,11 @@
 {
   "deploymentConfiguration": {
     "maximumPercent": 200,
-    "minimumHealthyPercent": 100
+    "minimumHealthyPercent": 100,
+    "deploymentCircuitBreaker": {
+      "enable": true,
+      "rollback": true
+    }
   },
   "desiredCount": 1,
   "enableECSManagedTags": false,


### PR DESCRIPTION
Add support to DeploymentCircuitBreaker.
https://aws.amazon.com/jp/blogs/containers/announcing-amazon-ecs-deployment-circuit-breaker/

update aws-sdk-go by #195 .
