### PR TITLE
Add render command

### DIFF
--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -114,6 +114,13 @@ func _main() int {
 		PutLogs: verify.Flag("put-logs", "put verification logs to CloudWatch Logs").Default("true").Bool(),
 	}
 
+	render := kingpin.Command("render", "render config, service definition or task definition file to stdout")
+	renderOption := ecspresso.RenderOption{
+		ServiceDefinition: render.Flag("service-definition", "render service definition").Bool(),
+		TaskDefinition:    render.Flag("task-definition", "render task definition").Bool(),
+		ConfigFile:        render.Flag("config-file", "render config file").Bool(),
+	}
+
 	sub := kingpin.Parse()
 	if sub == "version" {
 		fmt.Println("ecspresso", Version)
@@ -173,6 +180,8 @@ func _main() int {
 		err = app.AppSpec(appspecOption)
 	case "verify":
 		err = app.Verify(verifyOption)
+	case "render":
+		err = app.Render(renderOption)
 	default:
 		kingpin.Usage()
 		return 1

--- a/render.go
+++ b/render.go
@@ -1,0 +1,46 @@
+package ecspresso
+
+import (
+	"bufio"
+	"os"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"gopkg.in/yaml.v2"
+)
+
+type RenderOption struct {
+	ConfigFile        *bool
+	ServiceDefinition *bool
+	TaskDefinition    *bool
+}
+
+func (d *App) Render(opt RenderOption) error {
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	if aws.BoolValue(opt.ConfigFile) {
+		return yaml.NewEncoder(out).Encode(d.config)
+	}
+
+	if aws.BoolValue(opt.ServiceDefinition) {
+		sv, err := d.LoadServiceDefinition(d.config.ServiceDefinitionPath)
+		if err != nil {
+			return err
+		}
+		b, err := MarshalJSON(sv)
+		_, err = out.Write(b)
+		return err
+	}
+
+	if aws.BoolValue(opt.TaskDefinition) {
+		td, err := d.LoadTaskDefinition(d.config.TaskDefinitionPath)
+		if err != nil {
+			return err
+		}
+		b, err := MarshalJSON(td)
+		_, err = out.Write(b)
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
Add `render` subcommand.

`render` renders a config file, service definition, or task definition which has been read by ecspresso.