### PR TITLE
Add --color option to verify and diff command

### DIFF
--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/alecthomas/kingpin"
+	"github.com/fatih/color"
 	"github.com/kayac/ecspresso"
 	"github.com/mattn/go-isatty"
 )
@@ -21,6 +22,12 @@ func _main() int {
 
 	conf := kingpin.Flag("config", "config file").String()
 	debug := kingpin.Flag("debug", "enable debug log").Bool()
+
+	colorDefault := "false"
+	if isatty.IsTerminal(os.Stdout.Fd()) {
+		colorDefault = "true"
+	}
+	colorOpt := kingpin.Flag("color", "enalble colored output").Default(colorDefault).Bool()
 
 	var isSetSuspendAutoScaling bool
 	deploy := kingpin.Command("deploy", "deploy service")
@@ -102,14 +109,8 @@ func _main() int {
 		ServiceDefinitionPath: init.Flag("service-definition-path", "output service definition file path").Default("ecs-service-def.json").String(),
 	}
 
-	diff := kingpin.Command("diff", "display diff for task definition compared with latest one on ECS")
-	diffColorDefault := "false"
-	if isatty.IsTerminal(os.Stdout.Fd()) {
-		diffColorDefault = "true"
-	}
-	diffOption := ecspresso.DiffOption{
-		Color: diff.Flag("color", "colored output (default enabled when in a terminal)").Default(diffColorDefault).Bool(),
-	}
+	_ = kingpin.Command("diff", "display diff for task definition compared with latest one on ECS")
+	diffOption := ecspresso.DiffOption{}
 
 	appspec := kingpin.Command("appspec", "output AppSpec YAML for CodeDeploy to STDOUT")
 	appspecOption := ecspresso.AppSpecOption{
@@ -117,13 +118,8 @@ func _main() int {
 	}
 
 	verify := kingpin.Command("verify", "verify resources in configurations")
-	verifyColorDefault := "false"
-	if isatty.IsTerminal(os.Stdout.Fd()) {
-		verifyColorDefault = "true"
-	}
 	verifyOption := ecspresso.VerifyOption{
 		PutLogs: verify.Flag("put-logs", "put verification logs to CloudWatch Logs").Default("true").Bool(),
-		Color:   verify.Flag("color", "colored output (default enabled when in a terminal)").Default(verifyColorDefault).Bool(),
 	}
 
 	render := kingpin.Command("render", "render config, service definition or task definition file to stdout")
@@ -161,6 +157,7 @@ func _main() int {
 		return 1
 	}
 	app.Debug = *debug
+	color.NoColor = !*colorOpt
 
 	switch sub {
 	case "deploy":

--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/alecthomas/kingpin"
 	"github.com/kayac/ecspresso"
+	"github.com/mattn/go-isatty"
 )
 
 var Version = "current"
@@ -110,8 +111,13 @@ func _main() int {
 	}
 
 	verify := kingpin.Command("verify", "verify resources in configurations")
+	verifyColorDefault := "false"
+	if isatty.IsTerminal(os.Stdout.Fd()) {
+		verifyColorDefault = "true"
+	}
 	verifyOption := ecspresso.VerifyOption{
 		PutLogs: verify.Flag("put-logs", "put verification logs to CloudWatch Logs").Default("true").Bool(),
+		Color:   verify.Flag("color", "colored output (default enabled when run in terminal)").Default(verifyColorDefault).Bool(),
 	}
 
 	render := kingpin.Command("render", "render config, service definition or task definition file to stdout")

--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -102,8 +102,14 @@ func _main() int {
 		ServiceDefinitionPath: init.Flag("service-definition-path", "output service definition file path").Default("ecs-service-def.json").String(),
 	}
 
-	_ = kingpin.Command("diff", "display diff for task definition compared with latest one on ECS")
-	diffOption := ecspresso.DiffOption{}
+	diff := kingpin.Command("diff", "display diff for task definition compared with latest one on ECS")
+	diffColorDefault := "false"
+	if isatty.IsTerminal(os.Stdout.Fd()) {
+		diffColorDefault = "true"
+	}
+	diffOption := ecspresso.DiffOption{
+		Color: diff.Flag("color", "colored output (default enabled when in a terminal)").Default(diffColorDefault).Bool(),
+	}
 
 	appspec := kingpin.Command("appspec", "output AppSpec YAML for CodeDeploy to STDOUT")
 	appspecOption := ecspresso.AppSpecOption{
@@ -117,7 +123,7 @@ func _main() int {
 	}
 	verifyOption := ecspresso.VerifyOption{
 		PutLogs: verify.Flag("put-logs", "put verification logs to CloudWatch Logs").Default("true").Bool(),
-		Color:   verify.Flag("color", "colored output (default enabled when run in terminal)").Default(verifyColorDefault).Bool(),
+		Color:   verify.Flag("color", "colored output (default enabled when in a terminal)").Default(verifyColorDefault).Bool(),
 	}
 
 	render := kingpin.Command("render", "render config, service definition or task definition file to stdout")

--- a/diff.go
+++ b/diff.go
@@ -62,21 +62,12 @@ func (d *App) Diff(opt DiffOption) error {
 		return errors.Wrap(err, "failed to describe service")
 	}
 
-	cstr := plainString
-	if aws.BoolValue(opt.Color) {
-		cstr = colorString
-	}
-
 	if ds, err := diffServices(newSv, remoteSv); err != nil {
 		return err
 	} else if ds != "" {
-		fmt.Println(cstr(color.RedString, "--- %s", *remoteSv.ServiceArn))
-		fmt.Println(cstr(color.GreenString, "+++ %s", d.config.ServiceDefinitionPath))
-		if aws.BoolValue(opt.Color) {
-			fmt.Print(coloredDiff(ds))
-		} else {
-			fmt.Println(ds)
-		}
+		fmt.Println(color.RedString("--- %s", *remoteSv.ServiceArn))
+		fmt.Println(color.GreenString("+++ %s", d.config.ServiceDefinitionPath))
+		fmt.Print(coloredDiff(ds))
 	}
 
 	// task definition
@@ -93,13 +84,9 @@ func (d *App) Diff(opt DiffOption) error {
 	if ds, err := diffTaskDefs(newTd, remoteTd); err != nil {
 		return err
 	} else if ds != "" {
-		fmt.Println(cstr(color.RedString, "--- %s", *remoteTd.TaskDefinitionArn))
-		fmt.Println(cstr(color.GreenString, "+++ %s", d.config.TaskDefinitionPath))
-		if aws.BoolValue(opt.Color) {
-			fmt.Print(coloredDiff(ds))
-		} else {
-			fmt.Println(ds)
-		}
+		fmt.Println(color.RedString("--- %s", *remoteTd.TaskDefinitionArn))
+		fmt.Println(color.GreenString("+++ %s", d.config.TaskDefinitionPath))
+		fmt.Print(coloredDiff(ds))
 	}
 
 	return nil
@@ -109,9 +96,9 @@ func coloredDiff(src string) string {
 	var b strings.Builder
 	for _, line := range strings.Split(src, "\n") {
 		if strings.HasPrefix(line, "-") {
-			b.WriteString(colorString(color.RedString, line) + "\n")
+			b.WriteString(color.RedString(line) + "\n")
 		} else if strings.HasPrefix(line, "+") {
-			b.WriteString(colorString(color.GreenString, line) + "\n")
+			b.WriteString(color.GreenString(line) + "\n")
 		} else {
 			b.WriteString(line + "\n")
 		}

--- a/options.go
+++ b/options.go
@@ -122,6 +122,7 @@ type InitOption struct {
 }
 
 type DiffOption struct {
+	Color *bool
 }
 
 type AppSpecOption struct {

--- a/options.go
+++ b/options.go
@@ -122,7 +122,6 @@ type InitOption struct {
 }
 
 type DiffOption struct {
-	Color *bool
 }
 
 type AppSpecOption struct {


### PR DESCRIPTION
Add  --color flag to verify and diff sub command.

When run in a terminal, set  --no-color by the default.
