### PR TITLE
add plugin cfn_output

### DIFF
--- a/cloudformation/funcs.go
+++ b/cloudformation/funcs.go
@@ -1,0 +1,57 @@
+package cloudformation
+
+import (
+	"sync"
+	"text/template"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/pkg/errors"
+)
+
+var mu sync.Mutex
+var cache = make(map[string]*cloudformation.Stack, 1)
+
+func lookup(cfn *cloudformation.CloudFormation, stackName, outputKey string) (string, error) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	stack := cache[stackName]
+	if stack == nil {
+		out, err := cfn.DescribeStacks(&cloudformation.DescribeStacksInput{
+			StackName: aws.String(stackName),
+		})
+		if err != nil {
+			return "", errors.Wrapf(err, "failed to describe stacks: %s", stackName)
+		}
+		if len(out.Stacks) == 0 {
+			return "", errors.Wrapf(err, "no such stack: %s", stackName)
+		}
+		stack = out.Stacks[0]
+		cache[stackName] = out.Stacks[0]
+	}
+	return lookupStackOutput(stack, outputKey)
+}
+
+func lookupStackOutput(stack *cloudformation.Stack, outputKey string) (string, error) {
+	for _, outputs := range stack.Outputs {
+		if aws.StringValue(outputs.OutputKey) == outputKey {
+			return aws.StringValue(outputs.OutputValue), nil
+		}
+	}
+	return "", errors.Errorf("OutputKey %s is not found in stack %s", outputKey, *stack.StackName)
+}
+
+func NewFuncs(sess *session.Session) template.FuncMap {
+	cfn := cloudformation.New(sess)
+	return template.FuncMap{
+		"cfn_output": func(stackName, outputKey string) string {
+			outputValue, err := lookup(cfn, stackName, outputKey)
+			if err != nil {
+				panic(err)
+			}
+			return outputValue
+		},
+	}
+}

--- a/config.go
+++ b/config.go
@@ -6,6 +6,7 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/kayac/ecspresso/appspec"
 	gc "github.com/kayac/go-config"
 )
@@ -27,6 +28,7 @@ type Config struct {
 
 	templateFuncs []template.FuncMap
 	dir           string
+	sess          *session.Session
 }
 
 // Load loads configuration file from file path.
@@ -35,11 +37,13 @@ func (c *Config) Load(p string) error {
 		return err
 	}
 	c.dir = filepath.Dir(p)
-	return c.Restrict()
+	return nil
 }
 
-// Restrict restricts a configuration.
-func (c *Config) Restrict() error {
+// Setup setups the configuration.
+func (c *Config) Setup(sess *session.Session) error {
+	c.sess = sess
+
 	if c.Cluster == "" {
 		c.Cluster = DefaultClusterName
 	}

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -20,7 +20,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/codedeploy"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/aws/aws-sdk-go/service/iam"
-	"github.com/kayac/go-config"
+	goconfig "github.com/kayac/go-config"
 	"github.com/mattn/go-isatty"
 	"github.com/morikuni/aec"
 	"github.com/pkg/errors"
@@ -52,7 +52,7 @@ type App struct {
 	config  *Config
 	Debug   bool
 
-	loader *config.Loader
+	loader *goconfig.Loader
 }
 
 func (d *App) DescribeServicesInput() *ecs.DescribeServicesInput {
@@ -257,15 +257,19 @@ func (d *App) GetLogEvents(ctx context.Context, logGroup string, logStream strin
 }
 
 func NewApp(conf *Config) (*App, error) {
-	loader := config.New()
-	for _, f := range conf.templateFuncs {
-		loader.Funcs(f)
-	}
-
 	sess := session.Must(session.NewSessionWithOptions(session.Options{
 		Config:            aws.Config{Region: aws.String(conf.Region)},
 		SharedConfigState: session.SharedConfigEnable,
 	}))
+	if err := conf.Setup(sess); err != nil {
+		return nil, err
+	}
+
+	loader := goconfig.New()
+	for _, f := range conf.templateFuncs {
+		loader.Funcs(f)
+	}
+
 	d := &App{
 		Service:     conf.Service,
 		Cluster:     conf.Cluster,

--- a/ecspresso_test.go
+++ b/ecspresso_test.go
@@ -16,7 +16,7 @@ func TestLoadTaskDefinition(t *testing.T) {
 			Cluster:            "default",
 			TaskDefinitionPath: path,
 		}
-		if err := c.Restrict(); err != nil {
+		if err := c.Setup(nil); err != nil {
 			t.Error(err)
 		}
 		app, err := ecspresso.NewApp(c)

--- a/plugin.go
+++ b/plugin.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/fujiwara/tfstate-lookup/tfstate"
+	"github.com/kayac/ecspresso/cloudformation"
 )
 
 type ConfigPlugin struct {
@@ -17,6 +18,8 @@ func (p ConfigPlugin) Setup(c *Config) error {
 	switch p.Name {
 	case "tfstate":
 		return setupPluginTFState(p, c)
+	case "cfn_output":
+		return setupPluginCFnOutput(p, c)
 	default:
 		return fmt.Errorf("plugin %s is not available", p.Name)
 	}
@@ -35,5 +38,10 @@ func setupPluginTFState(p ConfigPlugin, c *Config) error {
 		return err
 	}
 	c.templateFuncs = append(c.templateFuncs, funcs)
+	return nil
+}
+
+func setupPluginCFnOutput(p ConfigPlugin, c *Config) error {
+	c.templateFuncs = append(c.templateFuncs, cloudformation.NewFuncs(c.sess))
 	return nil
 }


### PR DESCRIPTION
This PR adds `cfn_output` template function to lookup cloudformation stack's output.

For example,

```yaml
# config.yaml
# ...
service_definition: service-def.json
plugins:
  - name: cfn_output
```

`aws cloudformationcfn describe-stacks --stack-name EcsSampleStack` output.
```json
{
  "Stacks": [
    {
      "StackId": "arn:aws:cloudformation:ap-northeast-1:012345678901:stack/EcsSampleStack/790004d0-42aa-11eb-8fb1-06aa9b7dfc56",
      "StackName": "EcsSampleStack",
      "Outputs": [
        {
          "OutputKey": "Subnet1Output",
          "OutputValue": "subnet-01036767a9c7c3ab8"
        },
        {
          "OutputKey": "SecurityGroupIdOutput",
          "OutputValue": "sg-0aa077022a7a4c54d"
        },
        {
          "OutputKey": "Subnet2Output",
          "OutputValue": "subnet-0890a957951b89645"
        }
      ]
    }
  ]
}
```

service-def.json
```json
{
  "networkConfiguration": {
    "awsvpcConfiguration": {
      "assignPublicIp": "ENABLED",
      "securityGroups": [
        "{{ cfn_output `EcsSampleStack` `SecurityGroupIdOutput` }}"
      ],
      "subnets": [
        "{{ cfn_output `EcsSampleStack` `Subnet1Output` }}",
        "{{ cfn_output `EcsSampleStack` `Subnet2Output` }}"
      ]
    }
  }
}
```

`ecspreso render --service-definition` outputs as below.

```json
{
  "networkConfiguration": {
    "awsvpcConfiguration": {
      "assignPublicIp": "ENABLED",
      "securityGroups": [
        "sg-0aa077022a7a4c54d"
      ],
      "subnets": [
        "subnet-01036767a9c7c3ab8",
        "subnet-0890a957951b89645"
      ]
    }
  }
}
```