### PR TITLE
Fix diff command comparing task definitions.

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -71,12 +71,11 @@ func (d *App) Diff(opt DiffOption) error {
 	}
 
 	// task definition
-	newTd, err := d.
-		LoadTaskDefinition(d.config.TaskDefinitionPath)
+	newTd, err := d.LoadTaskDefinition(d.config.TaskDefinitionPath)
 	if err != nil {
 		return errors.Wrap(err, "failed to load task definition")
 	}
-	remoteTd, err := d.DescribeTaskDefinition(ctx, *newTd.Family)
+	remoteTd, err := d.DescribeTaskDefinition(ctx, *remoteSv.TaskDefinition)
 	if err != nil {
 		return errors.Wrap(err, "failed to describe task definition")
 	}

--- a/verify.go
+++ b/verify.go
@@ -200,6 +200,15 @@ func (d *App) verifyServiceDefinition(ctx context.Context) error {
 		return err
 	}
 
+	// networkMode
+	if aws.StringValue(td.NetworkMode) == "awsvpc" {
+		if sv.NetworkConfiguration == nil || sv.NetworkConfiguration.AwsvpcConfiguration == nil {
+			return errors.New(
+				`networkConfiguration.awsvpcConfiguration required for the taskDefinition networkMode=awsvpc`,
+			)
+		}
+	}
+
 	// LB
 	for i, lb := range sv.LoadBalancers {
 		name := fmt.Sprintf("LoadBalancer[%d]", i)


### PR DESCRIPTION
`diff` command compares local task definition and remote task definition.
Currently comparing with the latest task definition, but we should compare with that used in the ECS service.