### PR TITLE
config.Restrict required at any time.

### DIFF
--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -158,6 +158,10 @@ func _main() int {
 		c.TaskDefinitionPath = *initOption.TaskDefinitionPath
 		c.ServiceDefinitionPath = *initOption.ServiceDefinitionPath
 		initOption.ConfigFilePath = conf
+		if err := c.Restrict(); err != nil {
+			log.Println("Could not init config", err)
+			return 1
+		}
 	} else {
 		if err := c.Load(*conf); err != nil {
 			log.Println("Could not load config file", *conf, err)


### PR DESCRIPTION
v1.3.0 always crashed on `init` command.