### PR TITLE
[bugfix] support rollback for DAEMON

### DIFF
--- a/rollback.go
+++ b/rollback.go
@@ -32,11 +32,15 @@ func (d *App) Rollback(opt RollbackOption) error {
 		return nil
 	}
 
+	count := sv.DesiredCount
+	if sv.SchedulingStrategy != nil && *sv.SchedulingStrategy == "DAEMON" {
+		count = nil
+	}
 	f := false // Set ForceNewDeployment and UpdateService to false
 	if err := d.UpdateServiceTasks(
 		ctx,
 		targetArn,
-		sv.DesiredCount,
+		count,
 		DeployOption{ForceNewDeployment: &f, UpdateService: &f},
 	); err != nil {
 		return errors.Wrap(err, "failed to update service")


### PR DESCRIPTION
When I tried to rollback the DAEMON service, I got the following error: 

```console
2021/01/22 18:19:06 mysvc/api Starting rollback
Service: mysvc
Cluster: api
TaskDefinition: mysvc:6
Deployments:
   PRIMARY mysvc:6 desired:15 pending:0 running:0
Events:
2021/01/22 18:19:08 mysvc/api Rollbacking to mysvc:5
2021/01/22 18:19:08 mysvc/api Updating service tasks...
2021/01/22 18:19:08 rollback FAILED. failed to update service: InvalidParameterException: The daemon scheduling strategy does not support a desired count for services. Remove the desired count value and try again
```

It seems that DesiredCount should not be specified with DAEMON, so I fixed it.