### PR TITLE
Feature Request:  add `--no-get-secrets` option to `verify`

### DIFF
--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -133,7 +133,8 @@ func _main() int {
 
 	verify := kingpin.Command("verify", "verify resources in configurations")
 	verifyOption := ecspresso.VerifyOption{
-		PutLogs: verify.Flag("put-logs", "put verification logs to CloudWatch Logs").Default("true").Bool(),
+		GetSecrets: verify.Flag("get-secrets", "get secrets from ParameterStore or SecretsManager").Default("true").Bool(),
+		PutLogs:    verify.Flag("put-logs", "put verification logs to CloudWatch Logs").Default("true").Bool(),
 	}
 
 	render := kingpin.Command("render", "render config, service definition or task definition file to stdout")

--- a/verify.go
+++ b/verify.go
@@ -47,6 +47,10 @@ func newVerifier(sess *session.Session, opt *VerifyOption) *verifier {
 }
 
 func (v *verifier) existsSecretValue(ctx context.Context, from string) error {
+	if !aws.BoolValue(v.opt.GetSecrets) {
+		return verifySkipErr(fmt.Sprintf("get a secret value for %s", from))
+	}
+
 	// secrets manager
 	if strings.HasPrefix(from, "arn:aws:secretsmanager:") {
 		// https://docs.aws.amazon.com/ja_jp/AmazonECS/latest/developerguide/specifying-sensitive-data-secrets.html
@@ -102,7 +106,8 @@ func (d *App) newAssumedVerifier(sess *session.Session, executionRole string, op
 
 // VerifyOption represents options for Verify()
 type VerifyOption struct {
-	PutLogs *bool
+	GetSecrets *bool
+	PutLogs    *bool
 }
 
 type verifyResourceFunc func(context.Context) error


### PR DESCRIPTION
`ecspresso verify` checks if specified secrets exist.
Therefore, when run `ecspresso verify`, runner need permission to get the secret value.

The privillege to get secret values is an important and sensitive, so I don't want to grant it in some of my use cases.

My solution is that a new option `--no-get-secrets` is added to` ecspresso verify`.
With this option, sensitive privileges are no longer required.

example:
```
2021/02/05 16:22:01 my-service/my-cluster Starting verify
  TaskDefinition
    ExecutionRole[arn:aws:iam::1234567890:role/my-ecs-taskexecution]
    --> [OK]
    TaskRole[arn:aws:iam::1234567890:role/my-ecs-task]
    --> [OK]
    ContainerDefinition[Web]
      Image[1234567890.dkr.ecr.ap-northeast-1.amazonaws.com/myimage:latest]
      --> [OK]
      Secret MY_SECRET[arn:aws:secretsmanager:ap-northeast-1:1234567890:secret:my-secret-a12345]
      --> Secret MY_SECRET[arn:aws:secretsmanager:ap-northeast-1:1234567890:secret:my-secret-a12345] [SKIP] get a secret value for arn:aws:secretsmanager:ap-northeast-1:1234567890:secret:my-secret-a12345
  --> [OK]
  ServiceDefinition
    LoadBalancer[0]
    --> [OK]
  --> [OK]
  Cluster
  --> [OK]
2021/02/05 16:22:03 my-service/my-cluster Verify OK!
```