### PR TITLE
remove registerd(By|At) in initialized task definition.

### DIFF
--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -117,7 +117,7 @@ func _main() int {
 
 	init := kingpin.Command("init", "create service/task definition files by existing ECS service")
 	initOption := ecspresso.InitOption{
-		Region:                init.Flag("region", "AWS region name").Required().String(),
+		Region:                init.Flag("region", "AWS region name").Default(os.Getenv("AWS_REGION")).String(),
 		Cluster:               init.Flag("cluster", "cluster name").Default("default").String(),
 		Service:               init.Flag("service", "service name").Required().String(),
 		TaskDefinitionPath:    init.Flag("task-definition-path", "output task definition file path").Default("ecs-task-def.json").String(),

--- a/init.go
+++ b/init.go
@@ -91,6 +91,8 @@ func treatmentTaskDefinition(td *ecs.TaskDefinition) *ecs.TaskDefinition {
 	td.Status = nil
 	td.TaskDefinitionArn = nil
 	td.Compatibilities = nil
+	td.RegisteredAt = nil
+	td.RegisteredBy = nil
 	return td
 }
 


### PR DESCRIPTION
These elements added by aws-sdk-go v1.36.29 but not required for ecspresso.