### PR TITLE
add --force-overwrite flag to init command

### DIFF
--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -122,6 +122,7 @@ func _main() int {
 		Service:               init.Flag("service", "service name").Required().String(),
 		TaskDefinitionPath:    init.Flag("task-definition-path", "output task definition file path").Default("ecs-task-def.json").String(),
 		ServiceDefinitionPath: init.Flag("service-definition-path", "output service definition file path").Default("ecs-service-def.json").String(),
+		ForceOverwrite:        init.Flag("force-overwrite", "force overwrite files").Bool(),
 	}
 
 	_ = kingpin.Command("diff", "display diff for task definition compared with latest one on ECS")

--- a/init.go
+++ b/init.go
@@ -38,7 +38,7 @@ func (d *App) Init(opt InitOption) error {
 		return errors.Wrap(err, "unable to marshal service definition to JSON")
 	} else {
 		d.Log("save service definition to", config.ServiceDefinitionPath)
-		if err := d.saveFile(config.ServiceDefinitionPath, b, CreateFileMode); err != nil {
+		if err := d.saveFile(config.ServiceDefinitionPath, b, CreateFileMode, *opt.ForceOverwrite); err != nil {
 			return errors.Wrap(err, "failed to write file")
 		}
 	}
@@ -49,7 +49,7 @@ func (d *App) Init(opt InitOption) error {
 		return errors.Wrap(err, "unable to marshal task definition to JSON")
 	} else {
 		d.Log("save task definition to", config.TaskDefinitionPath)
-		if err := d.saveFile(config.TaskDefinitionPath, b, CreateFileMode); err != nil {
+		if err := d.saveFile(config.TaskDefinitionPath, b, CreateFileMode, *opt.ForceOverwrite); err != nil {
 			return errors.Wrap(err, "failed to write file")
 		}
 	}
@@ -59,7 +59,7 @@ func (d *App) Init(opt InitOption) error {
 		return errors.Wrap(err, "unable to marshal config to YAML")
 	} else {
 		d.Log("save config to", *opt.ConfigFilePath)
-		if err := d.saveFile(*opt.ConfigFilePath, b, CreateFileMode); err != nil {
+		if err := d.saveFile(*opt.ConfigFilePath, b, CreateFileMode, *opt.ForceOverwrite); err != nil {
 			return errors.Wrap(err, "failed to write file")
 		}
 	}
@@ -96,8 +96,8 @@ func treatmentTaskDefinition(td *ecs.TaskDefinition) *ecs.TaskDefinition {
 	return td
 }
 
-func (d *App) saveFile(path string, b []byte, mode os.FileMode) error {
-	if _, err := os.Stat(path); err == nil {
+func (d *App) saveFile(path string, b []byte, mode os.FileMode, force bool) error {
+	if _, err := os.Stat(path); err == nil && !force {
 		ok := prompter.YN(fmt.Sprintf("Overwrite existing file %s?", path), false)
 		if !ok {
 			d.Log("skip", path)

--- a/options.go
+++ b/options.go
@@ -156,6 +156,7 @@ type InitOption struct {
 	TaskDefinitionPath    *string
 	ServiceDefinitionPath *string
 	ConfigFilePath        *string
+	ForceOverwrite        *bool
 }
 
 type DiffOption struct {


### PR DESCRIPTION
refs #234

`init --force-overwrite` overwrites files without confirmation even if these already exist.