### PR TITLE
Go1.16

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,6 @@
 version: 2
 updates:
-- package-ecosystem: gomod
-  directory: "/"
-  schedule:
-    interval: weekly
-    time: "20:00"
-  open-pull-requests-limit: 10
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: monthly

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,8 +5,8 @@ jobs:
     strategy:
       matrix:
         go:
-          - 1.14
           - 1.15
+          - 1.16
     name: Build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.15
+          go-version: 1.16
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1

--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "monthly"


### PR DESCRIPTION
Update to Go 1.16.

This PR doesn't fix for [deprecation of io/ioutil](https://tip.golang.org/doc/go1.16#ioutil) because Go 1.15 is supported until Go 1.17 released.