### PR TITLE
Feature Request: Support add Tags to TaskDefinition

### DIFF
--- a/deploy.go
+++ b/deploy.go
@@ -60,11 +60,17 @@ func (d *App) Deploy(opt DeployOption) error {
 		if err != nil {
 			return errors.Wrap(err, "failed to load task definition")
 		}
+		tdTags, err := d.LoadTaskDefinitionTags(d.config.TaskDefinitionPath)
+		if err != nil {
+			return errors.Wrap(err, "failed to load task definition tags")
+		}
+
 		if *opt.DryRun {
 			d.Log("task definition:")
 			d.LogJSON(td)
+			d.LogJSON(tdTags)
 		} else {
-			newTd, err := d.RegisterTaskDefinition(ctx, td)
+			newTd, err := d.RegisterTaskDefinition(ctx, td, tdTags)
 			if err != nil {
 				return errors.Wrap(err, "failed to register task definition")
 			}

--- a/deploy.go
+++ b/deploy.go
@@ -68,6 +68,7 @@ func (d *App) Deploy(opt DeployOption) error {
 		if *opt.DryRun {
 			d.Log("task definition:")
 			d.LogJSON(td)
+			d.Log("task definition tags:")
 			d.LogJSON(tdTags)
 		} else {
 			newTd, err := d.RegisterTaskDefinition(ctx, td, tdTags)

--- a/diff.go
+++ b/diff.go
@@ -34,6 +34,8 @@ func diffServices(local, remote *ecs.Service) (string, error) {
 func diffTaskDefs(local *ecs.TaskDefinition, localTags []*ecs.Tag, remote *ecs.TaskDefinition, remoteTags []*ecs.Tag) (string, error) {
 	sortTaskDefinitionForDiff(local)
 	sortTaskDefinitionForDiff(remote)
+	sortTaskDefinitionTagsForDiff(localTags)
+	sortTaskDefinitionTagsForDiff(remoteTags)
 
 	newTdBytes, err := MarshalJSON(tdToRegisterTaskDefinitionInput(local, localTags))
 	if err != nil {
@@ -254,6 +256,12 @@ func sortTaskDefinitionForDiff(td *ecs.TaskDefinition) {
 			reflect.TypeOf(*td.ProxyConfiguration), reflect.Indirect(reflect.ValueOf(td.ProxyConfiguration)),
 			"Properties",
 		)
+	}
+}
+
+func sortTaskDefinitionTagsForDiff(tdTags []*ecs.Tag) {
+	if tdTags != nil && len(tdTags) > 0 {
+		sort.SliceStable(tdTags, func(i, j int) bool { return *tdTags[i].Key < *tdTags[j].Key })
 	}
 }
 

--- a/diff.go
+++ b/diff.go
@@ -32,15 +32,16 @@ func diffServices(local, remote *ecs.Service) (string, error) {
 }
 
 func diffTaskDefs(local, remote *ecs.TaskDefinition) (string, error) {
+	var tdTags []*ecs.Tag
 	sortTaskDefinitionForDiff(local)
 	sortTaskDefinitionForDiff(remote)
 
-	newTdBytes, err := MarshalJSON(tdToRegisterTaskDefinitionInput(local))
+	newTdBytes, err := MarshalJSON(tdToRegisterTaskDefinitionInput(local, tdTags))
 	if err != nil {
 		return "", errors.Wrap(err, "failed to marshal new task definition")
 	}
 
-	remoteTdBytes, err := MarshalJSON(tdToRegisterTaskDefinitionInput(remote))
+	remoteTdBytes, err := MarshalJSON(tdToRegisterTaskDefinitionInput(remote, tdTags))
 	if err != nil {
 		return "", errors.Wrap(err, "failed to marshal remote task definition")
 	}
@@ -105,7 +106,7 @@ func coloredDiff(src string) string {
 	return b.String()
 }
 
-func tdToRegisterTaskDefinitionInput(td *ecs.TaskDefinition) *ecs.RegisterTaskDefinitionInput {
+func tdToRegisterTaskDefinitionInput(td *ecs.TaskDefinition, tdTags []*ecs.Tag) *ecs.RegisterTaskDefinitionInput {
 	return &ecs.RegisterTaskDefinitionInput{
 		ContainerDefinitions:    td.ContainerDefinitions,
 		Cpu:                     td.Cpu,
@@ -118,6 +119,7 @@ func tdToRegisterTaskDefinitionInput(td *ecs.TaskDefinition) *ecs.RegisterTaskDe
 		TaskRoleArn:             td.TaskRoleArn,
 		ProxyConfiguration:      td.ProxyConfiguration,
 		Volumes:                 td.Volumes,
+		Tags:                    tdTags,
 	}
 }
 

--- a/diff_test.go
+++ b/diff_test.go
@@ -127,6 +127,36 @@ func TestTaskDefinitionDiffer(t *testing.T) {
 	}
 }
 
+var testTaskDefinitionTags1 = []*ecs.Tag{
+	{
+		Key:   aws.String("AppVersion"),
+		Value: aws.String("v1"),
+	}, {
+		Key:   aws.String("Environment"),
+		Value: aws.String("Dev"),
+	},
+}
+
+var testTaskDefinitionTags2 = []*ecs.Tag{
+	{
+		Key:   aws.String("Environment"),
+		Value: aws.String("Dev"),
+	}, {
+		Key:   aws.String("AppVersion"),
+		Value: aws.String("v1"),
+	},
+}
+
+func TestTaskDefinitionTaagsDiffer(t *testing.T) {
+	ecspresso.SortTaskDefinitionTagsForDiff(testTaskDefinitionTags1)
+	ecspresso.SortTaskDefinitionTagsForDiff(testTaskDefinitionTags2)
+	if ecspresso.MarshalJSONString(testTaskDefinitionTags1) != ecspresso.MarshalJSONString(testTaskDefinitionTags2) {
+		t.Error("failed to SortTaskDefinitionTagsForDiff")
+		t.Log(ecspresso.MarshalJSONString(testTaskDefinitionTags1))
+		t.Log(ecspresso.MarshalJSONString(testTaskDefinitionTags2))
+	}
+}
+
 var testServiceDefinition1 = &ecs.Service{
 	LaunchType: aws.String("FARGATE"),
 	NetworkConfiguration: &ecs.NetworkConfiguration{

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -581,6 +581,23 @@ func (d *App) LoadTaskDefinition(path string) (*ecs.TaskDefinition, error) {
 	return &td, nil
 }
 
+func (d *App) LoadTaskDefinitionTags(path string) ([]*ecs.Tag, error) {
+	c := struct {
+		Tags []*ecs.Tag
+	}{}
+	if err := d.loader.LoadWithEnvJSON(&c, path); err != nil {
+		return nil, err
+	}
+	if c.Tags != nil {
+		return c.Tags, nil
+	}
+	var tdTags []*ecs.Tag
+	if err := d.loader.LoadWithEnvJSON(&tdTags, path); err != nil {
+		return nil, err
+	}
+	return tdTags, nil
+}
+
 func (d *App) LoadServiceDefinition(path string) (*ecs.Service, error) {
 	if path == "" {
 		return nil, errors.New("service_definition is not defined")

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -226,14 +226,14 @@ func (d *App) DescribeTaskStatus(ctx context.Context, task *ecs.Task, watchConta
 	return nil
 }
 
-func (d *App) DescribeTaskDefinition(ctx context.Context, tdArn string) (*ecs.TaskDefinition, error) {
+func (d *App) DescribeTaskDefinition(ctx context.Context, tdArn string) (*ecs.TaskDefinition, []*ecs.Tag, error) {
 	out, err := d.ecs.DescribeTaskDefinitionWithContext(ctx, &ecs.DescribeTaskDefinitionInput{
 		TaskDefinition: &tdArn,
 	})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return out.TaskDefinition, nil
+	return out.TaskDefinition, out.Tags, nil
 }
 
 func (d *App) GetLogEvents(ctx context.Context, logGroup string, logStream string, startedAt time.Time) (int, error) {

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -594,14 +594,7 @@ func (d *App) LoadTaskDefinitionTags(path string) ([]*ecs.Tag, error) {
 	if err := d.loader.LoadWithEnvJSON(&c, path); err != nil {
 		return nil, err
 	}
-	if c.Tags != nil {
-		return c.Tags, nil
-	}
-	var tdTags []*ecs.Tag
-	if err := d.loader.LoadWithEnvJSON(&tdTags, path); err != nil {
-		return nil, err
-	}
-	return tdTags, nil
+	return c.Tags, nil
 }
 
 func (d *App) LoadServiceDefinition(path string) (*ecs.Service, error) {

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -229,6 +229,7 @@ func (d *App) DescribeTaskStatus(ctx context.Context, task *ecs.Task, watchConta
 func (d *App) DescribeTaskDefinition(ctx context.Context, tdArn string) (*ecs.TaskDefinition, []*ecs.Tag, error) {
 	out, err := d.ecs.DescribeTaskDefinitionWithContext(ctx, &ecs.DescribeTaskDefinitionInput{
 		TaskDefinition: &tdArn,
+		Include:        []*string{aws.String("TAGS")},
 	})
 	if err != nil {
 		return nil, nil, err

--- a/ecspresso_test.go
+++ b/ecspresso_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestLoadTaskDefinition(t *testing.T) {
-	for _, path := range []string{"tests/td-plain.json"} {
+	for _, path := range []string{"tests/td.json", "tests/td-plain.json"} {
 		c := &ecspresso.Config{
 			Region:             "ap-northeast-1",
 			Timeout:            600 * time.Second,
@@ -31,7 +31,7 @@ func TestLoadTaskDefinition(t *testing.T) {
 }
 
 func TestLoadTaskDefinitionTags(t *testing.T) {
-	for _, path := range []string{"tests/td.json", "tests/td-plain.json"} {
+	for _, path := range []string{"tests/td-plain.json"} {
 		c := &ecspresso.Config{
 			Region:             "ap-northeast-1",
 			Timeout:            600 * time.Second,

--- a/ecspresso_test.go
+++ b/ecspresso_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestLoadTaskDefinition(t *testing.T) {
-	for _, path := range []string{"tests/td.json", "tests/td-plain.json"} {
+	for _, path := range []string{"tests/td.json", "tests/td-plain.json", "tests/td-in-tags.json", "tests/td-plain-in-tags.json"} {
 		c := &ecspresso.Config{
 			Region:             "ap-northeast-1",
 			Timeout:            600 * time.Second,
@@ -46,8 +46,29 @@ func TestLoadTaskDefinitionTags(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		_, err = app.LoadTaskDefinitionTags(path)
+		tdTags, err := app.LoadTaskDefinitionTags(path)
+		if err != nil || tdTags != nil {
+			t.Errorf("%s load failed: %s", path, err)
+		}
+	}
+
+	for _, path := range []string{"tests/td-in-tags.json", "tests/td-plain-in-tags.json"} {
+		c := &ecspresso.Config{
+			Region:             "ap-northeast-1",
+			Timeout:            600 * time.Second,
+			Service:            "test",
+			Cluster:            "default",
+			TaskDefinitionPath: path,
+		}
+		if err := c.Restrict(); err != nil {
+			t.Error(err)
+		}
+		app, err := ecspresso.NewApp(c)
 		if err != nil {
+			t.Error(err)
+		}
+		tdTags, err := app.LoadTaskDefinitionTags(path)
+		if err != nil || tdTags == nil {
 			t.Errorf("%s load failed: %s", path, err)
 		}
 	}

--- a/ecspresso_test.go
+++ b/ecspresso_test.go
@@ -31,7 +31,7 @@ func TestLoadTaskDefinition(t *testing.T) {
 }
 
 func TestLoadTaskDefinitionTags(t *testing.T) {
-	for _, path := range []string{"tests/td-plain.json"} {
+	for _, path := range []string{"tests/td.json", "tests/td-plain.json"} {
 		c := &ecspresso.Config{
 			Region:             "ap-northeast-1",
 			Timeout:            600 * time.Second,
@@ -46,8 +46,8 @@ func TestLoadTaskDefinitionTags(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		tdTags, err := app.LoadTaskDefinitionTags(path)
-		if err != nil || tdTags == nil {
+		_, err = app.LoadTaskDefinitionTags(path)
+		if err != nil {
 			t.Errorf("%s load failed: %s", path, err)
 		}
 	}

--- a/ecspresso_test.go
+++ b/ecspresso_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestLoadTaskDefinition(t *testing.T) {
-	for _, path := range []string{"tests/td.json", "tests/td-plain.json"} {
+	for _, path := range []string{"tests/td-plain.json"} {
 		c := &ecspresso.Config{
 			Region:             "ap-northeast-1",
 			Timeout:            600 * time.Second,
@@ -25,6 +25,29 @@ func TestLoadTaskDefinition(t *testing.T) {
 		}
 		td, err := app.LoadTaskDefinition(path)
 		if err != nil || td == nil {
+			t.Errorf("%s load failed: %s", path, err)
+		}
+	}
+}
+
+func TestLoadTaskDefinitionTags(t *testing.T) {
+	for _, path := range []string{"tests/td.json", "tests/td-plain.json"} {
+		c := &ecspresso.Config{
+			Region:             "ap-northeast-1",
+			Timeout:            600 * time.Second,
+			Service:            "test",
+			Cluster:            "default",
+			TaskDefinitionPath: path,
+		}
+		if err := c.Restrict(); err != nil {
+			t.Error(err)
+		}
+		app, err := ecspresso.NewApp(c)
+		if err != nil {
+			t.Error(err)
+		}
+		tdTags, err := app.LoadTaskDefinitionTags(path)
+		if err != nil || tdTags == nil {
 			t.Errorf("%s load failed: %s", path, err)
 		}
 	}

--- a/export_test.go
+++ b/export_test.go
@@ -1,11 +1,12 @@
 package ecspresso
 
 var (
-	SortTaskDefinitionForDiff    = sortTaskDefinitionForDiff
-	SortServiceDefinitionForDiff = sortServiceDefinitionForDiff
-	EqualString                  = equalString
-	ToNumberCPU                  = toNumberCPU
-	ToNumberMemory               = toNumberMemory
-	CalcDesiredCount             = calcDesiredCount
-	ParseTags                    = parseTags
+	SortTaskDefinitionForDiff     = sortTaskDefinitionForDiff
+	SortTaskDefinitionTagsForDiff = sortTaskDefinitionTagsForDiff
+	SortServiceDefinitionForDiff  = sortServiceDefinitionForDiff
+	EqualString                   = equalString
+	ToNumberCPU                   = toNumberCPU
+	ToNumberMemory                = toNumberMemory
+	CalcDesiredCount              = calcDesiredCount
+	ParseTags                     = parseTags
 )

--- a/init.go
+++ b/init.go
@@ -27,7 +27,7 @@ func (d *App) Init(opt InitOption) error {
 	}
 
 	sv := out.Services[0]
-	td, tdTags, err := d.DescribeTaskDefinition(ctx, *sv.TaskDefinition)
+	td, _, err := d.DescribeTaskDefinition(ctx, *sv.TaskDefinition)
 	if err != nil {
 		return errors.Wrap(err, "failed to describe task definition")
 	}
@@ -45,7 +45,6 @@ func (d *App) Init(opt InitOption) error {
 
 	// task-def
 	treatmentTaskDefinition(td)
-	treatmentTaskDefinitionTags(tdTags)
 	if b, err := MarshalJSON(td); err != nil {
 		return errors.Wrap(err, "unable to marshal task definition to JSON")
 	} else {
@@ -95,12 +94,6 @@ func treatmentTaskDefinition(td *ecs.TaskDefinition) *ecs.TaskDefinition {
 	td.RegisteredAt = nil
 	td.RegisteredBy = nil
 	return td
-}
-
-func treatmentTaskDefinitionTags(tdTags []*ecs.Tag) []*ecs.Tag {
-	var tags []*ecs.Tag
-	tdTags = tags
-	return tdTags
 }
 
 func (d *App) saveFile(path string, b []byte, mode os.FileMode, force bool) error {

--- a/init.go
+++ b/init.go
@@ -27,7 +27,7 @@ func (d *App) Init(opt InitOption) error {
 	}
 
 	sv := out.Services[0]
-	td, err := d.DescribeTaskDefinition(ctx, *sv.TaskDefinition)
+	td, tdTags, err := d.DescribeTaskDefinition(ctx, *sv.TaskDefinition)
 	if err != nil {
 		return errors.Wrap(err, "failed to describe task definition")
 	}
@@ -45,6 +45,7 @@ func (d *App) Init(opt InitOption) error {
 
 	// task-def
 	treatmentTaskDefinition(td)
+	treatmentTaskDefinitionTags(tdTags)
 	if b, err := MarshalJSON(td); err != nil {
 		return errors.Wrap(err, "unable to marshal task definition to JSON")
 	} else {
@@ -94,6 +95,12 @@ func treatmentTaskDefinition(td *ecs.TaskDefinition) *ecs.TaskDefinition {
 	td.RegisteredAt = nil
 	td.RegisteredBy = nil
 	return td
+}
+
+func treatmentTaskDefinitionTags(tdTags []*ecs.Tag) []*ecs.Tag {
+	var tags []*ecs.Tag
+	tdTags = tags
+	return tdTags
 }
 
 func (d *App) saveFile(path string, b []byte, mode os.FileMode, force bool) error {

--- a/run.go
+++ b/run.go
@@ -47,7 +47,7 @@ func (d *App) Run(opt RunOption) error {
 			return errors.Wrap(err, "failed to load latest task definition")
 		}
 
-		td, err := d.DescribeTaskDefinition(ctx, tdArn)
+		td, tdTags, err := d.DescribeTaskDefinition(ctx, tdArn)
 		if err != nil {
 			return errors.Wrap(err, "failed to describe task definition")
 		}
@@ -55,9 +55,11 @@ func (d *App) Run(opt RunOption) error {
 		if *opt.DryRun {
 			d.Log("task definition:")
 			d.LogJSON(td)
+			d.Log("task definition tags:")
+			d.LogJSON(tdTags)
 		}
 	} else if *opt.SkipTaskDefinition {
-		td, err := d.DescribeTaskDefinition(ctx, *sv.TaskDefinition)
+		td, tdTags, err := d.DescribeTaskDefinition(ctx, *sv.TaskDefinition)
 		if err != nil {
 			return errors.Wrap(err, "failed to describe task definition")
 		}
@@ -66,6 +68,8 @@ func (d *App) Run(opt RunOption) error {
 		if *opt.DryRun {
 			d.Log("task definition:")
 			d.LogJSON(td)
+			d.Log("task definition tags:")
+			d.LogJSON(tdTags)
 		}
 	} else {
 		td, err := d.LoadTaskDefinition(d.config.TaskDefinitionPath)

--- a/run.go
+++ b/run.go
@@ -72,6 +72,10 @@ func (d *App) Run(opt RunOption) error {
 		if err != nil {
 			return errors.Wrap(err, "failed to load task definition")
 		}
+		tdTags, err := d.LoadTaskDefinitionTags(d.config.TaskDefinitionPath)
+		if err != nil {
+			return errors.Wrap(err, "failed to load task definition tags")
+		}
 
 		if len(*opt.TaskDefinition) > 0 {
 			d.Log("Loading task definition")
@@ -80,6 +84,12 @@ func (d *App) Run(opt RunOption) error {
 				return errors.Wrap(err, "failed to load task definition")
 			}
 			td = runTd
+
+			runTdTags, err := d.LoadTaskDefinitionTags(*opt.TaskDefinition)
+			if err != nil {
+				return errors.Wrap(err, "failed to load task definition tags")
+			}
+			tdTags = runTdTags
 		}
 		watchContainer = containerOf(td, opt.WatchContainer)
 
@@ -88,7 +98,7 @@ func (d *App) Run(opt RunOption) error {
 			d.Log("task definition:")
 			d.LogJSON(td)
 		} else {
-			newTd, err = d.RegisterTaskDefinition(ctx, td)
+			newTd, err = d.RegisterTaskDefinition(ctx, td, tdTags)
 			if err != nil {
 				return errors.Wrap(err, "failed to register task definition")
 			}

--- a/tests/td-in-tags.json
+++ b/tests/td-in-tags.json
@@ -1,0 +1,99 @@
+{
+  "taskDefinition": {
+    "status": "ACTIVE",
+    "networkMode": "awsvpc",
+    "family": "katsubushi",
+    "placementConstraints": [],
+    "requiresCompatibilities": [
+      "FARGATE"
+    ],
+    "volumes": [],
+    "taskRoleArn": "arn:aws:iam::999999999999:role/ecsTaskRole",
+    "executionRoleArn": "arn:aws:iam::999999999999:role/ecsTaskRole",
+    "containerDefinitions": [
+      {
+        "environment": [
+          {
+            "name": "worker_id",
+            "value": "3"
+          }
+        ],
+        "name": "katsubushi",
+        "mountPoints": [],
+        "portMappings": [
+          {
+            "protocol": "tcp",
+            "containerPort": 11212,
+            "hostPort": 11212
+          }
+        ],
+        "logConfiguration": {
+          "logDriver": "awslogs",
+          "options": {
+            "awslogs-group": "fargate",
+            "awslogs-region": "us-east-1",
+            "awslogs-stream-prefix": "katsubushi"
+          }
+        },
+        "image": "katsubushi/katsubushi:{{ env `TAG` `latest` }}",
+        "dockerLabels": {
+          "name": "katsubushi"
+        },
+        "cpu": 256,
+        "ulimits": [
+          {
+            "softLimit": 100000,
+            "name": "nofile",
+            "hardLimit": 100000
+          }
+        ],
+        "memory": 16,
+        "essential": true,
+        "volumesFrom": []
+      }
+    ],
+    "revision": 1,
+    "cpu": "1024",
+    "memory": "2048",
+    "proxyConfiguration": {
+      "type": "APPMESH",
+      "containerName": "envoy",
+      "properties": [
+        {
+          "name": "IgnoredUID",
+          "value": "1337"
+        },
+        {
+          "name": "IgnoredGID",
+          "value": ""
+        },
+        {
+          "name": "AppPorts",
+          "value": "26571"
+        },
+        {
+          "name": "ProxyIngressPort",
+          "value": "15000"
+        },
+        {
+          "name": "ProxyEgressPort",
+          "value": "15001"
+        },
+        {
+          "name": "EgressIgnoredIPs",
+          "value": "169.254.170.2,169.254.169.254"
+        },
+        {
+          "name": "EgressIgnoredPorts",
+          "value": ""
+        }
+      ]
+    }
+  },
+  "tags": [
+    {
+      "key": "TagKey",
+      "value": "TagValue"
+    }
+  ]
+}

--- a/tests/td-plain-in-tags.json
+++ b/tests/td-plain-in-tags.json
@@ -87,5 +87,11 @@
         "value": ""
       }
     ]
-  }
+  },
+  "tags": [
+    {
+      "key": "TagKey",
+      "value": "TagValue"
+    }
+  ]
 }

--- a/tests/td-plain.json
+++ b/tests/td-plain.json
@@ -87,5 +87,11 @@
         "value": ""
       }
     ]
-  }
+  },
+  "Tags": [
+    {
+      "key": "TagKey",
+      "value": "TagValue"
+    }
+  ]
 }


### PR DESCRIPTION
ref: https://github.com/kayac/ecspresso/issues/246

ecspresso can support to TaskDefinition tags.
There is no breaking change from Conventional version.
So as usual can ecspresso deploy.

example, show diff tags
```
$ go run cmd/ecspresso/main.go diff --config xxx --envfile xxx
--- arn:aws:ecs:xxxx
+++ ./ecs-task-def.json

...

   "cpu": "512",
   "executionRoleArn": "arn:aws:xxxxxx",
   "family": "XXXX",
   "memory": "1024",
   "networkMode": "awsvpc",
   "placementConstraints": [],
   "requiresCompatibilities": [
     "FARGATE"
   ],
   "tags": [
     {
       "key": "AppVersion",
       "value": "dev-xxxx"
     },
     {
       "key": "ReleaseOwner",
-      "value": "hirofumi.narita"
+      "value": "hirofumi.narita2"
     }
   ]
 }
```