### PR TITLE
Feature Request: Rollback by CodeDeploy

### DIFF
--- a/ecspresso.go
+++ b/ecspresso.go
@@ -721,6 +721,9 @@ func (d *App) RollbackByCodeDeploy(ctx context.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to list deployments")
 	}
+	if len(ld.Deployments) == 0 {
+		return errors.New("no deployments are found")
+	}
 
 	dpID := ld.Deployments[0] // latest deployment id
 	_, err = d.codedeploy.StopDeploymentWithContext(ctx, &codedeploy.StopDeploymentInput{

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -707,3 +707,31 @@ func (d *App) WaitForCodeDeploy(ctx context.Context, sv *ecs.Service) error {
 		&codedeploy.GetDeploymentInput{DeploymentId: dpID},
 	)
 }
+
+func (d *App) RollbackByCodeDeploy(ctx context.Context) error {
+	dp, err := d.findDeploymentInfo()
+	if err != nil {
+		return err
+	}
+
+	ld, err := d.codedeploy.ListDeploymentsWithContext(ctx, &codedeploy.ListDeploymentsInput{
+		ApplicationName:     dp.ApplicationName,
+		DeploymentGroupName: dp.DeploymentGroupName,
+	})
+	if err != nil {
+		return errors.Wrap(err, "failed to list deployments")
+	}
+
+	dpID := ld.Deployments[0] // latest deployment id
+	_, err = d.codedeploy.StopDeploymentWithContext(ctx, &codedeploy.StopDeploymentInput{
+		DeploymentId:        dpID,
+		AutoRollbackEnabled: aws.Bool(true),
+	})
+	if err != nil {
+		return errors.Wrap(err, "failed to rollback deployment")
+	}
+
+	d.Log(fmt.Sprintf("Deployment %s is rollbacked on CodeDeploy:", *dpID))
+
+	return nil
+}

--- a/rollback.go
+++ b/rollback.go
@@ -19,7 +19,7 @@ func (d *App) Rollback(opt RollbackOption) error {
 	}
 
 	if isCodeDeploy(sv.DeploymentController) {
-		return errors.New("could not rollback service using deployment controller CODE_DEPLOY")
+		return d.RollbackByCodeDeploy(ctx)
 	}
 
 	currentArn := *sv.TaskDefinition


### PR DESCRIPTION
This command will stop the deploy of the latest deployment id and perform an [automatic rollback](https://docs.aws.amazon.com/codedeploy/latest/userguide/deployments-rollback-and-redeploy.html#deployments-rollback-and-redeploy-automatic-rollbacks).

With this change, deploy and rollback by CodeDeploy can be completed with ecspresso alone.


demo:
```
~/c/s/g/c/ecspresso ❯❯❯ ./cmd/ecspresso/ecspresso --config config.yaml rollback
2021/03/18 10:49:21 example-service/example-cluster Starting rollback
Service: example-service
Cluster: example-cluster
TaskDefinition: example-task-def:15
TaskSets:
   PRIMARY example-task-def:15 desired:1 pending:0 running:1
    ACTIVE example-task-def:18 desired:1 pending:1 running:0
Events:
2021/03/18 10:49:22 example-service/example-cluster Deployment d-XXXXXXXXX is rollbacked on CodeDeploy: