### PR TITLE
Don't require `elasticloadbalancing:DescribeTargetGroups` in task execution role to `verify`

### DIFF
--- a/ecspresso.go
+++ b/ecspresso.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go/service/codedeploy"
 	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/aws/aws-sdk-go/service/iam"
 	gc "github.com/kayac/go-config"
 	"github.com/mattn/go-isatty"
@@ -42,6 +43,7 @@ type App struct {
 	codedeploy  *codedeploy.CodeDeploy
 	cwl         *cloudwatchlogs.CloudWatchLogs
 	iam         *iam.IAM
+	elbv2       *elbv2.ELBV2
 
 	sess     *session.Session
 	verifier *verifier
@@ -273,6 +275,7 @@ func NewApp(conf *Config) (*App, error) {
 		codedeploy:  codedeploy.New(sess),
 		cwl:         cloudwatchlogs.New(sess),
 		iam:         iam.New(sess),
+		elbv2:       elbv2.New(sess),
 
 		sess:   sess,
 		config: conf,

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -42,8 +42,8 @@ type App struct {
 	autoScaling *applicationautoscaling.ApplicationAutoScaling
 	codedeploy  *codedeploy.CodeDeploy
 	cwl         *cloudwatchlogs.CloudWatchLogs
-	iam         *iam.IAM
 	elbv2       *elbv2.ELBV2
+	iam         *iam.IAM
 
 	sess     *session.Session
 	verifier *verifier
@@ -274,8 +274,8 @@ func NewApp(conf *Config) (*App, error) {
 		autoScaling: applicationautoscaling.New(sess),
 		codedeploy:  codedeploy.New(sess),
 		cwl:         cloudwatchlogs.New(sess),
-		iam:         iam.New(sess),
 		elbv2:       elbv2.New(sess),
+		iam:         iam.New(sess),
 
 		sess:   sess,
 		config: conf,

--- a/verify.go
+++ b/verify.go
@@ -218,7 +218,7 @@ func (d *App) verifyServiceDefinition(ctx context.Context) error {
 	for i, lb := range sv.LoadBalancers {
 		name := fmt.Sprintf("LoadBalancer[%d]", i)
 		err := d.verifyResource(ctx, name, func(context.Context) error {
-			out, err := d.verifier.elbv2.DescribeTargetGroupsWithContext(ctx, &elbv2.DescribeTargetGroupsInput{
+			out, err := d.elbv2.DescribeTargetGroupsWithContext(ctx, &elbv2.DescribeTargetGroupsInput{
 				TargetGroupArns: []*string{lb.TargetGroupArn},
 			})
 			if err != nil {

--- a/verify.go
+++ b/verify.go
@@ -222,6 +222,16 @@ func (d *App) verifyServiceDefinition(ctx context.Context) error {
 				TargetGroupArns: []*string{lb.TargetGroupArn},
 			})
 			if err != nil {
+				fmt.Println(
+					color.YellowString(
+						"WARNING: verifying the target group using the task execution role has been DEPRECATED and will be removed in the future. " +
+						"Allow `elasticloadbalancing: DescribeTargetGroups` to the role that executes ecspresso."),
+				)
+				out, err = d.verifier.elbv2.DescribeTargetGroupsWithContext(ctx, &elbv2.DescribeTargetGroupsInput{
+					TargetGroupArns: []*string{lb.TargetGroupArn},
+				})
+			}
+			if err != nil {
 				return err
 			} else if len(out.TargetGroups) == 0 {
 				return errors.Errorf("target group %s is not found", *lb.TargetGroupArn)


### PR DESCRIPTION
Currently, you need to grant the task execution role the `elasticloadbalancing:DescribeTargetGroups` permission in order to run `verify`.

Since I don't want to grant any permissions other than executing tasks to the task execution role, I propose to use the IAM for executing `ecspresso` as it is when checking target groups with `verify`.