### PR TITLE
Add tasks and exec command

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Commands:
     render config, service definition or task definition file to stdout
 
   tasks [<flags>]
-    list tasks in a cluster
+    list tasks that are in a service or having the same family
 
   exec [<flags>]
     execute command in a task

--- a/README.md
+++ b/README.md
@@ -64,11 +64,12 @@ jobs:
 usage: ecspresso [<flags>] <command> [<args> ...]
 
 Flags:
-  --help                 Show context-sensitive help (also try --help-long and --help-man).
+  --help                 Show context-sensitive help (also try --help-long and
+                         --help-man).
   --config=CONFIG        config file
   --debug                enable debug log
   --envfile=ENVFILE ...  environment files
-  --color                enalble colored output
+  --color                enable colored output
 
 Commands:
   help [<command>...]
@@ -80,12 +81,13 @@ Commands:
   deploy [<flags>]
     deploy service
 
-  refresh [<flags>]
-    refresh service. equivalent to deploy --skip-task-definition --force-new-deployment
+  scale --tasks=TASKS [<flags>]
+    scale service. equivalent to deploy --skip-task-definition
     --no-update-service
 
-  scale --tasks=TASKS [<flags>]
-    scale service. equivalent to deploy --skip-task-definition --no-update-service
+  refresh [<flags>]
+    refresh service. equivalent to deploy --skip-task-definition
+    --force-new-deployment --no-update-service
 
   create [<flags>]
     create service
@@ -108,7 +110,7 @@ Commands:
   wait
     wait until service stable
 
-  init --region=REGION --service=SERVICE [<flags>]
+  init --service=SERVICE [<flags>]
     create service/task definition files by existing ECS service
 
   diff
@@ -122,6 +124,12 @@ Commands:
 
   render [<flags>]
     render config, service definition or task definition file to stdout
+
+  tasks [<flags>]
+    list tasks in a cluster
+
+  exec [<flags>]
+    execute command in a task
 ```
 
 For more options for sub-commands, See `ecspresso sub-command --help`.

--- a/README.md
+++ b/README.md
@@ -523,6 +523,42 @@ $ ecspresso --config config.yaml verify
 2020/12/08 11:43:14 nginx-local/ecspresso-test Verify OK!
 ```
 
+### tasks
+
+task command lists tasks that run by a service or having the same family to a task definition.
+
+```
+Flags:
+  --id=""                task ID
+  --output=table         output format (table|json|tsv)
+  --find                 find a task from tasks list and dump it as JSON
+```
+
+When `--find` option is set, you can select a task in a list of tasks and show the task as JSON.
+
+`filter_command` in config.yaml can define a command to filter tasks. For example [peco](https://github.com/peco/peco), [fzf](https://github.com/junegunn/fzf) and etc.
+
+```yaml
+filter_command: peco
+```
+
+### exec
+
+exec command executes a command on task.
+
+```
+Flags:
+  --id=""                task ID
+  --command="sh"         command
+  --container=CONTAINER  container name
+```
+
+If `--id` is not set, the command shows a list of tasks to select a task to execute.
+
+`filter_command` in config.yaml works ths same as tasks command.
+
+See also the official document [Using Amazon ECS Exec for debugging](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html).
+
 # Plugins
 
 ## tfstate

--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -147,6 +147,12 @@ func _main() int {
 		ConfigFile:        render.Flag("config-file", "render config file").Bool(),
 	}
 
+	tasks := kingpin.Command("tasks", "list tasks in the cluster")
+	tasksOption := ecspresso.TasksOption{
+		ID:     tasks.Flag("id", "task ID").Default("").String(),
+		Format: tasks.Flag("format", "output format").Default("table").Enum("table", "json", "tsv"),
+	}
+
 	sub := kingpin.Parse()
 	if sub == "version" {
 		fmt.Println("ecspresso", Version)
@@ -226,6 +232,8 @@ func _main() int {
 		err = app.Verify(verifyOption)
 	case "render":
 		err = app.Render(renderOption)
+	case "tasks":
+		err = app.Tasks(tasksOption)
 	default:
 		kingpin.Usage()
 		return 1

--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -151,12 +151,14 @@ func _main() int {
 	tasksOption := ecspresso.TasksOption{
 		ID:     tasks.Flag("id", "task ID").Default("").String(),
 		Output: tasks.Flag("output", "output format (table|json|tsv)").Default("table").Enum("table", "json", "tsv"),
+		Find:   tasks.Flag("find", "find a task from tasks list and dump it as JSON").Bool(),
 	}
 
 	exec := kingpin.Command("exec", "execute command into the task")
 	execOption := ecspresso.ExecOption{
-		ID:      exec.Flag("id", "task ID").Default("").String(),
-		Command: exec.Flag("command", "command").Default("sh").String(),
+		ID:        exec.Flag("id", "task ID").Default("").String(),
+		Command:   exec.Flag("command", "command").Default("sh").String(),
+		Container: exec.Flag("container", "container name").String(),
 	}
 
 	sub := kingpin.Parse()

--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -150,7 +150,7 @@ func _main() int {
 	tasks := kingpin.Command("tasks", "list tasks in the cluster")
 	tasksOption := ecspresso.TasksOption{
 		ID:     tasks.Flag("id", "task ID").Default("").String(),
-		Format: tasks.Flag("format", "output format").Default("table").Enum("table", "json", "tsv"),
+		Output: tasks.Flag("output", "output format (table|json|tsv)").Default("table").Enum("table", "json", "tsv"),
 	}
 
 	sub := kingpin.Parse()

--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -153,6 +153,12 @@ func _main() int {
 		Output: tasks.Flag("output", "output format (table|json|tsv)").Default("table").Enum("table", "json", "tsv"),
 	}
 
+	exec := kingpin.Command("exec", "execute command into the task")
+	execOption := ecspresso.ExecOption{
+		ID:      exec.Flag("id", "task ID").Default("").String(),
+		Command: exec.Flag("command", "command").Default("sh").String(),
+	}
+
 	sub := kingpin.Parse()
 	if sub == "version" {
 		fmt.Println("ecspresso", Version)
@@ -234,6 +240,8 @@ func _main() int {
 		err = app.Render(renderOption)
 	case "tasks":
 		err = app.Tasks(tasksOption)
+	case "exec":
+		err = app.Exec(execOption)
 	default:
 		kingpin.Usage()
 		return 1

--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -147,14 +147,14 @@ func _main() int {
 		ConfigFile:        render.Flag("config-file", "render config file").Bool(),
 	}
 
-	tasks := kingpin.Command("tasks", "list tasks in the cluster")
+	tasks := kingpin.Command("tasks", "list tasks that are in a service or having the same family")
 	tasksOption := ecspresso.TasksOption{
 		ID:     tasks.Flag("id", "task ID").Default("").String(),
 		Output: tasks.Flag("output", "output format (table|json|tsv)").Default("table").Enum("table", "json", "tsv"),
 		Find:   tasks.Flag("find", "find a task from tasks list and dump it as JSON").Bool(),
 	}
 
-	exec := kingpin.Command("exec", "execute command into the task")
+	exec := kingpin.Command("exec", "execute command in a task")
 	execOption := ecspresso.ExecOption{
 		ID:        exec.Flag("id", "task ID").Default("").String(),
 		Command:   exec.Flag("command", "command").Default("sh").String(),

--- a/config.go
+++ b/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	Timeout               time.Duration    `yaml:"timeout"`
 	Plugins               []ConfigPlugin   `yaml:"plugins,omitempty"`
 	AppSpec               *appspec.AppSpec `yaml:"appspec,omitempty"`
+	FinderCommand         string           `yaml:"finder_command,omitempty"`
 
 	templateFuncs      []template.FuncMap
 	dir                string

--- a/config.go
+++ b/config.go
@@ -32,7 +32,7 @@ type Config struct {
 	Timeout               time.Duration    `yaml:"timeout"`
 	Plugins               []ConfigPlugin   `yaml:"plugins,omitempty"`
 	AppSpec               *appspec.AppSpec `yaml:"appspec,omitempty"`
-	FinderCommand         string           `yaml:"finder_command,omitempty"`
+	FilterCommand         string           `yaml:"filter_command,omitempty"`
 
 	templateFuncs      []template.FuncMap
 	dir                string

--- a/exec.go
+++ b/exec.go
@@ -1,0 +1,66 @@
+package ecspresso
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"os/signal"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/pkg/errors"
+)
+
+type ExecOption struct {
+	ID      *string
+	Command *string
+}
+
+func (d *App) Exec(opt ExecOption) error {
+	ctx, cancel := d.Start()
+	defer cancel()
+
+	tasks, err := d.tasks(ctx, opt.ID)
+	if err != nil {
+		return err
+	}
+
+	finder := exec.Command("sh", "-c", "peco")
+	finder.Stderr = os.Stderr
+	p, _ := finder.StdinPipe()
+
+	go func() {
+		formatter := newTaskFormatterTSV(p)
+		for _, task := range tasks {
+			formatter.AddTask(task)
+		}
+		formatter.Close()
+		p.Close()
+	}()
+
+	var taskID string
+	if result, err := finder.Output(); err != nil {
+		return errors.Wrap(err, "failed to exucute finder command")
+	} else {
+		taskID = strings.Fields(string(result))[0]
+	}
+
+	out, err := d.ecs.ExecuteCommand(&ecs.ExecuteCommandInput{
+		Cluster:     &d.Cluster,
+		Interactive: aws.Bool(true),
+		Task:        aws.String(taskID),
+		Command:     opt.Command,
+	})
+	if err != nil {
+		return err
+	}
+	sess, _ := json.Marshal(out.Session)
+	cmd := exec.Command("session-manager-plugin", string(sess), d.config.Region, "StartSession")
+	signal.Ignore(os.Interrupt)
+	defer signal.Reset(os.Interrupt)
+	cmd.Stdout = os.Stdout
+	cmd.Stdin = os.Stdin
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/Songmu/prompter v0.4.0
 	github.com/alecthomas/kingpin v1.3.8-0.20190930021037-0a108b7f5563
-	github.com/aws/aws-sdk-go v1.37.31
+	github.com/aws/aws-sdk-go v1.38.11
 	github.com/fatih/color v1.10.0
 	github.com/fujiwara/cfn-lookup v0.0.2
 	github.com/fujiwara/tfstate-lookup v0.1.3
@@ -16,6 +16,7 @@ require (
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-isatty v0.0.12
 	github.com/morikuni/aec v1.0.0
+	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pkg/errors v0.9.1
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2c
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/aws/aws-sdk-go v1.30.7/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.36.15/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
-github.com/aws/aws-sdk-go v1.37.31 h1:eK7hgg1H4xivwopAbnzfQ7ZBbDb9cEkGDivd9rUMnJs=
-github.com/aws/aws-sdk-go v1.37.31/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
+github.com/aws/aws-sdk-go v1.38.11 h1:jmxKh557ZRc+Z8fALnGrL01Ctjks2aSUFLb7n/BZoEs=
+github.com/aws/aws-sdk-go v1.38.11/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -75,9 +75,13 @@ github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOA
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.8/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/pbnjay/strptime v0.0.0-20140226051138-5c05b0d668c9 h1:4lfz0keanz7/gAlvJ7lAe9zmE08HXxifBZJC0AdeGKo=
 github.com/pbnjay/strptime v0.0.0-20140226051138-5c05b0d668c9/go.mod h1:6Hr+C/olSdkdL3z68MlyXWzwhvwmwN7KuUFXGb3PoOk=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/service.go
+++ b/service.go
@@ -10,8 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ecs"
 )
 
-var timezone, _ = time.LoadLocation("Local")
-
 func arnToName(s string) string {
 	ns := strings.Split(s, "/")
 	return ns[len(ns)-1]
@@ -37,7 +35,7 @@ func formatTaskSet(d *ecs.TaskSet) string {
 
 func formatEvent(e *ecs.ServiceEvent, chars int) []string {
 	line := fmt.Sprintf("%s %s",
-		e.CreatedAt.In(timezone).Format("2006/01/02 15:04:05"),
+		e.CreatedAt.In(time.Local).Format("2006/01/02 15:04:05"),
 		*e.Message,
 	)
 	lines := []string{}
@@ -55,7 +53,7 @@ func formatEvent(e *ecs.ServiceEvent, chars int) []string {
 func formatLogEvent(e *cloudwatchlogs.OutputLogEvent, chars int) []string {
 	t := time.Unix((*e.Timestamp / int64(1000)), 0)
 	line := fmt.Sprintf("%s %s",
-		t.In(timezone).Format("2006/01/02 15:04:05"),
+		t.In(time.Local).Format("2006/01/02 15:04:05"),
 		*e.Message,
 	)
 	lines := []string{}

--- a/tasks.go
+++ b/tasks.go
@@ -1,0 +1,169 @@
+package ecspresso
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/olekukonko/tablewriter"
+	"github.com/pkg/errors"
+)
+
+type TasksOption struct {
+	ID             *string
+	Format         *string
+	ExecuteCommand *string
+}
+
+func (opt TasksOption) Formatter() taskFormatter {
+	switch *opt.Format {
+	case "json":
+		return newTaskFormatterJSON(os.Stdout)
+	case "tsv":
+		return newTaskFormatterTSV(os.Stdout)
+	}
+	return newTaskFormatterTable(os.Stdout)
+}
+
+func (d *App) Tasks(opt TasksOption) error {
+	ctx, cancel := d.Start()
+	defer cancel()
+
+	td, err := d.LoadTaskDefinition(d.config.TaskDefinitionPath)
+	if err != nil {
+		return err
+	}
+	var taskIDs []*string
+
+	if aws.StringValue(opt.ID) != "" {
+		taskIDs = []*string{opt.ID}
+	} else {
+		for _, desiredStatus := range []string{"RUNNING", "STOPPED"} {
+			var nextToken *string
+			for {
+				out, err := d.ecs.ListTasks(&ecs.ListTasksInput{
+					Cluster:       &d.config.Cluster,
+					Family:        td.Family,
+					DesiredStatus: aws.String(desiredStatus),
+					NextToken:     nextToken,
+				})
+				if err != nil {
+					return errors.Wrap(err, "failed to list tasks")
+				}
+				for _, id := range out.TaskArns {
+					taskIDs = append(taskIDs, aws.String(arnToName(*id)))
+				}
+				if nextToken = out.NextToken; nextToken == nil {
+					break
+				}
+			}
+		}
+		if len(taskIDs) == 0 {
+			return nil
+		}
+	}
+	in := &ecs.DescribeTasksInput{
+		Cluster: aws.String(d.Cluster),
+		Tasks:   taskIDs,
+	}
+	out, err := d.ecs.DescribeTasksWithContext(ctx, in)
+	if err != nil {
+		return errors.Wrap(err, "failed to describe tasks")
+	}
+	if len(out.Tasks) == 0 && len(in.Tasks) != 0 {
+		return errors.Errorf("task ID %s is not found", *in.Tasks[0])
+	}
+	formatter := opt.Formatter()
+	for _, task := range out.Tasks {
+		formatter.AddTask(task)
+	}
+	formatter.Close()
+	return nil
+}
+
+type taskFormatter interface {
+	AddTask(*ecs.Task)
+	Close()
+}
+
+var taskFormatterColumns = []string{
+	"ID",
+	"TaskDefinition",
+	"Instance",
+	"LastStatus",
+	"DesiredStatus",
+	"CreatedAt",
+	"Group",
+	"Type",
+}
+
+func taskToColumns(task *ecs.Task) []string {
+	return []string{
+		arnToName(*task.TaskArn),
+		arnToName(*task.TaskDefinitionArn),
+		arnToName(aws.StringValue(task.ContainerInstanceArn)),
+		aws.StringValue(task.LastStatus),
+		aws.StringValue(task.DesiredStatus),
+		task.CreatedAt.In(time.Local).Format(time.RFC3339),
+		aws.StringValue(task.Group),
+		aws.StringValue(task.LaunchType),
+	}
+}
+
+type taskFormatterTable struct {
+	table *tablewriter.Table
+}
+
+func newTaskFormatterTable(w io.Writer) *taskFormatterTable {
+	t := &taskFormatterTable{
+		table: tablewriter.NewWriter(w),
+	}
+	t.table.SetHeader(taskFormatterColumns)
+	t.table.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
+	return t
+}
+
+func (t *taskFormatterTable) AddTask(task *ecs.Task) {
+	t.table.Append(taskToColumns(task))
+}
+
+func (t *taskFormatterTable) Close() {
+	t.table.Render()
+}
+
+type taskFormatterTSV struct {
+	w io.Writer
+}
+
+func newTaskFormatterTSV(w io.Writer) *taskFormatterTSV {
+	t := &taskFormatterTSV{w: w}
+	fmt.Fprintln(t.w, strings.Join(taskFormatterColumns, "\t"))
+	return t
+}
+
+func (t *taskFormatterTSV) AddTask(task *ecs.Task) {
+	fmt.Fprintln(t.w, strings.Join(taskToColumns(task), "\t"))
+}
+
+func (t *taskFormatterTSV) Close() {
+}
+
+type taskFormatterJSON struct {
+	w io.Writer
+}
+
+func newTaskFormatterJSON(w io.Writer) *taskFormatterJSON {
+	return &taskFormatterJSON{w: w}
+}
+
+func (t *taskFormatterJSON) AddTask(task *ecs.Task) {
+	b, _ := marshalJSON(task)
+	t.w.Write(b.Bytes())
+}
+
+func (t *taskFormatterJSON) Close() {
+}

--- a/tasks.go
+++ b/tasks.go
@@ -110,9 +110,9 @@ func (d *App) Tasks(opt TasksOption) error {
 		tasksDict[arnToName(*task.TaskArn)] = task
 	}
 	formatter.Close()
-	result, err := d.runFinderCommand(buf, "task ID")
+	result, err := d.runFinder(buf, "task ID")
 	if err != nil {
-		return errors.Wrap(err, "failed to exucute finder")
+		return err
 	}
 	taskID := strings.Fields(string(result))[0]
 

--- a/tasks.go
+++ b/tasks.go
@@ -110,7 +110,7 @@ func (d *App) Tasks(opt TasksOption) error {
 		tasksDict[arnToName(*task.TaskArn)] = task
 	}
 	formatter.Close()
-	result, err := d.runFinder(buf, "task ID")
+	result, err := d.runFilter(buf, "task ID")
 	if err != nil {
 		return err
 	}

--- a/tests/ci/config.yaml
+++ b/tests/ci/config.yaml
@@ -4,3 +4,4 @@ service: "{{ must_env `SERVICE` }}"
 service_definition: ecs-service-def.json
 task_definition: ecs-task-def.json
 timeout: 10m0s
+#finder_command: peco

--- a/tests/ci/config.yaml
+++ b/tests/ci/config.yaml
@@ -4,4 +4,4 @@ service: "{{ must_env `SERVICE` }}"
 service_definition: ecs-service-def.json
 task_definition: ecs-task-def.json
 timeout: 10m0s
-#finder_command: peco
+finder_command: peco

--- a/tests/ci/ecs-task-def.json
+++ b/tests/ci/ecs-task-def.json
@@ -37,6 +37,24 @@
         }
       ],
       "volumesFrom": []
+    },
+    {
+      "essential": true,
+      "image": "debian:buster-slim",
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "ecspresso-test",
+          "awslogs-region": "ap-northeast-1",
+          "awslogs-stream-prefix": "bash"
+        }
+      },
+      "name": "bash",
+      "command": [
+        "tail",
+        "-f",
+        "/dev/null"
+      ]
     }
   ],
   "cpu": "256",


### PR DESCRIPTION
Add tasks and exec command.

[![asciicast](https://asciinema.org/a/405167.svg)](https://asciinema.org/a/405167)

```
usage: ecspresso tasks [<flags>]

list tasks in a cluster

Flags:
  --help                 Show context-sensitive help (also try --help-long and
                         --help-man).
  --config=CONFIG        config file
  --debug                enable debug log
  --envfile=ENVFILE ...  environment files
  --color                enable colored output
  --id=""                task ID
  --output=table         output format (table|json|tsv)
  --find                 find a task from tasks list and dump it as JSON
```

```
usage: ecspresso exec [<flags>]

execute command in a task

Flags:
  --help                 Show context-sensitive help (also try --help-long and
                         --help-man).
  --config=CONFIG        config file
  --debug                enable debug log
  --envfile=ENVFILE ...  environment files
  --color                enable colored output
  --id=""                task ID
  --command="sh"         command
  --container=CONTAINER  container name
```