### PR TITLE
refactoring verifier

### DIFF
--- a/ecspresso.go
+++ b/ecspresso.go
@@ -18,7 +18,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go/service/codedeploy"
 	"github.com/aws/aws-sdk-go/service/ecs"
-	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/aws/aws-sdk-go/service/iam"
 	gc "github.com/kayac/go-config"
 	"github.com/mattn/go-isatty"
@@ -46,7 +45,6 @@ type App struct {
 	autoScaling *applicationautoscaling.ApplicationAutoScaling
 	codedeploy  *codedeploy.CodeDeploy
 	cwl         *cloudwatchlogs.CloudWatchLogs
-	elbv2       *elbv2.ELBV2
 	iam         *iam.IAM
 
 	sess     *session.Session
@@ -279,7 +277,6 @@ func NewApp(conf *Config) (*App, error) {
 		autoScaling: applicationautoscaling.New(sess),
 		codedeploy:  codedeploy.New(sess),
 		cwl:         cloudwatchlogs.New(sess),
-		elbv2:       elbv2.New(sess),
 		iam:         iam.New(sess),
 
 		sess:   sess,


### PR DESCRIPTION
remove App.elbv2
"verifier.elbv2" becomes a slice of *elbv2.ELBV2 to enable fallback.

refs #262 