### PR TITLE
Support tags&propagateTags to `init` & `create`

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -28,7 +28,10 @@ func TestLoadServiceDefinition(t *testing.T) {
 		*sv.DesiredCount != 2 ||
 		*sv.LoadBalancers[0].TargetGroupArn != "arn:aws:elasticloadbalancing:us-east-1:1111111111:targetgroup/test/12345678" ||
 		*sv.LaunchType != "EC2" ||
-		*sv.SchedulingStrategy != "REPLICA" {
+		*sv.SchedulingStrategy != "REPLICA" ||
+		*sv.PropagateTags != "SERVICE" ||
+		*sv.Tags[0].Key != "cluster" ||
+		*sv.Tags[0].Value != "default2" {
 		t.Errorf("unexpected service definition %s", sv.String())
 	}
 }

--- a/init.go
+++ b/init.go
@@ -31,6 +31,13 @@ func (d *App) Init(opt InitOption) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to describe task definition")
 	}
+	lt, err := d.ecs.ListTagsForResourceWithContext(ctx, &ecs.ListTagsForResourceInput{
+		ResourceArn: sv.ServiceArn,
+	})
+	if err != nil {
+		return errors.Wrap(err, "failed to list tags for service")
+	}
+	sv.Tags = lt.Tags
 
 	// service-def
 	treatmentServiceDefinition(sv)

--- a/init.go
+++ b/init.go
@@ -80,7 +80,6 @@ func treatmentServiceDefinition(sv *ecs.Service) *ecs.Service {
 	sv.Deployments = nil
 	sv.Events = nil
 	sv.PendingCount = nil
-	sv.PropagateTags = nil
 	sv.RunningCount = nil
 	sv.Status = nil
 	sv.TaskDefinition = nil

--- a/init.go
+++ b/init.go
@@ -88,7 +88,7 @@ func treatmentServiceDefinition(sv *ecs.Service) *ecs.Service {
 	sv.RoleArn = nil
 	sv.ServiceName = nil
 
-	if *sv.PropagateTags == "NONE" {
+	if *sv.PropagateTags != "SERVICE" && *sv.PropagateTags != "TASK_DEFINITION" {
 		sv.PropagateTags = nil
 	}
 

--- a/init.go
+++ b/init.go
@@ -87,6 +87,11 @@ func treatmentServiceDefinition(sv *ecs.Service) *ecs.Service {
 	sv.ServiceArn = nil
 	sv.RoleArn = nil
 	sv.ServiceName = nil
+
+	if *sv.PropagateTags == "NONE" {
+		sv.PropagateTags = nil
+	}
+
 	return sv
 }
 

--- a/tests/ci/ecs-service-def.json
+++ b/tests/ci/ecs-service-def.json
@@ -41,5 +41,12 @@
   "placementStrategy": [],
   "platformVersion": "LATEST",
   "schedulingStrategy": "REPLICA",
-  "serviceRegistries": []
+  "serviceRegistries": [],
+  "propagateTags": "SERVICE",
+  "tags": [
+    {
+      "key": "cluster",
+      "value": "ecspresso-test"
+    }
+  ]
 }

--- a/tests/sv.json
+++ b/tests/sv.json
@@ -21,5 +21,12 @@
       ],
       "assignPublicIp": "ENABLED"
     }
-  }
+  },
+  "propagateTags": "SERVICE",
+  "tags": [
+    {
+      "key": "cluster",
+      "value": "default2"
+    }
+  ]
 }


### PR DESCRIPTION
Supports tagging for service and propagateTags.
We can combine #256 and #260 with this PR to support tagging tasks.

`create` already supports both Tags and Propagate Tags.
https://github.com/kayac/ecspresso/blob/21451a1bf7e7fc492f9049ece9965ac98eb745aa/ecspresso.go#L356-L360