### PR TITLE
Add --resume-auto-scaling to deploy and scale command

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Commands:
   deploy [<flags>]
     deploy service
 
-  scale --tasks=TASKS [<flags>]
+  scale [<flags>]
     scale service. equivalent to deploy --skip-task-definition
     --no-update-service
 
@@ -564,6 +564,15 @@ If `--id` is not set, the command shows a list of tasks to select a task to exec
 `filter_command` in config.yaml works ths same as tasks command.
 
 See also the official document [Using Amazon ECS Exec for debugging](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html).
+
+### suspend / resume application auto scaling
+
+`ecspresso deploy` and `scale` can suspend / resume application auto scaling.
+
+`--suspend-auto-scaling` sets suspended state true.
+`--resume-auto-scaling` sets suspended state false.
+
+When you want to change the suspended state simply, try `ecspresso scale --suspend-auto-scaling` or `ecspresso scale --resume-auto-scaling`. That operation will change suspended state only.
 
 # Plugins
 

--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/alecthomas/kingpin"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/fatih/color"
 	"github.com/kayac/ecspresso"
 	"github.com/mattn/go-isatty"
@@ -30,26 +31,28 @@ func _main() int {
 	}
 	colorOpt := kingpin.Flag("color", "enable colored output").Default(colorDefault).Bool()
 
-	var isSetSuspendAutoScaling bool
+	var isSetSuspendAutoScaling, isSetResumeAutoScaling bool
 	deploy := kingpin.Command("deploy", "deploy service")
+	deploy.Flag("resume-auto-scaling", "resume application auto-scaling attached with the ECS service").IsSetByUser(&isSetResumeAutoScaling).Bool()
 	deployOption := ecspresso.DeployOption{
 		DryRun:               deploy.Flag("dry-run", "dry-run").Bool(),
 		DesiredCount:         deploy.Flag("tasks", "desired count of tasks").Default("-1").Int64(),
 		SkipTaskDefinition:   deploy.Flag("skip-task-definition", "skip register a new task definition").Bool(),
 		ForceNewDeployment:   deploy.Flag("force-new-deployment", "force a new deployment of the service").Bool(),
 		NoWait:               deploy.Flag("no-wait", "exit ecspresso immediately after just deployed without waiting for service stable").Bool(),
-		SuspendAutoScaling:   deploy.Flag("suspend-auto-scaling", "set suspend to auto-scaling attached with the ECS service").IsSetByUser(&isSetSuspendAutoScaling).Bool(),
+		SuspendAutoScaling:   deploy.Flag("suspend-auto-scaling", "suspend application auto-scaling attached with the ECS service").IsSetByUser(&isSetSuspendAutoScaling).Bool(),
 		RollbackEvents:       deploy.Flag("rollback-events", " rollback when specified events happened (DEPLOYMENT_FAILURE,DEPLOYMENT_STOP_ON_ALARM,DEPLOYMENT_STOP_ON_REQUEST,...) CodeDeploy only.").String(),
 		UpdateService:        deploy.Flag("update-service", "update service attributes by service definition").Default("true").Bool(),
 		LatestTaskDefinition: deploy.Flag("latest-task-definition", "deploy with latest task definition without registering new task definition").Default("false").Bool(),
 	}
 
 	scale := kingpin.Command("scale", "scale service. equivalent to deploy --skip-task-definition --no-update-service")
+	scale.Flag("resume-auto-scaling", "resume application auto-scaling attached with the ECS service").IsSetByUser(&isSetResumeAutoScaling).Bool()
 	scaleOption := ecspresso.DeployOption{
 		DryRun:               scale.Flag("dry-run", "dry-run").Bool(),
-		DesiredCount:         scale.Flag("tasks", "desired count of tasks").Required().Int64(),
+		DesiredCount:         scale.Flag("tasks", "desired count of tasks").Default("-1").Int64(),
 		SkipTaskDefinition:   boolp(true),
-		SuspendAutoScaling:   scale.Flag("suspend-auto-scaling", "set suspend to auto-scaling attached with the ECS service").IsSetByUser(&isSetSuspendAutoScaling).Bool(),
+		SuspendAutoScaling:   scale.Flag("suspend-auto-scaling", "suspend application auto-scaling attached with the ECS service").IsSetByUser(&isSetSuspendAutoScaling).Bool(),
 		ForceNewDeployment:   boolp(false),
 		NoWait:               scale.Flag("no-wait", "exit ecspresso immediately after just deployed without waiting for service stable").Bool(),
 		UpdateService:        boolp(false),
@@ -214,12 +217,18 @@ func _main() int {
 		if !isSetSuspendAutoScaling {
 			deployOption.SuspendAutoScaling = nil
 		}
+		if isSetResumeAutoScaling {
+			deployOption.SuspendAutoScaling = aws.Bool(false)
+		}
 		err = app.Deploy(deployOption)
 	case "refresh":
 		err = app.Deploy(refreshOption)
 	case "scale":
 		if !isSetSuspendAutoScaling {
 			scaleOption.SuspendAutoScaling = nil
+		}
+		if isSetResumeAutoScaling {
+			scaleOption.SuspendAutoScaling = aws.Bool(false)
 		}
 		err = app.Deploy(scaleOption)
 	case "status":

--- a/deploy.go
+++ b/deploy.go
@@ -106,8 +106,8 @@ func (d *App) Deploy(opt DeployOption) error {
 	}
 
 	// manage auto scaling only when set option --suspend-auto-scaling or --no-suspend-auto-scaling explicitly
-	if suspend := opt.SuspendAutoScaling; suspend != nil {
-		if err := d.suspendAutoScaling(*suspend); err != nil {
+	if suspendState := opt.SuspendAutoScaling; suspendState != nil {
+		if err := d.suspendAutoScaling(*suspendState); err != nil {
 			return err
 		}
 	}

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -644,7 +644,7 @@ func (d *App) Register(opt RegisterOption) error {
 	return nil
 }
 
-func (d *App) suspendAutoScaling(suspend bool) error {
+func (d *App) suspendAutoScaling(suspendState bool) error {
 	resouceId := fmt.Sprintf("service/%s/%s", d.Cluster, d.Service)
 
 	out, err := d.autoScaling.DescribeScalableTargets(
@@ -662,21 +662,21 @@ func (d *App) suspendAutoScaling(suspend bool) error {
 		return nil
 	}
 	for _, target := range out.ScalableTargets {
-		d.Log(fmt.Sprintf("Register scalable target %s set suspend to %t", *target.ResourceId, suspend))
+		d.Log(fmt.Sprintf("Register scalable target %s set suspend state to %t", *target.ResourceId, suspendState))
 		_, err := d.autoScaling.RegisterScalableTarget(
 			&applicationautoscaling.RegisterScalableTargetInput{
 				ServiceNamespace:  target.ServiceNamespace,
 				ScalableDimension: target.ScalableDimension,
 				ResourceId:        target.ResourceId,
 				SuspendedState: &applicationautoscaling.SuspendedState{
-					DynamicScalingInSuspended:  &suspend,
-					DynamicScalingOutSuspended: &suspend,
-					ScheduledScalingSuspended:  &suspend,
+					DynamicScalingInSuspended:  &suspendState,
+					DynamicScalingOutSuspended: &suspendState,
+					ScheduledScalingSuspended:  &suspendState,
 				},
 			},
 		)
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("failed to register scalable target %s set suspend to %t", *target.ResourceId, suspend))
+			return errors.Wrap(err, fmt.Sprintf("failed to register scalable target %s set suspend state to %t", *target.ResourceId, suspendState))
 		}
 	}
 	return nil


### PR DESCRIPTION
scale command doesn't require --tasks flag.
When --tasks is not defined, keep desired count.