### PR TITLE
CodeDeploy: If the deployment is not running, rollback by running a new deployment

### DIFF
--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -87,6 +87,7 @@ func _main() int {
 		DryRun:                   rollback.Flag("dry-run", "dry-run").Bool(),
 		DeregisterTaskDefinition: rollback.Flag("deregister-task-definition", "deregister rolled back task definition").Bool(),
 		NoWait:                   rollback.Flag("no-wait", "exit ecspresso immediately after just rollbacked without waiting for service stable").Bool(),
+		RollbackEvents:           rollback.Flag("rollback-events", " rollback when specified events happened (DEPLOYMENT_FAILURE,DEPLOYMENT_STOP_ON_ALARM,DEPLOYMENT_STOP_ON_REQUEST,...) CodeDeploy only.").String(),
 	}
 
 	delete := kingpin.Command("delete", "delete service")

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -746,8 +746,10 @@ func (d *App) RollbackByCodeDeploy(ctx context.Context, sv *ecs.Service, tdArn s
 		return nil
 	}
 
-	// If the deployment is not yet complete
-	if *dep.DeploymentInfo.Status != "Succeeded" && *dep.DeploymentInfo.Status != "Failed" && *dep.DeploymentInfo.Status != "Stopped" {
+	switch *dep.DeploymentInfo.Status {
+	case "Succeeded", "Failed", "Stopped":
+		return d.createDeployment(ctx, sv, tdArn, opt.RollbackEvents)
+	default: // If the deployment is not yet complete
 		_, err = d.codedeploy.StopDeploymentWithContext(ctx, &codedeploy.StopDeploymentInput{
 			DeploymentId:        dpID,
 			AutoRollbackEnabled: aws.Bool(true),
@@ -759,6 +761,4 @@ func (d *App) RollbackByCodeDeploy(ctx context.Context, sv *ecs.Service, tdArn s
 		d.Log(fmt.Sprintf("Deployment %s is rollbacked on CodeDeploy:", *dpID))
 		return nil
 	}
-
-	return d.createDeployment(ctx, sv, tdArn, opt.RollbackEvents)
 }

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -733,9 +733,12 @@ func (d *App) RollbackByCodeDeploy(ctx context.Context, sv *ecs.Service, tdArn s
 
 	dpID := ld.Deployments[0] // latest deployment id
 
-	dep, _ := d.codedeploy.GetDeploymentWithContext(ctx, &codedeploy.GetDeploymentInput{
+	dep, err := d.codedeploy.GetDeploymentWithContext(ctx, &codedeploy.GetDeploymentInput{
 		DeploymentId: dpID,
 	})
+	if err != nil {
+		return errors.Wrap(err, "failed to get deployment")
+	}
 
 	if *opt.DryRun {
 		d.Log("deployment id:", *dpID)

--- a/options.go
+++ b/options.go
@@ -66,6 +66,7 @@ type RollbackOption struct {
 	DryRun                   *bool
 	DeregisterTaskDefinition *bool
 	NoWait                   *bool
+	RollbackEvents           *string
 }
 
 func (opt RollbackOption) DryRunString() string {

--- a/rollback.go
+++ b/rollback.go
@@ -18,15 +18,16 @@ func (d *App) Rollback(opt RollbackOption) error {
 		return errors.Wrap(err, "failed to describe service status")
 	}
 
-	if isCodeDeploy(sv.DeploymentController) {
-		return d.RollbackByCodeDeploy(ctx, opt)
-	}
-
 	currentArn := *sv.TaskDefinition
 	targetArn, err := d.FindRollbackTarget(ctx, currentArn)
 	if err != nil {
 		return errors.Wrap(err, "failed to find rollback target")
 	}
+
+	if isCodeDeploy(sv.DeploymentController) {
+		return d.RollbackByCodeDeploy(ctx, sv, targetArn, opt)
+	}
+
 	d.Log("Rollbacking to", arnToName(targetArn))
 	if *opt.DryRun {
 		d.Log("DRY RUN OK")


### PR DESCRIPTION
## Current issues

There are two ways to revert to an earlier version with CodeDeploy, but both are limited.
- `rollback`: Only succeeds when the deployment **is** running
- `deploy`: Only succeeds when the deployment **is not** running

Therefore, at present, it was necessary to manually check the deployment status.

## Changes

- When you execute rollback, it will check the current deployment status, and if it has already finished, it will execute a new deployment and rollback.
  - The rollback destination is determined in the same way as a rolling deployment.