### PR TITLE
fix parseRoleArn

### DIFF
--- a/verify.go
+++ b/verify.go
@@ -437,7 +437,7 @@ func parseRoleArn(arn string) (roleName string, err error) {
 	if !strings.HasSuffix(rn[0], ":role") {
 		return "", errors.Errorf("not a valid role arn")
 	}
-	return rn[1], nil
+	return rn[len(rn)-1], nil
 }
 
 func (d *App) verifyRole(ctx context.Context, arn string) error {

--- a/verify_test.go
+++ b/verify_test.go
@@ -17,6 +17,11 @@ var testRoleArns = []struct {
 		isValid:  true,
 	},
 	{
+		arn:      "arn:aws:iam::123456789012:role/path/to/ecsTaskRole",
+		roleName: "ecsTaskRole",
+		isValid:  true,
+	},
+	{
 		arn: "arn:aws:iam::123456789012:foo",
 	},
 	{


### PR DESCRIPTION
didn't consider the Path of IAM Role.

for example: in verify set executionRole =`arn:aws:iam::123456789012:role/path/to/ecsExecutionRole` 

following error:
```
    --> ExecutionRole[arn:aws:iam::***:role/path/to/ecsExecutionRole] [NG] AccessDenied: User: arn:aws:sts::***:assumed-role/deploy-role/github-actions is not authorized to perform: iam:GetRole on resource: role path
```
Because result of parseRoleArn() function 
- before fix : `path`
- after fix: `ecsTaskRole`

