### PR TITLE
Get service tags only if it have long format ARN.

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -9,4 +9,5 @@ var (
 	CalcDesiredCount             = calcDesiredCount
 	ParseTags                    = parseTags
 	ParseRoleArn                 = parseRoleArn
+	IsLongArnFormat              = isLongArnFormat
 )

--- a/init.go
+++ b/init.go
@@ -31,13 +31,17 @@ func (d *App) Init(opt InitOption) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to describe task definition")
 	}
-	lt, err := d.ecs.ListTagsForResourceWithContext(ctx, &ecs.ListTagsForResourceInput{
-		ResourceArn: sv.ServiceArn,
-	})
-	if err != nil {
-		return errors.Wrap(err, "failed to list tags for service")
+
+	if long, _ := isLongArnFormat(*sv.ServiceArn); long {
+		// Long arn format must be used for tagging operations
+		lt, err := d.ecs.ListTagsForResourceWithContext(ctx, &ecs.ListTagsForResourceInput{
+			ResourceArn: sv.ServiceArn,
+		})
+		if err != nil {
+			return errors.Wrap(err, "failed to list tags for service")
+		}
+		sv.Tags = lt.Tags
 	}
-	sv.Tags = lt.Tags
 
 	// service-def
 	treatmentServiceDefinition(sv)

--- a/util.go
+++ b/util.go
@@ -3,7 +3,9 @@ package ecspresso
 import (
 	"bytes"
 	"encoding/json"
+	"strings"
 
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/private/protocol/json/jsonutil"
 )
 
@@ -29,4 +31,18 @@ func MarshalJSON(s interface{}) ([]byte, error) {
 func MarshalJSONString(s interface{}) string {
 	b, _ := marshalJSON(s)
 	return b.String()
+}
+
+func isLongArnFormat(a string) (bool, error) {
+	an, err := arn.Parse(a)
+	if err != nil {
+		return false, err
+	}
+	rs := strings.Split(an.Resource, "/")
+	switch rs[0] {
+	case "container-instance", "service", "task":
+		return len(rs) >= 3, nil
+	default:
+		return false, nil
+	}
 }

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,49 @@
+package ecspresso_test
+
+import (
+	"testing"
+
+	"github.com/kayac/ecspresso"
+)
+
+var ecsArns = []struct {
+	arnStr string
+	isLong bool
+}{
+	{
+		arnStr: "arn:aws:ecs:region:aws_account_id:container-instance/container-instance-id",
+		isLong: false,
+	},
+	{
+		arnStr: "arn:aws:ecs:region:aws_account_id:container-instance/cluster-name/container-instance-id",
+		isLong: true,
+	},
+	{
+		arnStr: "arn:aws:ecs:region:aws_account_id:service/service-name",
+		isLong: false,
+	},
+	{
+		arnStr: "arn:aws:ecs:region:aws_account_id:service/cluster-name/service-name",
+		isLong: true,
+	},
+	{
+		arnStr: "arn:aws:ecs:region:aws_account_id:task/task-id",
+		isLong: false,
+	},
+	{
+		arnStr: "arn:aws:ecs:region:aws_account_id:task/cluster-name/task-id",
+		isLong: true,
+	},
+}
+
+func TestLongArnFormat(t *testing.T) {
+	for _, ts := range ecsArns {
+		b, err := ecspresso.IsLongArnFormat(ts.arnStr)
+		if err != nil {
+			t.Error(err)
+		}
+		if b != ts.isLong {
+			t.Errorf("isLongArnFormat(%s) expected %v got %v", ts.arnStr, ts.isLong, b)
+		}
+	}
+}


### PR DESCRIPTION
ECS API says,
> Long arn format must be used for tagging operations