### PR TITLE
fix DockerHub API endpoint

### DIFF
--- a/registry/client.go
+++ b/registry/client.go
@@ -11,7 +11,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-const dockerHubHost = "registry.hub.docker.com"
+const dockerHubHost = "registry-1.docker.io"
 
 // Repositry represents a repositry using Docker Registry API v2.
 type Repositry struct {


### PR DESCRIPTION
registry.hub.docker.com/v2 now redirects to hub.docker.com/v2,
and it is 404!
Switch to registry-1.docker.io