### PR TITLE
Add run --wait-until option.

### DIFF
--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -101,6 +101,7 @@ func _main() int {
 		DryRun:               run.Flag("dry-run", "dry-run").Bool(),
 		TaskDefinition:       run.Flag("task-def", "task definition json for run task").String(),
 		NoWait:               run.Flag("no-wait", "exit ecspresso after task run").Bool(),
+		WaitUntil:            run.Flag("wait-until", "wait until invoked tasks status reached to (running or stopped)").Default("stopped").Enum("running", "stopped"),
 		TaskOverrideStr:      run.Flag("overrides", "task overrides JSON string").Default("").String(),
 		TaskOverrideFile:     run.Flag("overrides-file", "task overrides JSON file path").Default("").String(),
 		SkipTaskDefinition:   run.Flag("skip-task-definition", "skip register a new task definition").Bool(),

--- a/options.go
+++ b/options.go
@@ -100,6 +100,11 @@ type RunOption struct {
 	LatestTaskDefinition *bool
 	PropagateTags        *string
 	Tags                 *string
+	WaitUntil            *string
+}
+
+func (opt RunOption) waitUntilRunning() bool {
+	return aws.StringValue(opt.WaitUntil) == "running"
 }
 
 func (opt RunOption) DryRunString() string {

--- a/run.go
+++ b/run.go
@@ -232,7 +232,7 @@ func (d *App) waitTask(ctx context.Context, task *ecs.Task, untilRunning bool) e
 	}
 
 	id := arnToName(*task.TaskArn)
-	d.Log(fmt.Sprintf("Waiting for task ID %s running", id))
+	d.Log(fmt.Sprintf("Waiting for task ID %s until running", id))
 	if err := d.ecs.WaitUntilTasksRunningWithContext(
 		ctx,
 		d.DescribeTasksInput(task),
@@ -241,7 +241,7 @@ func (d *App) waitTask(ctx context.Context, task *ecs.Task, untilRunning bool) e
 	); err != nil {
 		return err
 	}
-	d.Log(fmt.Sprintf("Task ID %s is until running", id))
+	d.Log(fmt.Sprintf("Task ID %s is running", id))
 	if untilRunning {
 		return nil
 	}

--- a/run.go
+++ b/run.go
@@ -199,7 +199,7 @@ func (d *App) WaitRunTask(ctx context.Context, task *ecs.Task, watchContainer *e
 	time.Sleep(3 * time.Second) // wait for log stream
 
 	go func() {
-		tick := time.Tick(5 * time.Second)
+		ticker := time.NewTicker(5 * time.Second)
 		var lines int
 		for {
 			select {

--- a/run.go
+++ b/run.go
@@ -241,12 +241,12 @@ func (d *App) waitTask(ctx context.Context, task *ecs.Task, untilRunning bool) e
 	); err != nil {
 		return err
 	}
-	d.Log(fmt.Sprintf("Task ID %s is running", id))
+	d.Log(fmt.Sprintf("Task ID %s is until running", id))
 	if untilRunning {
 		return nil
 	}
 
-	d.Log(fmt.Sprintf("Waiting for task ID %s stopped", id))
+	d.Log(fmt.Sprintf("Waiting for task ID %s until stopped", id))
 	return d.ecs.WaitUntilTasksStoppedWithContext(
 		ctx, d.DescribeTasksInput(task),
 		request.WithWaiterDelay(request.ConstantWaiterDelay(delay)),


### PR DESCRIPTION
Currently, "ecspresso run" doesn't fail even if an invoked task did not run.
But it should fail.

This PR adds option --wait-until.
- `--wait-until running` waits for task running.
- `--wait-until stopped`(default) waits for task running and stopped.

Previous behavior is equivalent to --wait-until stopped.