### PR TITLE
Proposal: Revise comments and logs to use "rollback" only as a noun

### DIFF
--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -41,7 +41,7 @@ func _main() int {
 		ForceNewDeployment:   deploy.Flag("force-new-deployment", "force a new deployment of the service").Bool(),
 		NoWait:               deploy.Flag("no-wait", "exit ecspresso immediately after just deployed without waiting for service stable").Bool(),
 		SuspendAutoScaling:   deploy.Flag("suspend-auto-scaling", "suspend application auto-scaling attached with the ECS service").IsSetByUser(&isSetSuspendAutoScaling).Bool(),
-		RollbackEvents:       deploy.Flag("rollback-events", " rollback when specified events happened (DEPLOYMENT_FAILURE,DEPLOYMENT_STOP_ON_ALARM,DEPLOYMENT_STOP_ON_REQUEST,...) CodeDeploy only.").String(),
+		RollbackEvents:       deploy.Flag("rollback-events", " roll back when specified events happened (DEPLOYMENT_FAILURE,DEPLOYMENT_STOP_ON_ALARM,DEPLOYMENT_STOP_ON_REQUEST,...) CodeDeploy only.").String(),
 		UpdateService:        deploy.Flag("update-service", "update service attributes by service definition").Default("true").Bool(),
 		LatestTaskDefinition: deploy.Flag("latest-task-definition", "deploy with latest task definition without registering new task definition").Default("false").Bool(),
 	}
@@ -82,12 +82,12 @@ func _main() int {
 		Events: status.Flag("events", "show events num").Default("2").Int(),
 	}
 
-	rollback := kingpin.Command("rollback", "rollback service")
+	rollback := kingpin.Command("rollback", "roll back a service")
 	rollbackOption := ecspresso.RollbackOption{
 		DryRun:                   rollback.Flag("dry-run", "dry-run").Bool(),
-		DeregisterTaskDefinition: rollback.Flag("deregister-task-definition", "deregister rolled back task definition").Bool(),
-		NoWait:                   rollback.Flag("no-wait", "exit ecspresso immediately after just rollbacked without waiting for service stable").Bool(),
-		RollbackEvents:           rollback.Flag("rollback-events", " rollback when specified events happened (DEPLOYMENT_FAILURE,DEPLOYMENT_STOP_ON_ALARM,DEPLOYMENT_STOP_ON_REQUEST,...) CodeDeploy only.").String(),
+		DeregisterTaskDefinition: rollback.Flag("deregister-task-definition", "deregister a rolled-back task definition").Bool(),
+		NoWait:                   rollback.Flag("no-wait", "exit ecspresso immediately after just rolled back without waiting for service stable").Bool(),
+		RollbackEvents:           rollback.Flag("rollback-events", " roll back when specified events happened (DEPLOYMENT_FAILURE,DEPLOYMENT_STOP_ON_ALARM,DEPLOYMENT_STOP_ON_REQUEST,...) CodeDeploy only.").String(),
 	}
 
 	delete := kingpin.Command("delete", "delete service")

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -763,10 +763,10 @@ func (d *App) RollbackByCodeDeploy(ctx context.Context, sv *ecs.Service, tdArn s
 			AutoRollbackEnabled: aws.Bool(true),
 		})
 		if err != nil {
-			return errors.Wrap(err, "failed to rollback deployment")
+			return errors.Wrap(err, "failed to roll back the deployment")
 		}
 
-		d.Log(fmt.Sprintf("Deployment %s is rollbacked on CodeDeploy:", *dpID))
+		d.Log(fmt.Sprintf("Deployment %s is rolled back on CodeDeploy:", *dpID))
 		return nil
 	}
 }

--- a/rollback.go
+++ b/rollback.go
@@ -28,7 +28,7 @@ func (d *App) Rollback(opt RollbackOption) error {
 		return d.RollbackByCodeDeploy(ctx, sv, targetArn, opt)
 	}
 
-	d.Log("Rollbacking to", arnToName(targetArn))
+	d.Log("Rolling back to", arnToName(targetArn))
 	if *opt.DryRun {
 		d.Log("DRY RUN OK")
 		return nil
@@ -47,7 +47,7 @@ func (d *App) Rollback(opt RollbackOption) error {
 	}
 
 	if *opt.NoWait {
-		d.Log("Service is rollbacked.")
+		d.Log("Service is rolled back.")
 		return nil
 	}
 
@@ -59,7 +59,7 @@ func (d *App) Rollback(opt RollbackOption) error {
 	d.Log("Service is stable now. Completed!")
 
 	if *opt.DeregisterTaskDefinition {
-		d.Log("Deregistering rolled back task definition", arnToName(currentArn))
+		d.Log("Deregistering the rolled-back task definition", arnToName(currentArn))
 		_, err := d.ecs.DeregisterTaskDefinitionWithContext(
 			ctx,
 			&ecs.DeregisterTaskDefinitionInput{


### PR DESCRIPTION
ロジックの本体とは関係ないです。
コードを眺めていて、rollback という言葉を動詞として使っているところが気になったので作成しました。

軽く調べてみたところ、ECSの公式ドキュメントで rollback という単語が見あたるのは [Service の Update](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/update-service-console-v1.html) に関するところで、ここでは名詞として使われているようです。

また、以下のリンクでも rollback は名詞で、動詞として使いたいケースでは roll を動詞、back は副詞的に使われていました。

- [Automating rollback of failed Amazon ECS deployments - 公式ブログ](https://aws.amazon.com/jp/blogs/compute/automating-rollback-of-failed-amazon-ecs-deployments/)
- [update-service - AWS CLI ドキュメント](https://docs.aws.amazon.com/cli/latest/reference/ecs/update-service.html)

Stack Overflow や個人のブログなどでは、全文英文のものでも rollback をそのまま動詞として使用している例もあり、カジュアルな表現としては成立すると思うので、 Proposal に留めてあります。