### PR TITLE
Amend typological/grammatical errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ ecspresso supports `diff` and `verify` subcommands.
 
 ### diff
 
-Shows defferencies between local task/service definitions and remote (on ECS) definitions.
+Shows differences between local task/service definitions and remote (on ECS) definitions.
 
 ```diff
 $ ecspresso --config config.yaml diff
@@ -507,7 +507,7 @@ For example,
 - Secrets in task definition exist and be readable.
 - Can create log streams, can put messages to the streams in specified CloudWatch log groups.
 
-ecspresso verify tries to assume role to task execution role defined in task definition to verify these items. If faild to assume role, continue to verify with the current sessions.
+ecspresso verify tries to assume role to task execution role defined in task definition to verify these items. If failed to assume role, continue to verify with the current sessions.
 
 ```console
 $ ecspresso --config config.yaml verify
@@ -569,7 +569,7 @@ Flags:
 
 If `--id` is not set, the command shows a list of tasks to select a task to execute.
 
-`filter_command` in config.yaml works ths same as tasks command.
+`filter_command` in config.yaml works the same as tasks command.
 
 See also the official document [Using Amazon ECS Exec for debugging](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html).
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ For more options for sub-commands, See `ecspresso sub-command --help`.
 
 ## Quick Start
 
-ecspresso can easily manage for your existing/running ECS service by codes.
+ecspresso can easily manage your existing/running ECS service by codes.
 
 Try `ecspresso init` for your ECS service with option `--region`, `--cluster` and `--service`.
 
@@ -178,16 +178,16 @@ timeout: 5m
 ecspresso deploy works as below.
 
 - Register a new task definition from JSON file.
-  - JSON file is allowed both of formats as below.
+  - JSON file is allowed in both formats as below.
     - `aws ecs describe-task-definition` output.
     - `aws ecs register-task-definition --cli-input-json` input.
   - Replace ```{{ env `FOO` `bar` }}``` syntax in the JSON file to environment variable "FOO".
     - If "FOO" is not defined, replaced by "bar"
   - Replace ```{{ must_env `FOO` }}``` syntax in the JSON file to environment variable "FOO".
     - If "FOO" is not defined, abort immediately.
-- Update a service tasks.
+- Update service tasks.
   - When `--update-service` option set, update service attributes by service definition.
-- Wait a service stable.
+- Wait for a service to be stable.
 
 Configuration files and task/service definition files are read by [go-config](https://github.com/kayac/go-config). go-config has template functions `env`, `must_env` and `json_escape`.
 
@@ -303,7 +303,7 @@ example of service.json below.
 }
 ```
 
-Keys are same format as `aws ecs describe-services` output.
+Keys are in the same format as `aws ecs describe-services` output.
 
 - deploymentConfiguration
 - launchType
@@ -328,9 +328,9 @@ Other options for RunTask API are set by service attributes(CapacityProviderStra
 
 ## Deploy to Fargate
 
-If you want to deploy services to Fargate, task-definition and service-definition requires some settings.
+If you want to deploy services to Fargate, task definitions and service definitions require some settings.
 
-For task definition,
+For task definitions,
 
 - requiresCompatibilities (required "FARGATE")
 - networkMode (required "awsvpc")
@@ -497,17 +497,17 @@ $ ecspresso --config config.yaml diff
 
 ### verify
 
-Verify resources which related with service/task definitions.
+Verify resources related with service/task definitions.
 
 For example,
 - An ECS cluster exists.
-- The target groups in service definitions matches container name and port defined in task definition.
+- The target groups in service definitions match the container name and port defined in the definitions.
 - A task role and a task execution role exist and can be assumed by ecs-tasks.amazonaws.com.
-- Container images exist at URL defined in task definition. (Checks only for ECR or DockerHub public images.)
-- Secrets in task definition exist and be readable.
+- Container images exist at the URL defined in task definitions. (Checks only for ECR or DockerHub public images.)
+- Secrets in task definitions exist and be readable.
 - Can create log streams, can put messages to the streams in specified CloudWatch log groups.
 
-ecspresso verify tries to assume role to task execution role defined in task definition to verify these items. If failed to assume role, continue to verify with the current sessions.
+ecspresso verify tries to assume the task execution role defined in task definitions to verify these items. If failed to assume the role, it continues to verify with the current sessions.
 
 ```console
 $ ecspresso --config config.yaml verify
@@ -533,7 +533,7 @@ $ ecspresso --config config.yaml verify
 
 ### tasks
 
-task command lists tasks that run by a service or having the same family to a task definition.
+task command lists tasks run by a service or having the same family to a task definition.
 
 ```
 Flags:

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -129,10 +129,10 @@ func (d *App) DescribeServiceStatus(ctx context.Context, events int) (*ecs.Servi
 }
 
 func (d *App) describeAutoScaling(s *ecs.Service) error {
-	resouceId := fmt.Sprintf("service/%s/%s", arnToName(*s.ClusterArn), *s.ServiceName)
+	resourceId := fmt.Sprintf("service/%s/%s", arnToName(*s.ClusterArn), *s.ServiceName)
 	tout, err := d.autoScaling.DescribeScalableTargets(
 		&applicationautoscaling.DescribeScalableTargetsInput{
-			ResourceIds:       []*string{&resouceId},
+			ResourceIds:       []*string{&resourceId},
 			ServiceNamespace:  aws.String("ecs"),
 			ScalableDimension: aws.String("ecs:service:DesiredCount"),
 		},
@@ -157,7 +157,7 @@ func (d *App) describeAutoScaling(s *ecs.Service) error {
 
 	pout, err := d.autoScaling.DescribeScalingPolicies(
 		&applicationautoscaling.DescribeScalingPoliciesInput{
-			ResourceId:        &resouceId,
+			ResourceId:        &resourceId,
 			ServiceNamespace:  aws.String("ecs"),
 			ScalableDimension: aws.String("ecs:service:DesiredCount"),
 		},
@@ -653,11 +653,11 @@ func (d *App) Register(opt RegisterOption) error {
 }
 
 func (d *App) suspendAutoScaling(suspendState bool) error {
-	resouceId := fmt.Sprintf("service/%s/%s", d.Cluster, d.Service)
+	resourceId := fmt.Sprintf("service/%s/%s", d.Cluster, d.Service)
 
 	out, err := d.autoScaling.DescribeScalableTargets(
 		&applicationautoscaling.DescribeScalableTargetsInput{
-			ResourceIds:       []*string{&resouceId},
+			ResourceIds:       []*string{&resourceId},
 			ServiceNamespace:  aws.String("ecs"),
 			ScalableDimension: aws.String("ecs:service:DesiredCount"),
 		},
@@ -666,7 +666,7 @@ func (d *App) suspendAutoScaling(suspendState bool) error {
 		return errors.Wrap(err, "failed to describe scalable targets")
 	}
 	if len(out.ScalableTargets) == 0 {
-		d.Log(fmt.Sprintf("No scalable target for %s", resouceId))
+		d.Log(fmt.Sprintf("No scalable target for %s", resourceId))
 		return nil
 	}
 	for _, target := range out.ScalableTargets {

--- a/exec.go
+++ b/exec.go
@@ -68,7 +68,7 @@ func (d *App) Exec(opt ExecOption) error {
 		}
 		result, err := d.runFilter(buf, "container name")
 		if err != nil {
-			return errors.Wrap(err, "failed to exucute filter")
+			return errors.Wrap(err, "failed to execute filter")
 		}
 		targetContainer = aws.String(strings.Fields(string(result))[0])
 	}

--- a/verify.go
+++ b/verify.go
@@ -94,7 +94,7 @@ func (d *App) newAssumedVerifier(sess *session.Session, executionRole *string, o
 	})
 	if err != nil {
 		fmt.Println(
-			color.CyanString("INFO: failed to assume role to taskExecutuionRole. Continue to verifiy with current session. %s", err.Error()),
+			color.CyanString("INFO: failed to assume role to taskExecutionRole. Continue to verify with current session. %s", err.Error()),
 		)
 		return newVerifier(sess, sess, opt), nil
 	}


### PR DESCRIPTION
## About

タイポおよび(明らかな)文法ミスの修正です。

自分も普通に非ネイティヴなので、漏れているところがあったり、微妙なニュアンスの違いなどについては指摘できていないと思います。ゆえに明らかなものに限定しています。

### 大変素晴らしいツールで、より多くの人に使われて欲しいという気持ちからの修正提案になります

指摘箇所が多く、気分を害してしまったら申し訳ありません。
また、自分の英語力もあまり高くないので、お力になれる範囲が限定的なのが悔やまれます。

## タイポ

- `resouce` → `resource`
- `exucute` → `execute`
- `Executuion` → `Execution`
- `verifiy` → `verify`
- `faild` → `failed`
- `ths` → `the`
- `defferencies` → `differences`

## 文法

コードにコメントします