### PR TITLE
Add CapacityProviderStrategy in CodeDeploy AppSpec

### DIFF
--- a/appspec/spec.go
+++ b/appspec/spec.go
@@ -58,6 +58,15 @@ func NewWithService(sv *ecs.Service, tdArn string) (*AppSpec, error) {
 			},
 		}
 	}
+	if sv.CapacityProviderStrategy != nil {
+		for _, strategy := range sv.CapacityProviderStrategy {
+			resource.TargetService.Properties.CapacityProviderStrategy = append(resource.TargetService.Properties.CapacityProviderStrategy, &CapacityProviderStrategy{
+				CapacityProvider: strategy.CapacityProvider,
+				Base:             strategy.Base,
+				Weight:           strategy.Weight,
+			})
+		}
+	}
 	spec.Resources = append(spec.Resources, resource)
 	return spec, nil
 }
@@ -72,10 +81,11 @@ type TargetService struct {
 }
 
 type Properties struct {
-	TaskDefinition       *string               `yaml:"TaskDefinition,omitempty"`
-	LoadBalancerInfo     *LoadBalancerInfo     `yaml:"LoadBalancerInfo,omitempty"`
-	PlatformVersion      *string               `yaml:"PlatformVersion,omitempty"`
-	NetworkConfiguration *NetworkConfiguration `yaml:"NetworkConfiguration,omitempty"`
+	TaskDefinition           *string                     `yaml:"TaskDefinition,omitempty"`
+	LoadBalancerInfo         *LoadBalancerInfo           `yaml:"LoadBalancerInfo,omitempty"`
+	PlatformVersion          *string                     `yaml:"PlatformVersion,omitempty"`
+	NetworkConfiguration     *NetworkConfiguration       `yaml:"NetworkConfiguration,omitempty"`
+	CapacityProviderStrategy []*CapacityProviderStrategy `yaml:"CapacityProviderStrategy,omitempty"`
 }
 
 type LoadBalancerInfo struct {
@@ -91,6 +101,12 @@ type AwsVpcConfiguration struct {
 	AssignPublicIp *string   `yaml:"AssignPublicIp,omitempty"`
 	SecurityGroups []*string `yaml:"SecurityGroups,omitempty"`
 	Subnets        []*string `yaml:"Subnets,omitempty"`
+}
+
+type CapacityProviderStrategy struct {
+	CapacityProvider *string `yaml:"CapacityProvider,omitempty""`
+	Base             *int64  `yaml:"Base,omitempty"`
+	Weight           *int64  `yaml:"Weight,omitempty"`
 }
 
 type Hook struct {

--- a/appspec/spec_test.go
+++ b/appspec/spec_test.go
@@ -34,6 +34,18 @@ var expected = &appspec.AppSpec{
 							AssignPublicIp: aws.String("ENABLED"),
 						},
 					},
+					CapacityProviderStrategy: []*appspec.CapacityProviderStrategy{
+						{
+							CapacityProvider: aws.String("FARGATE_SPOT"),
+							Base: aws.Int64(1),
+							Weight: aws.Int64(2),
+						},
+						{
+							CapacityProvider: aws.String("FARGATE"),
+							Base: aws.Int64(0),
+							Weight: aws.Int64(1),
+						},
+					},
 				},
 			},
 		},

--- a/appspec/test.yml
+++ b/appspec/test.yml
@@ -14,6 +14,13 @@ Resources:
             Subnets: ["subnet-1234abcd", "subnet-5678abcd"]
             SecurityGroups: ["sg-12345678"]
             AssignPublicIp: "ENABLED"
+        CapacityProviderStrategy:
+          - Base: 1
+            CapacityProvider: "FARGATE_SPOT"
+            Weight: 2
+          - Base: 0
+            CapacityProvider: "FARGATE"
+            Weight: 1
 Hooks:
   - BeforeInstall: "LambdaFunctionToValidateBeforeInstall"
   - AfterInstall: "LambdaFunctionToValidateAfterTraffic"


### PR DESCRIPTION
Including the capacity provider strategy in the AppSpec file, I can use a Blue-Green Deployment for ECS with the Capacity Provider enabled via CodeDeploy.

AppSpec file's example
https://docs.aws.amazon.com/codedeploy/latest/userguide/reference-appspec-file-structure-resources.html#reference-appspec-file-structure-resources-ecs

refs: https://github.com/aws/containers-roadmap/issues/713