### PR TITLE
add an option to deregister the task definition on the deploy command

### DIFF
--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -35,39 +35,42 @@ func _main() int {
 	deploy := kingpin.Command("deploy", "deploy service")
 	deploy.Flag("resume-auto-scaling", "resume application auto-scaling attached with the ECS service").IsSetByUser(&isSetResumeAutoScaling).Bool()
 	deployOption := ecspresso.DeployOption{
-		DryRun:               deploy.Flag("dry-run", "dry-run").Bool(),
-		DesiredCount:         deploy.Flag("tasks", "desired count of tasks").Default("-1").Int64(),
-		SkipTaskDefinition:   deploy.Flag("skip-task-definition", "skip register a new task definition").Bool(),
-		ForceNewDeployment:   deploy.Flag("force-new-deployment", "force a new deployment of the service").Bool(),
-		NoWait:               deploy.Flag("no-wait", "exit ecspresso immediately after just deployed without waiting for service stable").Bool(),
-		SuspendAutoScaling:   deploy.Flag("suspend-auto-scaling", "suspend application auto-scaling attached with the ECS service").IsSetByUser(&isSetSuspendAutoScaling).Bool(),
-		RollbackEvents:       deploy.Flag("rollback-events", " roll back when specified events happened (DEPLOYMENT_FAILURE,DEPLOYMENT_STOP_ON_ALARM,DEPLOYMENT_STOP_ON_REQUEST,...) CodeDeploy only.").String(),
-		UpdateService:        deploy.Flag("update-service", "update service attributes by service definition").Default("true").Bool(),
-		LatestTaskDefinition: deploy.Flag("latest-task-definition", "deploy with latest task definition without registering new task definition").Default("false").Bool(),
+		DryRun:                   deploy.Flag("dry-run", "dry-run").Bool(),
+		DesiredCount:             deploy.Flag("tasks", "desired count of tasks").Default("-1").Int64(),
+		SkipTaskDefinition:       deploy.Flag("skip-task-definition", "skip register a new task definition").Bool(),
+		DeregisterTaskDefinition: deploy.Flag("latest-task-definition", "deregister the old revision of task definitions after the deployment").Default("false").Bool(),
+		ForceNewDeployment:       deploy.Flag("force-new-deployment", "force a new deployment of the service").Bool(),
+		NoWait:                   deploy.Flag("no-wait", "exit ecspresso immediately after just deployed without waiting for service stable").Bool(),
+		SuspendAutoScaling:       deploy.Flag("suspend-auto-scaling", "suspend application auto-scaling attached with the ECS service").IsSetByUser(&isSetSuspendAutoScaling).Bool(),
+		RollbackEvents:           deploy.Flag("rollback-events", " roll back when specified events happened (DEPLOYMENT_FAILURE,DEPLOYMENT_STOP_ON_ALARM,DEPLOYMENT_STOP_ON_REQUEST,...) CodeDeploy only.").String(),
+		UpdateService:            deploy.Flag("update-service", "update service attributes by service definition").Default("true").Bool(),
+		LatestTaskDefinition:     deploy.Flag("latest-task-definition", "deploy with latest task definition without registering new task definition").Default("false").Bool(),
 	}
 
 	scale := kingpin.Command("scale", "scale service. equivalent to deploy --skip-task-definition --no-update-service")
 	scale.Flag("resume-auto-scaling", "resume application auto-scaling attached with the ECS service").IsSetByUser(&isSetResumeAutoScaling).Bool()
 	scaleOption := ecspresso.DeployOption{
-		DryRun:               scale.Flag("dry-run", "dry-run").Bool(),
-		DesiredCount:         scale.Flag("tasks", "desired count of tasks").Default("-1").Int64(),
-		SkipTaskDefinition:   boolp(true),
-		SuspendAutoScaling:   scale.Flag("suspend-auto-scaling", "suspend application auto-scaling attached with the ECS service").IsSetByUser(&isSetSuspendAutoScaling).Bool(),
-		ForceNewDeployment:   boolp(false),
-		NoWait:               scale.Flag("no-wait", "exit ecspresso immediately after just deployed without waiting for service stable").Bool(),
-		UpdateService:        boolp(false),
-		LatestTaskDefinition: boolp(false),
+		DryRun:                   scale.Flag("dry-run", "dry-run").Bool(),
+		DesiredCount:             scale.Flag("tasks", "desired count of tasks").Default("-1").Int64(),
+		SkipTaskDefinition:       boolp(true),
+		DeregisterTaskDefinition: boolp(false),
+		SuspendAutoScaling:       scale.Flag("suspend-auto-scaling", "suspend application auto-scaling attached with the ECS service").IsSetByUser(&isSetSuspendAutoScaling).Bool(),
+		ForceNewDeployment:       boolp(false),
+		NoWait:                   scale.Flag("no-wait", "exit ecspresso immediately after just deployed without waiting for service stable").Bool(),
+		UpdateService:            boolp(false),
+		LatestTaskDefinition:     boolp(false),
 	}
 
 	refresh := kingpin.Command("refresh", "refresh service. equivalent to deploy --skip-task-definition --force-new-deployment --no-update-service")
 	refreshOption := ecspresso.DeployOption{
-		DryRun:               refresh.Flag("dry-run", "dry-run").Bool(),
-		DesiredCount:         nil,
-		SkipTaskDefinition:   boolp(true),
-		ForceNewDeployment:   boolp(true),
-		NoWait:               refresh.Flag("no-wait", "exit ecspresso immediately after just deployed without waiting for service stable").Bool(),
-		UpdateService:        boolp(false),
-		LatestTaskDefinition: boolp(false),
+		DryRun:                   refresh.Flag("dry-run", "dry-run").Bool(),
+		DesiredCount:             nil,
+		SkipTaskDefinition:       boolp(true),
+		DeregisterTaskDefinition: boolp(false),
+		ForceNewDeployment:       boolp(true),
+		NoWait:                   refresh.Flag("no-wait", "exit ecspresso immediately after just deployed without waiting for service stable").Bool(),
+		UpdateService:            boolp(false),
+		LatestTaskDefinition:     boolp(false),
 	}
 
 	create := kingpin.Command("create", "create service")

--- a/options.go
+++ b/options.go
@@ -36,15 +36,16 @@ func (opt CreateOption) DryRunString() string {
 }
 
 type DeployOption struct {
-	DryRun               *bool
-	DesiredCount         *int64
-	SkipTaskDefinition   *bool
-	ForceNewDeployment   *bool
-	NoWait               *bool
-	SuspendAutoScaling   *bool
-	RollbackEvents       *string
-	UpdateService        *bool
-	LatestTaskDefinition *bool
+	DryRun                   *bool
+	DeregisterTaskDefinition *bool
+	DesiredCount             *int64
+	SkipTaskDefinition       *bool
+	ForceNewDeployment       *bool
+	NoWait                   *bool
+	SuspendAutoScaling       *bool
+	RollbackEvents           *string
+	UpdateService            *bool
+	LatestTaskDefinition     *bool
 }
 
 func (opt DeployOption) getDesiredCount() *int64 {

--- a/rollback.go
+++ b/rollback.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/pkg/errors"
 )
 
@@ -58,19 +57,8 @@ func (d *App) Rollback(opt RollbackOption) error {
 
 	d.Log("Service is stable now. Completed!")
 
-	if *opt.DeregisterTaskDefinition {
-		d.Log("Deregistering the rolled-back task definition", arnToName(currentArn))
-		_, err := d.ecs.DeregisterTaskDefinitionWithContext(
-			ctx,
-			&ecs.DeregisterTaskDefinitionInput{
-				TaskDefinition: &currentArn,
-			},
-		)
-		if err != nil {
-			return errors.Wrap(err, "failed to deregister task definition")
-		}
-		d.Log(arnToName(currentArn), "was deregistered successfully")
-	}
-
-	return nil
+	return d.deregisterTaskDefinition(ctx, currentArn, DeployOption{
+		DeregisterTaskDefinition: opt.DeregisterTaskDefinition,
+		SkipTaskDefinition:       aws.Bool(false),
+	})
 }


### PR DESCRIPTION
deploy コマンドでもタスク定義の登録解除をオプションで自動化できたら嬉しいなぁと思っています。

モチベーションは完全に Terraform の挙動です。
Terraform でタスク定義を更新すると（changesではなくadd and destroy になるので）[destroy 用のフック](
https://github.com/hashicorp/terraform-provider-aws/blob/7577840b7453a36f075f53c00199b2e207fe9a1f/aws/resource_aws_ecs_task_definition.go#L649-L662)が走って登録解除されます。なおTerraform には stable になるまで待つなんてオプションはないので、同様に待機オプションをつけなくても解除できる仕様にしています。

コード的に気に入らないところや抜け漏れ・ミスがあればコミットを積んでいただいて構いません 🙌