### PR TITLE
warn unknown fields in task/service definition JSON.

### DIFF
--- a/ecspresso.go
+++ b/ecspresso.go
@@ -612,9 +612,7 @@ func (d *App) unmarshalJSON(src []byte, v interface{}, path string) error {
 		)
 		// unknown field -> try lax decoder
 		lax := json.NewDecoder(bytes.NewReader(src))
-		if err := lax.Decode(&v); err != nil {
-			return err
-		}
+		return lax.Decode(&v)
 	}
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/google/go-cmp v0.5.6
 	github.com/hashicorp/go-envparse v0.0.0-20200406174449-d9cfd743a15e
 	github.com/hashicorp/go-version v1.3.0
-	github.com/kayac/go-config v0.5.1
+	github.com/kayac/go-config v0.6.0
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-isatty v0.0.13
 	github.com/morikuni/aec v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -233,8 +233,8 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfC
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1 h1:6QPYqodiu3GuPL+7mfx+NwDdp2eTkp9IfEUpgAwUN0o=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
-github.com/kayac/go-config v0.5.1 h1:TbqadCm/HQeXtTJ6WnozpldBtm8KKfucPM+5tL/KCP8=
-github.com/kayac/go-config v0.5.1/go.mod h1:5C4ZN+sMjYpEX0bi+AcgF6g0hZYVdzZiV16TEyzAzfk=
+github.com/kayac/go-config v0.6.0 h1:Y4l9tsWrUCvT1id8tbO4aT4SdGxbYqd8lqSe5l1GrK0=
+github.com/kayac/go-config v0.6.0/go.mod h1:5C4ZN+sMjYpEX0bi+AcgF6g0hZYVdzZiV16TEyzAzfk=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=

--- a/tests/td.json
+++ b/tests/td.json
@@ -1,6 +1,5 @@
 {
   "taskDefinition": {
-    "status": "ACTIVE",
     "networkMode": "awsvpc",
     "family": "katsubushi",
     "placementConstraints": [],
@@ -55,7 +54,6 @@
         "volumesFrom": []
       }
     ],
-    "revision": 1,
     "cpu": "1024",
     "memory": "2048",
     "proxyConfiguration": {


### PR DESCRIPTION
This PR enables to output a warning of unable to map an SDK struct field from task or service definition JSON.

For example, 
```
WARNING: json: unknown field "status" in tests/td-plain.json
```

This is useful to find a typo in JSON.
