### PR TITLE
Add deregister and revisions command

### DIFF
--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -93,7 +93,7 @@ func _main() int {
 	delete := kingpin.Command("delete", "delete service")
 	deleteOption := ecspresso.DeleteOption{
 		DryRun: delete.Flag("dry-run", "dry-run").Bool(),
-		Force:  delete.Flag("force", "force delete. not confirm").Bool(),
+		Force:  delete.Flag("force", "delete without confirmation").Bool(),
 	}
 
 	run := kingpin.Command("run", "run task")
@@ -121,7 +121,9 @@ func _main() int {
 	deregister := kingpin.Command("deregister", "deregister task definition")
 	deregisterOption := ecspresso.DeregisterOption{
 		DryRun:   deregister.Flag("dry-run", "dry-run").Bool(),
-		Revision: deregister.Flag("revision", "revision").Required().Int64(),
+		Revision: deregister.Flag("revision", "revision").Int64(),
+		Keeps:    deregister.Flag("keeps", "numbers to keep latest revisions").Int(),
+		Force:    deregister.Flag("force", "deregister without confirmation").Bool(),
 	}
 
 	_ = kingpin.Command("wait", "wait until service stable")
@@ -165,7 +167,7 @@ func _main() int {
 		Output: tasks.Flag("output", "output format (table|json|tsv)").Default("table").Enum("table", "json", "tsv"),
 		Find:   tasks.Flag("find", "find a task from tasks list and dump it as JSON").Bool(),
 		Stop:   tasks.Flag("stop", "stop a task").Bool(),
-		Force:  tasks.Flag("force", "stop a task without confirmation prompt").Bool(),
+		Force:  tasks.Flag("force", "stop a task without confirmation").Bool(),
 	}
 
 	exec := kingpin.Command("exec", "execute command in a task")

--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -122,8 +122,14 @@ func _main() int {
 	deregisterOption := ecspresso.DeregisterOption{
 		DryRun:   deregister.Flag("dry-run", "dry-run").Bool(),
 		Revision: deregister.Flag("revision", "revision").Int64(),
-		Keeps:    deregister.Flag("keeps", "numbers to keep latest revisions except in-use revisions").Int(),
+		Keeps:    deregister.Flag("keeps", "numbers of keep latest revisions except in-use").Int(),
 		Force:    deregister.Flag("force", "deregister without confirmation").Bool(),
+	}
+
+	revisions := kingpin.Command("revisions", "show revisions of task definitions")
+	revisionsOption := ecspresso.RevisionsOption{
+		Output:   revisions.Flag("output", "output format (table|json|tsv)").Default("table").Enum("table", "json", "tsv"),
+		Revision: revisions.Flag("revision", "revision number to output task definition as JSON").Int64(),
 	}
 
 	_ = kingpin.Command("wait", "wait until service stable")
@@ -257,6 +263,8 @@ func _main() int {
 		err = app.Register(registerOption)
 	case "deregister":
 		err = app.Deregister(deregisterOption)
+	case "revisions":
+		err = app.Revesions(revisionsOption)
 	case "init":
 		err = app.Init(initOption)
 	case "diff":

--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -122,7 +122,7 @@ func _main() int {
 	deregisterOption := ecspresso.DeregisterOption{
 		DryRun:   deregister.Flag("dry-run", "dry-run").Bool(),
 		Revision: deregister.Flag("revision", "revision").Int64(),
-		Keeps:    deregister.Flag("keeps", "numbers to keep latest revisions").Int(),
+		Keeps:    deregister.Flag("keeps", "numbers to keep latest revisions except in-use revisions").Int(),
 		Force:    deregister.Flag("force", "deregister without confirmation").Bool(),
 	}
 

--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -121,7 +121,7 @@ func _main() int {
 	deregister := kingpin.Command("deregister", "deregister task definition")
 	deregisterOption := ecspresso.DeregisterOption{
 		DryRun:   deregister.Flag("dry-run", "dry-run").Bool(),
-		Revision: deregister.Flag("revision", "revision").Int64(),
+		Revision: deregister.Flag("revision", "revision number to deregister").Int64(),
 		Keeps:    deregister.Flag("keeps", "numbers of keep latest revisions except in-use").Int(),
 		Force:    deregister.Flag("force", "deregister without confirmation").Bool(),
 	}

--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -118,6 +118,12 @@ func _main() int {
 		Output: register.Flag("output", "output registered task definition").Bool(),
 	}
 
+	deregister := kingpin.Command("deregister", "deregister task definition")
+	deregisterOption := ecspresso.DeregisterOption{
+		DryRun:   deregister.Flag("dry-run", "dry-run").Bool(),
+		Revision: deregister.Flag("revision", "revision").Required().Int64(),
+	}
+
 	_ = kingpin.Command("wait", "wait until service stable")
 	waitOption := ecspresso.WaitOption{}
 
@@ -247,6 +253,8 @@ func _main() int {
 		err = app.Wait(waitOption)
 	case "register":
 		err = app.Register(registerOption)
+	case "deregister":
+		err = app.Deregister(deregisterOption)
 	case "init":
 		err = app.Init(initOption)
 	case "diff":

--- a/deregister.go
+++ b/deregister.go
@@ -60,7 +60,7 @@ func (d *App) Deregister(opt DeregisterOption) error {
 	} else if aws.IntValue(opt.Keeps) > 0 {
 		return d.deregisterKeeps(ctx, opt, inUse)
 	}
-	return nil
+	return errors.New("--revision or --keeps required")
 }
 
 func (d *App) deregiserRevision(ctx context.Context, opt DeregisterOption, inUse map[string]string) error {

--- a/deregister.go
+++ b/deregister.go
@@ -3,16 +3,21 @@ package ecspresso
 import (
 	"context"
 	"fmt"
+	"strings"
+	"time"
 
+	"github.com/Songmu/prompter"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/pkg/errors"
 )
 
 type DeregisterOption struct {
 	DryRun   *bool
-	Keeps    *int64
+	Keeps    *int
 	Revision *int64
+	Force    *bool
 }
 
 func (opt DeregisterOption) DryRunString() string {
@@ -26,32 +31,146 @@ func (d *App) Deregister(opt DeregisterOption) error {
 	ctx, cancel := d.Start()
 	defer cancel()
 	d.Log("Starting deregister task definition", opt.DryRunString())
+	inUse := make(map[string]bool)
 
-	if opt.Revision != nil {
-		return d.deregiserRevision(ctx, opt)
+	if d.config.Service != "" {
+		sv, err := d.DescribeService(ctx)
+		if err != nil {
+			return err
+		}
+		for _, dp := range sv.Deployments {
+			name, _ := taskDefinitionToName(*dp.TaskDefinition)
+			inUse[name] = true
+			d.DebugLog(fmt.Sprintf("%s is in use by deployments", name))
+		}
+	}
+
+	tasks, err := d.listTasks(ctx, nil)
+	if err != nil {
+		return err
+	}
+	for _, task := range tasks {
+		name, _ := taskDefinitionToName(*task.TaskDefinitionArn)
+		inUse[name] = true
+		d.DebugLog(fmt.Sprintf("%s is in use by tasks", name))
+	}
+
+	if aws.Int64Value(opt.Revision) > 0 {
+		return d.deregiserRevision(ctx, opt, inUse)
+	} else if aws.IntValue(opt.Keeps) > 0 {
+		return d.deregisterKeeps(ctx, opt, inUse)
 	}
 	return nil
 }
 
-func (d *App) deregiserRevision(ctx context.Context, opt DeregisterOption) error {
+func (d *App) deregiserRevision(ctx context.Context, opt DeregisterOption, inUse map[string]bool) error {
 	td, err := d.LoadTaskDefinition(d.config.TaskDefinitionPath)
 	if err != nil {
 		return errors.Wrap(err, "failed to load task definition")
 	}
 	name := fmt.Sprintf("%s:%d", aws.StringValue(td.Family), aws.Int64Value(opt.Revision))
 
+	if inUse[name] {
+		return errors.Errorf("%s is in use", name)
+	}
+
 	if aws.BoolValue(opt.DryRun) {
 		d.Log(fmt.Sprintf("task definition %s will be deregistered", name))
 		d.Log("DRY RUN OK")
 		return nil
 	}
-
-	d.Log(fmt.Sprintf("Deregistring %s", name))
-	if _, err := d.ecs.DeregisterTaskDefinitionWithContext(ctx, &ecs.DeregisterTaskDefinitionInput{
-		TaskDefinition: aws.String(name),
-	}); err != nil {
-		return errors.Wrap(err, "failed to deregister task definition")
+	if aws.BoolValue(opt.Force) || prompter.YesNo(fmt.Sprintf("Deregister %s ?", name), false) {
+		d.Log(fmt.Sprintf("Deregistring %s", name))
+		if _, err := d.ecs.DeregisterTaskDefinitionWithContext(ctx, &ecs.DeregisterTaskDefinitionInput{
+			TaskDefinition: aws.String(name),
+		}); err != nil {
+			return errors.Wrap(err, "failed to deregister task definition")
+		}
+		d.Log(fmt.Sprintf("%s was deregistered successfully", name))
+	} else {
+		d.Log("Aborted")
+		return errors.New("confirmation failed")
 	}
-	d.Log(fmt.Sprintf("task definition %s is deregistered successfully", name))
 	return nil
+}
+
+func (d *App) deregisterKeeps(ctx context.Context, opt DeregisterOption, inUse map[string]bool) error {
+	keeps := aws.IntValue(opt.Keeps)
+	td, err := d.LoadTaskDefinition(d.config.TaskDefinitionPath)
+	if err != nil {
+		return errors.Wrap(err, "failed to load task definition")
+	}
+	names := []string{}
+	var nextToken *string
+	for {
+		res, err := d.ecs.ListTaskDefinitionsWithContext(ctx, &ecs.ListTaskDefinitionsInput{
+			FamilyPrefix: td.Family,
+			NextToken:    nextToken,
+		})
+		if err != nil {
+			return errors.Wrap(err, "failed to list task definitions")
+		}
+		for _, a := range res.TaskDefinitionArns {
+			name, err := taskDefinitionToName(*a)
+			if err != nil {
+				continue
+			}
+			if inUse[name] {
+				d.Log(fmt.Sprintf("%s is in use. skip", name))
+			} else {
+				d.DebugLog(fmt.Sprintf("%s mark to deregister", name))
+				names = append(names, name)
+			}
+		}
+		if nextToken = res.NextToken; nextToken == nil {
+			break
+		}
+	}
+
+	deregs := []string{}
+	idx := len(names) - keeps
+	if idx <= 0 {
+		d.Log("No need to deregister task definitions")
+		return nil
+	}
+	for i, name := range names {
+		if i < idx {
+			d.Log(fmt.Sprintf("%s will be deregistered", name))
+			deregs = append(deregs, name)
+		}
+	}
+	if aws.BoolValue(opt.DryRun) {
+		d.Log("DRY RUN OK")
+		return nil
+	}
+
+	deregistered := 0
+	if aws.BoolValue(opt.Force) || prompter.YesNo(fmt.Sprintf("Deregister %d revisons?", len(deregs)), false) {
+		for _, name := range deregs {
+			d.Log(fmt.Sprintf("Deregistring %s", name))
+			if _, err := d.ecs.DeregisterTaskDefinitionWithContext(ctx, &ecs.DeregisterTaskDefinitionInput{
+				TaskDefinition: aws.String(name),
+			}); err != nil {
+				return errors.Wrap(err, "failed to deregister task definition")
+			}
+			d.Log(fmt.Sprintf("%s was deregistered successfully", name))
+			time.Sleep(time.Second)
+			deregistered++
+		}
+	} else {
+		d.Log("Aborted")
+		return errors.New("confirmation failed")
+	}
+	d.Log(fmt.Sprintf("%d task definitions were deregistered", deregistered))
+
+	return nil
+}
+
+func taskDefinitionToName(a string) (string, error) {
+	an, err := arn.Parse(a)
+	if err != nil {
+		return "", err
+	}
+	n := strings.SplitN(an.Resource, "/", 2)
+	return n[1], nil
 }

--- a/deregister.go
+++ b/deregister.go
@@ -1,0 +1,57 @@
+package ecspresso
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/pkg/errors"
+)
+
+type DeregisterOption struct {
+	DryRun   *bool
+	Keeps    *int64
+	Revision *int64
+}
+
+func (opt DeregisterOption) DryRunString() string {
+	if *opt.DryRun {
+		return dryRunStr
+	}
+	return ""
+}
+
+func (d *App) Deregister(opt DeregisterOption) error {
+	ctx, cancel := d.Start()
+	defer cancel()
+	d.Log("Starting deregister task definition", opt.DryRunString())
+
+	if opt.Revision != nil {
+		return d.deregiserRevision(ctx, opt)
+	}
+	return nil
+}
+
+func (d *App) deregiserRevision(ctx context.Context, opt DeregisterOption) error {
+	td, err := d.LoadTaskDefinition(d.config.TaskDefinitionPath)
+	if err != nil {
+		return errors.Wrap(err, "failed to load task definition")
+	}
+	name := fmt.Sprintf("%s:%d", aws.StringValue(td.Family), aws.Int64Value(opt.Revision))
+
+	if aws.BoolValue(opt.DryRun) {
+		d.Log(fmt.Sprintf("task definition %s will be deregistered", name))
+		d.Log("DRY RUN OK")
+		return nil
+	}
+
+	d.Log(fmt.Sprintf("Deregistring %s", name))
+	if _, err := d.ecs.DeregisterTaskDefinitionWithContext(ctx, &ecs.DeregisterTaskDefinitionInput{
+		TaskDefinition: aws.String(name),
+	}); err != nil {
+		return errors.Wrap(err, "failed to deregister task definition")
+	}
+	d.Log(fmt.Sprintf("task definition %s is deregistered successfully", name))
+	return nil
+}

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -650,33 +650,6 @@ func (d *App) GetLogInfo(task *ecs.Task, c *ecs.ContainerDefinition) (string, st
 	return logGroup, logStream
 }
 
-func (d *App) Register(opt RegisterOption) error {
-	ctx, cancel := d.Start()
-	defer cancel()
-
-	d.Log("Starting register task definition", opt.DryRunString())
-	td, err := d.LoadTaskDefinition(d.config.TaskDefinitionPath)
-	if err != nil {
-		return errors.Wrap(err, "failed to load task definition")
-	}
-	if *opt.DryRun {
-		d.Log("task definition:")
-		d.LogJSON(td)
-		d.Log("DRY RUN OK")
-		return nil
-	}
-
-	newTd, err := d.RegisterTaskDefinition(ctx, td)
-	if err != nil {
-		return errors.Wrap(err, "failed to register task definition")
-	}
-
-	if *opt.Output {
-		d.LogJSON(newTd)
-	}
-	return nil
-}
-
 func (d *App) suspendAutoScaling(suspendState bool) error {
 	resourceId := fmt.Sprintf("service/%s/%s", d.Cluster, d.Service)
 

--- a/options.go
+++ b/options.go
@@ -143,18 +143,6 @@ func parseTags(s string) ([]*ecs.Tag, error) {
 type WaitOption struct {
 }
 
-type RegisterOption struct {
-	DryRun *bool
-	Output *bool
-}
-
-func (opt RegisterOption) DryRunString() string {
-	if *opt.DryRun {
-		return dryRunStr
-	}
-	return ""
-}
-
 type InitOption struct {
 	Region                *string
 	Cluster               *string

--- a/register.go
+++ b/register.go
@@ -1,0 +1,42 @@
+package ecspresso
+
+import "github.com/pkg/errors"
+
+type RegisterOption struct {
+	DryRun *bool
+	Output *bool
+}
+
+func (opt RegisterOption) DryRunString() string {
+	if *opt.DryRun {
+		return dryRunStr
+	}
+	return ""
+}
+
+func (d *App) Register(opt RegisterOption) error {
+	ctx, cancel := d.Start()
+	defer cancel()
+
+	d.Log("Starting register task definition", opt.DryRunString())
+	td, err := d.LoadTaskDefinition(d.config.TaskDefinitionPath)
+	if err != nil {
+		return errors.Wrap(err, "failed to load task definition")
+	}
+	if *opt.DryRun {
+		d.Log("task definition:")
+		d.LogJSON(td)
+		d.Log("DRY RUN OK")
+		return nil
+	}
+
+	newTd, err := d.RegisterTaskDefinition(ctx, td)
+	if err != nil {
+		return errors.Wrap(err, "failed to register task definition")
+	}
+
+	if *opt.Output {
+		d.LogJSON(newTd)
+	}
+	return nil
+}

--- a/revisions.go
+++ b/revisions.go
@@ -1,0 +1,129 @@
+package ecspresso
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/olekukonko/tablewriter"
+	"github.com/pkg/errors"
+)
+
+type RevisionsOption struct {
+	Revision *int64
+	Output   *string
+}
+
+type revision struct {
+	Name  string `json:"name"`
+	InUse string `json:"in_use"`
+}
+
+func (rev revision) Cols() []string {
+	return []string{rev.Name, rev.InUse}
+}
+
+type revisions []revision
+
+func (revs revisions) OutputJSON(w io.Writer) error {
+	b, err := MarshalJSON(revs)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(b)
+	return err
+}
+
+func (revs revisions) Header() []string {
+	return []string{"Name", "In Use"}
+}
+
+func (revs revisions) OutputTSV(w io.Writer) error {
+	for _, rev := range revs {
+		_, err := fmt.Fprintln(w, strings.Join([]string{rev.Name, rev.InUse}, "\t"))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (revs revisions) OutputTable(w io.Writer) error {
+	t := tablewriter.NewWriter(w)
+	t.SetHeader(revs.Header())
+	t.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
+	for _, rev := range revs {
+		t.Append(rev.Cols())
+	}
+	t.Render()
+	return nil
+}
+
+func (d *App) Revesions(opt RevisionsOption) error {
+	ctx, cancel := d.Start()
+	defer cancel()
+
+	inUse, err := d.inUseRevisions(ctx)
+	if err != nil {
+		return err
+	}
+
+	td, err := d.LoadTaskDefinition(d.config.TaskDefinitionPath)
+	if err != nil {
+		return errors.Wrap(err, "failed to load task definition")
+	}
+
+	if r := aws.Int64Value(opt.Revision); r > 0 {
+		name := fmt.Sprintf("%s:%d", aws.StringValue(td.Family), r)
+		res, err := d.ecs.DescribeTaskDefinitionWithContext(ctx, &ecs.DescribeTaskDefinitionInput{
+			TaskDefinition: &name,
+			Include:        []*string{aws.String("TAGS")},
+		})
+		if err != nil {
+			return errors.Wrap(err, "failed to describe task definition")
+		}
+		b, err := MarshalJSON(res.TaskDefinition)
+		if err != nil {
+			return err
+		}
+		_, err = os.Stdout.Write(b)
+		return err
+	}
+
+	revs := revisions{}
+	var nextToken *string
+	for {
+		res, err := d.ecs.ListTaskDefinitionsWithContext(ctx, &ecs.ListTaskDefinitionsInput{
+			FamilyPrefix: td.Family,
+			NextToken:    nextToken,
+		})
+		if err != nil {
+			return errors.Wrap(err, "failed to list task definitions")
+		}
+		for _, a := range res.TaskDefinitionArns {
+			name, err := taskDefinitionToName(*a)
+			if err != nil {
+				continue
+			}
+			revs = append(revs, revision{
+				Name:  name,
+				InUse: inUse[name],
+			})
+		}
+		if nextToken = res.NextToken; nextToken == nil {
+			break
+		}
+	}
+	switch aws.StringValue(opt.Output) {
+	case "json":
+		revs.OutputJSON(os.Stdout)
+	case "table":
+		revs.OutputTable(os.Stdout)
+	case "tsv":
+		revs.OutputTSV(os.Stdout)
+	}
+	return nil
+}


### PR DESCRIPTION
Add deregister command to deregister task definitions.
Add revisions command to list / describe task definition revisions.

```
usage: ecspresso deregister [<flags>]

deregister task definition

Flags:
  --help                    Show context-sensitive help (also try --help-long and
                            --help-man).
  --config="ecspresso.yml"  config file
  --debug                   enable debug log
  --envfile=ENVFILE ...     environment files
  --color                   enable colored output
  --dry-run                 dry-run
  --revision=REVISION       revision
  --keeps=KEEPS             numbers of keep latest revisions except in-use
  --force                   deregister without confirmation
```

```
usage: ecspresso revisions [<flags>]

show revisions of task definitions

Flags:
  --help                    Show context-sensitive help (also try --help-long and
                            --help-man).
  --config="ecspresso.yml"  config file
  --debug                   enable debug log
  --envfile=ENVFILE ...     environment files
  --color                   enable colored output
  --output=table            output format (table|json|tsv)
  --revision=REVISION       revision number to output task definition as JSON
```