### PR TITLE
Windows containers support. Update to aws-sdk-go-v1.14.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/Songmu/prompter v0.5.0
 	github.com/alecthomas/kingpin v1.3.8-0.20190930021037-0a108b7f5563
-	github.com/aws/aws-sdk-go v1.40.28
+	github.com/aws/aws-sdk-go v1.41.13
 	github.com/fatih/color v1.12.0
 	github.com/fujiwara/cfn-lookup v0.0.2
 	github.com/fujiwara/tfstate-lookup v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -90,8 +90,9 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2cI+DC1Mbh0TJxzA3RcLoMsFw+aXw7E=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/aws/aws-sdk-go v1.36.15/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
-github.com/aws/aws-sdk-go v1.40.28 h1:IWzkX36BHx9R4jYd5y8NAudk8sxUeJHHohZgPI9kq/A=
 github.com/aws/aws-sdk-go v1.40.28/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
+github.com/aws/aws-sdk-go v1.41.13 h1:wGgr6jkHdGExF33phfOqijFq7ZF+h7a6FXvJc77GpTc=
+github.com/aws/aws-sdk-go v1.41.13/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=

--- a/tests/ci/ecs-task-def.jsonnet
+++ b/tests/ci/ecs-task-def.jsonnet
@@ -4,13 +4,14 @@
       cpu: 1024,
       environment: [],
       essential: true,
-      image: 'nginx:{{ env `NGINX_VERSION` `latest` }}',
+#      image: 'nginx:{{ env `NGINX_VERSION` `latest` }}',
+      image: 'mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2019',
       logConfiguration: {
         logDriver: 'awslogs',
         options: {
           'awslogs-group': 'ecspresso-test',
           'awslogs-region': 'ap-northeast-1',
-          'awslogs-stream-prefix': 'nginx',
+          'awslogs-stream-prefix': 'windows',
         },
       },
       mountPoints: [],
@@ -38,34 +39,16 @@
       ],
       volumesFrom: [],
     },
-    {
-      essential: true,
-      image: 'debian:buster-slim',
-      logConfiguration: {
-        logDriver: 'awslogs',
-        options: {
-          'awslogs-group': 'ecspresso-test',
-          'awslogs-region': 'ap-northeast-1',
-          'awslogs-stream-prefix': 'bash',
-        },
-      },
-      name: 'bash',
-      command: [
-        'tail',
-        '-f',
-        '/dev/null',
-      ],
-    },
   ],
-  cpu: '256',
-  ephemeralStorage: {
-    sizeInGiB: 50,
-  },
+  cpu: '1024',
   executionRoleArn: 'arn:aws:iam::{{must_env `AWS_ACCOUNT_ID`}}:role/ecsTaskRole',
   family: 'ecspresso-test',
-  memory: '512',
+  memory: '2048',
   networkMode: 'awsvpc',
   placementConstraints: [],
+  runtimePlatform: {
+    operatingSystemFamily: 'WINDOWS_SERVER_2019_CORE',
+  },
   requiresCompatibilities: [
     'FARGATE',
   ],


### PR DESCRIPTION
Supports Windows Container!
https://aws.amazon.com/jp/blogs/containers/running-windows-containers-with-amazon-ecs-on-aws-fargate/