### PR TITLE
add tasks --trace option

### DIFF
--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -177,6 +177,7 @@ func _main() int {
 		Find:   tasks.Flag("find", "find a task from tasks list and dump it as JSON").Bool(),
 		Stop:   tasks.Flag("stop", "stop a task").Bool(),
 		Force:  tasks.Flag("force", "stop a task without confirmation").Bool(),
+		Trace:  tasks.Flag("trace", "trace a task").Bool(),
 	}
 
 	exec := kingpin.Command("exec", "execute command in a task")

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/fatih/color v1.12.0
 	github.com/fujiwara/cfn-lookup v0.0.2
 	github.com/fujiwara/tfstate-lookup v0.4.0
-	github.com/fujiwara/tracer v0.0.3 // indirect
+	github.com/fujiwara/tracer v0.0.3
 	github.com/google/go-cmp v0.5.6
 	github.com/google/go-jsonnet v0.17.0
 	github.com/hashicorp/go-envparse v0.0.0-20200406174449-d9cfd743a15e

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/fatih/color v1.12.0
 	github.com/fujiwara/cfn-lookup v0.0.2
 	github.com/fujiwara/tfstate-lookup v0.4.0
-	github.com/fujiwara/tracer v0.0.3
+	github.com/fujiwara/tracer v0.0.4
 	github.com/google/go-cmp v0.5.6
 	github.com/google/go-jsonnet v0.17.0
 	github.com/hashicorp/go-envparse v0.0.0-20200406174449-d9cfd743a15e

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,11 @@ go 1.12
 require (
 	github.com/Songmu/prompter v0.5.0
 	github.com/alecthomas/kingpin v1.3.8-0.20190930021037-0a108b7f5563
-	github.com/aws/aws-sdk-go v1.41.13
+	github.com/aws/aws-sdk-go v1.42.12
 	github.com/fatih/color v1.12.0
 	github.com/fujiwara/cfn-lookup v0.0.2
 	github.com/fujiwara/tfstate-lookup v0.4.0
+	github.com/fujiwara/tracer v0.0.3 // indirect
 	github.com/google/go-cmp v0.5.6
 	github.com/google/go-jsonnet v0.17.0
 	github.com/hashicorp/go-envparse v0.0.0-20200406174449-d9cfd743a15e

--- a/go.sum
+++ b/go.sum
@@ -93,6 +93,8 @@ github.com/aws/aws-sdk-go v1.36.15/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2z
 github.com/aws/aws-sdk-go v1.40.28/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/aws/aws-sdk-go v1.41.13 h1:wGgr6jkHdGExF33phfOqijFq7ZF+h7a6FXvJc77GpTc=
 github.com/aws/aws-sdk-go v1.41.13/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
+github.com/aws/aws-sdk-go v1.42.12 h1:zVrAgi3/HuMPygZknc+f2KAHcn+Zuq767857hnHBMPA=
+github.com/aws/aws-sdk-go v1.42.12/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
@@ -125,6 +127,10 @@ github.com/fujiwara/cfn-lookup v0.0.2 h1:1l0HNyPMO5yzXacVi6LWbyahs6uW+faBPd8CwFO
 github.com/fujiwara/cfn-lookup v0.0.2/go.mod h1:if7hlqDFCHxOy2TnH/GWKpD6j5Bp3UwFl+jfj9WZYis=
 github.com/fujiwara/tfstate-lookup v0.4.0 h1:AaubXvolethCndWpZ+c/Sibm6J4SCIlSxcxvn6cYon4=
 github.com/fujiwara/tfstate-lookup v0.4.0/go.mod h1:F56Bz3W497ZJA0ijFLVgcYeAVuhtbzvV6/hMtu6f2Ek=
+github.com/fujiwara/tracer v0.0.2 h1:N2zHbdT1DYKmJAavTzdCy/oM5D5ho2XDorjrHKZY4o0=
+github.com/fujiwara/tracer v0.0.2/go.mod h1:lwW3eh3+hy5EHqzE0iy/U0MpGJWpdZz4w7SpR+jYla4=
+github.com/fujiwara/tracer v0.0.3 h1:JZ26YWTC2MroTuGDkikFWByF0DCUFbBWaUcRWnFF258=
+github.com/fujiwara/tracer v0.0.3/go.mod h1:lwW3eh3+hy5EHqzE0iy/U0MpGJWpdZz4w7SpR+jYla4=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=

--- a/go.sum
+++ b/go.sum
@@ -125,8 +125,8 @@ github.com/fujiwara/cfn-lookup v0.0.2 h1:1l0HNyPMO5yzXacVi6LWbyahs6uW+faBPd8CwFO
 github.com/fujiwara/cfn-lookup v0.0.2/go.mod h1:if7hlqDFCHxOy2TnH/GWKpD6j5Bp3UwFl+jfj9WZYis=
 github.com/fujiwara/tfstate-lookup v0.4.0 h1:AaubXvolethCndWpZ+c/Sibm6J4SCIlSxcxvn6cYon4=
 github.com/fujiwara/tfstate-lookup v0.4.0/go.mod h1:F56Bz3W497ZJA0ijFLVgcYeAVuhtbzvV6/hMtu6f2Ek=
-github.com/fujiwara/tracer v0.0.3 h1:JZ26YWTC2MroTuGDkikFWByF0DCUFbBWaUcRWnFF258=
-github.com/fujiwara/tracer v0.0.3/go.mod h1:lwW3eh3+hy5EHqzE0iy/U0MpGJWpdZz4w7SpR+jYla4=
+github.com/fujiwara/tracer v0.0.4 h1:Z/2PCynU8a1VqbmJtW6khHMiSOzXUBH+URk5m+N5TRI=
+github.com/fujiwara/tracer v0.0.4/go.mod h1:lwW3eh3+hy5EHqzE0iy/U0MpGJWpdZz4w7SpR+jYla4=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,6 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2c
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/aws/aws-sdk-go v1.36.15/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go v1.40.28/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
-github.com/aws/aws-sdk-go v1.41.13 h1:wGgr6jkHdGExF33phfOqijFq7ZF+h7a6FXvJc77GpTc=
-github.com/aws/aws-sdk-go v1.41.13/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/aws/aws-sdk-go v1.42.12 h1:zVrAgi3/HuMPygZknc+f2KAHcn+Zuq767857hnHBMPA=
 github.com/aws/aws-sdk-go v1.42.12/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -127,8 +125,6 @@ github.com/fujiwara/cfn-lookup v0.0.2 h1:1l0HNyPMO5yzXacVi6LWbyahs6uW+faBPd8CwFO
 github.com/fujiwara/cfn-lookup v0.0.2/go.mod h1:if7hlqDFCHxOy2TnH/GWKpD6j5Bp3UwFl+jfj9WZYis=
 github.com/fujiwara/tfstate-lookup v0.4.0 h1:AaubXvolethCndWpZ+c/Sibm6J4SCIlSxcxvn6cYon4=
 github.com/fujiwara/tfstate-lookup v0.4.0/go.mod h1:F56Bz3W497ZJA0ijFLVgcYeAVuhtbzvV6/hMtu6f2Ek=
-github.com/fujiwara/tracer v0.0.2 h1:N2zHbdT1DYKmJAavTzdCy/oM5D5ho2XDorjrHKZY4o0=
-github.com/fujiwara/tracer v0.0.2/go.mod h1:lwW3eh3+hy5EHqzE0iy/U0MpGJWpdZz4w7SpR+jYla4=
 github.com/fujiwara/tracer v0.0.3 h1:JZ26YWTC2MroTuGDkikFWByF0DCUFbBWaUcRWnFF258=
 github.com/fujiwara/tracer v0.0.3/go.mod h1:lwW3eh3+hy5EHqzE0iy/U0MpGJWpdZz4w7SpR+jYla4=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=


### PR DESCRIPTION
Runs github.com/fujiwara/tracer via ecspresso.

`ecspresso tasks --trace` invokes fujiwara/tracer for the selected task.