### PR TITLE
Fix ext option in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,10 +339,10 @@ task_definition: ecs-task-def.jsonnet
 
 ecspresso includes [github.com/google/go-jsonnet](go-jsonnet) as a library, we don't need the jsonnet command.
 
-`--ext-var` and `--ext-code` flag sets [Jsonnet External Variables](https://jsonnet.org/ref/stdlib.html#ext_vars).
+`--ext-str` and `--ext-code` flag sets [Jsonnet External Variables](https://jsonnet.org/ref/stdlib.html#ext_vars).
 
 ```console
-$ ecspresso --ext-var Foo=foo --ext-code "Bar=1+1" ...
+$ ecspresso --ext-str Foo=foo --ext-code "Bar=1+1" ...
 ```
 
 ```jsonnet


### PR DESCRIPTION
The addition of the ability to pass jsonnet external variables is very good!

The option in the README was different from the actual option, so I corrected it.
If the implementation is app.ExtVar, I would appreciate it if you would consider it!