### PR TITLE
add exec --port-forward

### DIFF
--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -182,9 +182,12 @@ func _main() int {
 
 	exec := kingpin.Command("exec", "execute command in a task")
 	execOption := ecspresso.ExecOption{
-		ID:        exec.Flag("id", "task ID").Default("").String(),
-		Command:   exec.Flag("command", "command").Default("sh").String(),
-		Container: exec.Flag("container", "container name").String(),
+		ID:          exec.Flag("id", "task ID").Default("").String(),
+		Command:     exec.Flag("command", "command").Default("sh").String(),
+		Container:   exec.Flag("container", "container name").String(),
+		LocalPort:   exec.Flag("local-port", "local port number").Default("0").Int(),
+		Port:        exec.Flag("port", "remote port number").Default("0").Int(),
+		PortForward: exec.Flag("port-forward", "enable port forward").Default("false").Bool(),
 	}
 
 	sub := kingpin.Parse()

--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -186,7 +186,7 @@ func _main() int {
 		Command:     exec.Flag("command", "command").Default("sh").String(),
 		Container:   exec.Flag("container", "container name").String(),
 		LocalPort:   exec.Flag("local-port", "local port number").Default("0").Int(),
-		Port:        exec.Flag("port", "remote port number").Default("0").Int(),
+		Port:        exec.Flag("port", "remote port number (required for --port-forward)").Default("0").Int(),
 		PortForward: exec.Flag("port-forward", "enable port forward").Default("false").Bool(),
 	}
 


### PR DESCRIPTION
Add `ecspresso exec --port-forward` option to enable port forwarding using session-manager-plugin.

```console
$ ecspresso exec --port-forward --port 80 --local-port 9999 --id 6d22774a0e9c4feb959eda63b4b65ce6 

Starting session with SessionId: 1640354961643483997-06c79341313b64b2d
Port 9999 opened for sessionId 1640354961643483997-06c79341313b64b2d.
Waiting for connections...

Connection accepted for session [1640354961643483997-06c79341313b64b2d]
^CTerminate signal received, exiting.


Exiting session with sessionId: 1640354961643483997-06c79341313b64b2d.
```

```
usage: ecspresso exec [<flags>]

execute command in a task

Flags:
  --help                    Show context-sensitive help (also try --help-long and --help-man).
  --config="ecspresso.yml"  config file
  --debug                   enable debug log
  --envfile=ENVFILE ...     environment files
  --ext-str=EXT-STR ...     external string values for Jsonnet
  --ext-code=EXT-CODE ...   external code values for Jsonnet
  --color                   enable colored output
  --id=""                   task ID
  --command="sh"            command
  --container=CONTAINER     container name
  --local-port=0            local port number
  --port=0                  remote port number (required for --port-forward)
  --port-forward            enable port forward
```

- --port is required when --port-forward specified.
- When --local-port is not specified, use the ephemeral port for local port.