### PR TITLE
Add diff --unified option

### DIFF
--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -148,8 +148,10 @@ func _main() int {
 		ForceOverwrite:        init.Flag("force-overwrite", "force overwrite files").Bool(),
 	}
 
-	_ = kingpin.Command("diff", "display diff for task definition compared with latest one on ECS")
-	diffOption := ecspresso.DiffOption{}
+	diff := kingpin.Command("diff", "display diff for task definition compared with latest one on ECS")
+	diffOption := ecspresso.DiffOption{
+		Unified: diff.Flag("unified", "display diff in unified format").Bool(),
+	}
 
 	appspec := kingpin.Command("appspec", "output AppSpec YAML for CodeDeploy to STDOUT")
 	appspecOption := ecspresso.AppSpecOption{

--- a/deploy.go
+++ b/deploy.go
@@ -78,7 +78,7 @@ func (d *App) Deploy(opt DeployOption) error {
 		if err != nil {
 			return errors.Wrap(err, "failed to load service definition")
 		}
-		ds, err := diffServices(sv, newSv)
+		ds, err := diffServices(sv, newSv, *newSv.ServiceArn, d.config.ServiceDefinitionPath, false)
 		if err != nil {
 			return errors.Wrap(err, "failed to diff of service definitions")
 		}

--- a/diff.go
+++ b/diff.go
@@ -36,16 +36,17 @@ func diffServices(local, remote *ecs.Service, remoteArn string, localPath string
 
 	remoteSv := string(remoteSvBytes)
 	newSv := string(newSvBytes)
+
 	if unified {
 		edits := myers.ComputeEdits(span.URIFromPath(remoteArn), remoteSv, newSv)
 		return fmt.Sprint(gotextdiff.ToUnified(remoteArn, localPath, remoteSv, edits)), nil
-	} else {
-		ds := diff.Diff(remoteSv, newSv)
-		if ds == "" {
-			return ds, nil
-		}
-		return fmt.Sprintf("--- %s\n+++ %s\n%s", remoteArn, localPath, ds), nil
 	}
+
+	ds := diff.Diff(remoteSv, newSv)
+	if ds == "" {
+		return ds, nil
+	}
+	return fmt.Sprintf("--- %s\n+++ %s\n%s", remoteArn, localPath, ds), nil
 }
 
 func diffTaskDefs(local, remote *TaskDefinitionInput, remoteArn string, localPath string, unified bool) (string, error) {
@@ -64,16 +65,17 @@ func diffTaskDefs(local, remote *TaskDefinitionInput, remoteArn string, localPat
 
 	remoteTd := string(remoteTdBytes)
 	newTd := string(newTdBytes)
+
 	if unified {
 		edits := myers.ComputeEdits(span.URIFromPath(remoteArn), remoteTd, newTd)
 		return fmt.Sprint(gotextdiff.ToUnified(remoteArn, localPath, remoteTd, edits)), nil
-	} else {
-		ds := diff.Diff(remoteTd, newTd)
-		if ds == "" {
-			return ds, nil
-		}
-		return fmt.Sprintf("--- %s\n+++ %s\n%s", remoteArn, localPath, ds), nil
 	}
+
+	ds := diff.Diff(remoteTd, newTd)
+	if ds == "" {
+		return ds, nil
+	}
+	return fmt.Sprintf("--- %s\n+++ %s\n%s", remoteArn, localPath, ds), nil
 }
 
 func (d *App) Diff(opt DiffOption) error {

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/google/go-jsonnet v0.17.0
 	github.com/hashicorp/go-envparse v0.0.0-20200406174449-d9cfd743a15e
 	github.com/hashicorp/go-version v1.3.0
+	github.com/hexops/gotextdiff v1.0.3
 	github.com/kayac/go-config v0.6.0
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-isatty v0.0.13

--- a/go.sum
+++ b/go.sum
@@ -222,6 +222,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/jsonapi v0.0.0-20210518035559-1e50d74c8db3 h1:mzwkutymYIXR5oQT9YnfbLuuw7LZmksiHKRPUTN5ijo=
 github.com/hashicorp/jsonapi v0.0.0-20210518035559-1e50d74c8db3/go.mod h1:Yog5+CPEM3c99L1CL2CFCYoSzgWm5vTU58idbRUaLik=
+github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
+github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/hokaccha/go-prettyjson v0.0.0-20190818114111-108c894c2c0e/go.mod h1:pFlLw2CfqZiIBOx6BuCeRLCrfxBJipTY0nIOF/VbGcI=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/options.go
+++ b/options.go
@@ -138,6 +138,7 @@ type InitOption struct {
 }
 
 type DiffOption struct {
+	Unified *bool
 }
 
 type AppSpecOption struct {


### PR DESCRIPTION
Enabled to display unified format like git diff.
It makes it easier to see if there are any unintended changes.

```diff
cohalz@co ecspresso % ./cmd/ecspresso/ecspresso diff --config=ecspresso.yml --unified
--- arn:aws:ecs:ap-northeast-1:123456789012:service/my-cluster/my-service
+++ ecs-service-def.json
@@ -7,7 +7,7 @@
     "maximumPercent": 200,
     "minimumHealthyPercent": 100
   },
-  "desiredCount": 1,
+  "desiredCount": 2,
   "enableExecuteCommand": true,
   "healthCheckGracePeriodSeconds": 0,
   "networkConfiguration": {

--- arn:aws:ecs:ap-northeast-1:123456789012:task-definition/my-tesk-definition:1
+++ ecs-task-def.json
@@ -44,7 +44,7 @@
     {
       "cpu": 0,
       "environment": [],
-      "essential": true,
+      "essential": false,
       "image": "nginx:latest",
       "linuxParameters": {
         "initProcessEnabled": true

```