### PR TITLE
Raise an error when rollback --deregister-task-definition and --no-wait

### DIFF
--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -87,7 +87,7 @@ func _main() int {
 	rollback := kingpin.Command("rollback", "roll back a service")
 	rollbackOption := ecspresso.RollbackOption{
 		DryRun:                   rollback.Flag("dry-run", "dry-run").Bool(),
-		DeregisterTaskDefinition: rollback.Flag("deregister-task-definition", "deregister a rolled-back task definition").Bool(),
+		DeregisterTaskDefinition: rollback.Flag("deregister-task-definition", "deregister a rolled-back task definition. cannot set with --no-wait").Bool(),
 		NoWait:                   rollback.Flag("no-wait", "exit ecspresso immediately after just rolled back without waiting for service stable").Bool(),
 		RollbackEvents:           rollback.Flag("rollback-events", " roll back when specified events happened (DEPLOYMENT_FAILURE,DEPLOYMENT_STOP_ON_ALARM,DEPLOYMENT_STOP_ON_REQUEST,...) CodeDeploy only.").String(),
 	}

--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -87,7 +87,7 @@ func _main() int {
 	rollback := kingpin.Command("rollback", "roll back a service")
 	rollbackOption := ecspresso.RollbackOption{
 		DryRun:                   rollback.Flag("dry-run", "dry-run").Bool(),
-		DeregisterTaskDefinition: rollback.Flag("deregister-task-definition", "deregister a rolled-back task definition. cannot set with --no-wait").Bool(),
+		DeregisterTaskDefinition: rollback.Flag("deregister-task-definition", "deregister a rolled-back task definition. not works with --no-wait").Bool(),
 		NoWait:                   rollback.Flag("no-wait", "exit ecspresso immediately after just rolled back without waiting for service stable").Bool(),
 		RollbackEvents:           rollback.Flag("rollback-events", " roll back when specified events happened (DEPLOYMENT_FAILURE,DEPLOYMENT_STOP_ON_ALARM,DEPLOYMENT_STOP_ON_REQUEST,...) CodeDeploy only.").String(),
 	}

--- a/rollback.go
+++ b/rollback.go
@@ -1,10 +1,12 @@
 package ecspresso
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/fatih/color"
 	"github.com/pkg/errors"
 )
 
@@ -13,7 +15,9 @@ func (d *App) Rollback(opt RollbackOption) error {
 	defer cancel()
 
 	if aws.BoolValue(opt.DeregisterTaskDefinition) && aws.BoolValue(opt.NoWait) {
-		return errors.New("cannot set --deregister-task-definition and --no-wait together")
+		fmt.Println(
+			color.YellowString("WARNING: --deregister-task-definition not works with --no-wait together"),
+		)
 	}
 
 	d.Log("Starting rollback", opt.DryRunString())

--- a/rollback.go
+++ b/rollback.go
@@ -12,6 +12,10 @@ func (d *App) Rollback(opt RollbackOption) error {
 	ctx, cancel := d.Start()
 	defer cancel()
 
+	if aws.BoolValue(opt.DeregisterTaskDefinition) && aws.BoolValue(opt.NoWait) {
+		return errors.New("cannot set --deregister-task-definition and --no-wait together")
+	}
+
 	d.Log("Starting rollback", opt.DryRunString())
 	sv, err := d.DescribeServiceStatus(ctx, 0)
 	if err != nil {


### PR DESCRIPTION
fixes #341
Currently, --no-wait avoids --deregister-task-definition.
Put warning message.