### PR TITLE
Init as jsonnet

### DIFF
--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -146,6 +146,7 @@ func _main() int {
 		TaskDefinitionPath:    init.Flag("task-definition-path", "output task definition file path").Default("ecs-task-def.json").String(),
 		ServiceDefinitionPath: init.Flag("service-definition-path", "output service definition file path").Default("ecs-service-def.json").String(),
 		ForceOverwrite:        init.Flag("force-overwrite", "force overwrite files").Bool(),
+		Jsonnet:               init.Flag("jsonnet", "format as jsonnet to generate definition files").Bool(),
 	}
 
 	diff := kingpin.Command("diff", "display diff for task definition compared with latest one on ECS")

--- a/options.go
+++ b/options.go
@@ -127,16 +127,6 @@ func parseTags(s string) ([]*ecs.Tag, error) {
 type WaitOption struct {
 }
 
-type InitOption struct {
-	Region                *string
-	Cluster               *string
-	Service               *string
-	TaskDefinitionPath    *string
-	ServiceDefinitionPath *string
-	ConfigFilePath        *string
-	ForceOverwrite        *bool
-}
-
 type DiffOption struct {
 	Unified *bool
 }

--- a/util.go
+++ b/util.go
@@ -51,7 +51,7 @@ func isLongArnFormat(a string) (bool, error) {
 
 func (d *App) readDefinitionFile(path string) ([]byte, error) {
 	switch filepath.Ext(path) {
-	case ".jsonnet":
+	case jsonnetExt:
 		vm := jsonnet.MakeVM()
 		for k, v := range d.ExtStr {
 			vm.ExtVar(k, v)


### PR DESCRIPTION
Add init --jsonnet option to format definition files as Jsonnet.

```
usage: ecspresso init --service=SERVICE [<flags>]

create service/task definition files by existing ECS service

Flags:
(snip)
  --jsonnet                  format as jsonnet to generate definition files
```
