### PR TITLE
diff services only when config.service defined.

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -83,8 +83,8 @@ func (d *App) Diff(opt DiffOption) error {
 	defer cancel()
 
 	var taskDefArn string
-	// service definition
-	if d.config.ServiceDefinitionPath != "" {
+	// diff for services only when service defined
+	if d.config.Service != "" {
 		newSv, err := d.LoadServiceDefinition(d.config.ServiceDefinitionPath)
 		if err != nil {
 			return errors.Wrap(err, "failed to load service definition")


### PR DESCRIPTION
service_definition_path is also used to run tasks.

refs #376 