### PR TITLE
ecspresso exec can now be run without an envfile

### DIFF
--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -191,6 +191,7 @@ func _main() int {
 		LocalPort:   exec.Flag("local-port", "local port number").Default("0").Int(),
 		Port:        exec.Flag("port", "remote port number (required for --port-forward)").Default("0").Int(),
 		PortForward: exec.Flag("port-forward", "enable port forward").Default("false").Bool(),
+		NoEnvfile:   exec.Flag("no-envfile", "without envfile").Default("false").Bool(),
 	}
 
 	sub := kingpin.Parse()

--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -290,9 +290,7 @@ func _main() int {
 	case "tasks":
 		err = app.Tasks(tasksOption)
 	case "exec":
-		if len(*envFiles) == 0 {
-			execOption.NoEnvfile = aws.Bool(true)
-		}
+		execOption.NoEnvfile = aws.Bool(len(*envFiles) == 0)
 		err = app.Exec(execOption)
 	default:
 		kingpin.Usage()

--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -191,7 +191,6 @@ func _main() int {
 		LocalPort:   exec.Flag("local-port", "local port number").Default("0").Int(),
 		Port:        exec.Flag("port", "remote port number (required for --port-forward)").Default("0").Int(),
 		PortForward: exec.Flag("port-forward", "enable port forward").Default("false").Bool(),
-		NoEnvfile:   exec.Flag("no-envfile", "without envfile").Default("false").Bool(),
 	}
 
 	sub := kingpin.Parse()
@@ -291,6 +290,9 @@ func _main() int {
 	case "tasks":
 		err = app.Tasks(tasksOption)
 	case "exec":
+		if len(*envFiles) == 0 {
+			execOption.NoEnvfile = aws.Bool(true)
+		}
 		err = app.Exec(execOption)
 	default:
 		kingpin.Usage()

--- a/deregister.go
+++ b/deregister.go
@@ -150,7 +150,7 @@ func (d *App) deregisterKeeps(ctx context.Context, opt DeregisterOption, inUse m
 
 func (d *App) inUseRevisions(ctx context.Context) (map[string]string, error) {
 	inUse := make(map[string]string)
-	tasks, err := d.listTasks(ctx, nil)
+	tasks, err := d.listTasks(ctx, nil, false)
 	if err != nil {
 		return nil, err
 	}

--- a/exec.go
+++ b/exec.go
@@ -35,6 +35,7 @@ type ExecOption struct {
 	PortForward *bool
 	LocalPort   *int
 	Port        *int
+	NoEnvfile   *bool
 }
 
 func (o ExecOption) taskID() string {
@@ -50,7 +51,7 @@ func (d *App) Exec(opt ExecOption) error {
 	}
 
 	// find a task to exec
-	tasks, err := d.listTasks(ctx, opt.ID, "RUNNING")
+	tasks, err := d.listTasks(ctx, opt.ID, *opt.NoEnvfile, "RUNNING")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
jsonnetで定義を抽象化しつつ、環境差分を環境変数で注入するような定義をしている等で、`ecspresso exec`を実行したい環境で`envfile`をすぐに用意することが困難な場面を想定して、`ecspresso exec`をenvfileの指定無しでも実行できるようにしてみました。