### PR TITLE
Correct `ExtVar` to `extVar`

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,8 +347,8 @@ $ ecspresso --ext-str Foo=foo --ext-code "Bar=1+1" ...
 
 ```jsonnet
 {
-  foo: std.ExtVar('Foo'), // = "foo"
-  bar: std.ExtVar('Bar'), // = 2
+  foo: std.extVar('Foo'), // = "foo"
+  bar: std.extVar('Bar'), // = 2
 }
 ```
 


### PR DESCRIPTION
## What's this
Fix `README.md` as follows:
`ExtVar` to `extVar`

## Why
I tried using jsonnet, but error occured because `ExtVar` is not correct.

## Reference
https://jsonnet.org/ref/stdlib.html#ext_vars
`std.extVar(x)`