### PR TITLE
remove loadBalancers and serviceRegistries for CodeDeploy

### DIFF
--- a/deploy.go
+++ b/deploy.go
@@ -193,6 +193,8 @@ func (d *App) UpdateServiceAttributes(ctx context.Context, sv *ecs.Service, opt 
 		in.NetworkConfiguration = nil
 		in.PlatformVersion = nil
 		in.ForceNewDeployment = nil
+		in.LoadBalancers = nil
+		in.ServiceRegistries = nil
 	} else {
 		in.ForceNewDeployment = opt.ForceNewDeployment
 	}


### PR DESCRIPTION
when using CodeDeploy, these attributes raise errors.
> InvalidParameterException: Unable to update load balancers on services with a CODE_DEPLOY deployment controller. Use AWS CodeDeploy to trigger a new deployment.

refs #393