### PR TITLE
fix daemon service deploy

### DIFF
--- a/deploy.go
+++ b/deploy.go
@@ -181,7 +181,7 @@ func svToUpdateServiceInput(sv *ecs.Service) *ecs.UpdateServiceInput {
 		ServiceRegistries:             sv.ServiceRegistries,
 	}
 	if aws.StringValue(sv.SchedulingStrategy) == "DAEMON" {
-		in.PlacementConstraints = nil
+		in.PlacementStrategy = nil
 	}
 	return in
 }


### PR DESCRIPTION
Attempting to deploy the DAEMON service failed with the following error:
```
2022/04/13 22:28:22 service-name/cluster-name Starting deploy
Service: service-name
Cluster: cluster-name
TaskDefinition: task-name:1082
Deployments:
   PRIMARY task-name:1082 desired:2 pending:0 running:2
Events:
2022/04/13 22:28:23 service-name/cluster-name Registering a new task definition...
2022/04/13 22:28:23 service-name/cluster-name Task definition is registered task-name:1087
2022/04/13 22:28:23 service-name/cluster-name Updating service attributes...
2022/04/13 22:28:23 deploy FAILED. failed to update service attributes: InvalidParameterException: The daemon scheduling strategy does not support placement strategies. Remove the placement strategy and try again
```

According to the following documents, it seems that the Placement Strategy should not be set for the DAEMON service.
Conversely, Placement Constraints are configurable.

https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_services.html
> The daemon scheduling strategy deploys exactly one task on each active container instance that meets all of the task placement constraints that you specify in your cluster. The service scheduler evaluates the task placement constraints for running tasks and will stop tasks that do not meet the placement constraints. When using this strategy, there is no need to specify a desired number of tasks, a task placement strategy, or use Service Auto Scaling policies. For more information, see Daemon.

So, I changed it according to this PR and was able to deploy it.
If there is no problem with this PR, can you please review it?
@fujiwara 