### PR TITLE
Support an explicit "ECS" deploymentController type parameter value in ecs-service-def.json

### DIFF
--- a/deploy.go
+++ b/deploy.go
@@ -117,6 +117,8 @@ func (d *App) Deploy(opt DeployOption) error {
 		switch t := *dc.Type; t {
 		case "CODE_DEPLOY":
 			return d.DeployByCodeDeploy(ctx, tdArn, count, sv, opt)
+		case "ECS":
+			// fallthrough to "rolling deploy (ECS internal)"
 		default:
 			return fmt.Errorf("could not deploy a service using deployment controller type %s", t)
 		}


### PR DESCRIPTION
Prior to this commit, if the user specifies `"ECS"` parameter at `deploymentController.type` in ecs-service-def.json, it raises an error like the following:

> deploy FAILED. could not deploy a service using deployment controller type ECS

Amazon ECS provides three types of DeploymentController:
https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_DeploymentController.html

And ecspresso has already supported ECS rolling deployment and Blue/Green deployment, so this commit allows to user to specify the "ECS" deploymentController type explicitly.

For example:

```json
  "deploymentController": {
    "type": "ECS"
  },
```