### PR TITLE
aws-sdk-go-v2 (ecs, applicationautoscaling, cloudwatchlogs, codedeploy and iam)

### DIFF
--- a/appspec.go
+++ b/appspec.go
@@ -41,7 +41,7 @@ func (d *App) AppSpec(opt AppSpecOption) error {
 		sv = newSv
 	}
 
-	spec, err := appspec.NewWithService(sv, taskDefinitionArn)
+	spec, err := appspec.NewWithService(&sv.Service, taskDefinitionArn)
 	if err != nil {
 		return errors.Wrap(err, "failed to create appspec")
 	}

--- a/appspec.go
+++ b/appspec.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/kayac/ecspresso/appspec"
 	"github.com/pkg/errors"
 )
@@ -33,7 +33,7 @@ func (d *App) AppSpec(opt AppSpecOption) error {
 			return errors.New("--task-definition requires current, latest or a valid task definition arn")
 		}
 	}
-	if aws.BoolValue(opt.UpdateService) {
+	if aws.ToBool(opt.UpdateService) {
 		newSv, err := d.LoadServiceDefinition(d.config.ServiceDefinitionPath)
 		if err != nil {
 			return err

--- a/appspec/spec.go
+++ b/appspec/spec.go
@@ -3,8 +3,8 @@ package appspec
 import (
 	"errors"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"gopkg.in/yaml.v2"
 )
 
@@ -30,7 +30,7 @@ func (a *AppSpec) String() string {
 	return string(b)
 }
 
-func NewWithService(sv *ecs.Service, tdArn string) (*AppSpec, error) {
+func NewWithService(sv *types.Service, tdArn string) (*AppSpec, error) {
 	if len(sv.LoadBalancers) == 0 {
 		return nil, errors.New("require LoadBalancers")
 	}
@@ -90,7 +90,7 @@ type Properties struct {
 
 type LoadBalancerInfo struct {
 	ContainerName *string `yaml:"ContainerName"`
-	ContainerPort *int64  `yaml:"ContainerPort"`
+	ContainerPort *int32  `yaml:"ContainerPort"`
 }
 
 type NetworkConfiguration struct {
@@ -98,15 +98,15 @@ type NetworkConfiguration struct {
 }
 
 type AwsVpcConfiguration struct {
-	AssignPublicIp *string   `yaml:"AssignPublicIp,omitempty"`
-	SecurityGroups []*string `yaml:"SecurityGroups,omitempty"`
-	Subnets        []*string `yaml:"Subnets,omitempty"`
+	AssignPublicIp types.AssignPublicIp `yaml:"AssignPublicIp,omitempty"`
+	SecurityGroups []string             `yaml:"SecurityGroups,omitempty"`
+	Subnets        []string             `yaml:"Subnets,omitempty"`
 }
 
 type CapacityProviderStrategy struct {
-	CapacityProvider *string `yaml:"CapacityProvider,omitempty""`
-	Base             *int64  `yaml:"Base,omitempty"`
-	Weight           *int64  `yaml:"Weight,omitempty"`
+	CapacityProvider *string `yaml:"CapacityProvider,omitempty"`
+	Base             int32   `yaml:"Base,omitempty"`
+	Weight           int32   `yaml:"Weight,omitempty"`
 }
 
 type Hook struct {

--- a/appspec/spec_test.go
+++ b/appspec/spec_test.go
@@ -3,7 +3,8 @@ package appspec_test
 import (
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/google/go-cmp/cmp"
 	"github.com/kayac/ecspresso/appspec"
 	"github.com/kayac/go-config"
@@ -19,31 +20,31 @@ var expected = &appspec.AppSpec{
 					TaskDefinition: aws.String("arn:aws:ecs:us-east-1:111222333444:task-definition/my-task-definition-family-name:1"),
 					LoadBalancerInfo: &appspec.LoadBalancerInfo{
 						ContainerName: aws.String("SampleApplicationName"),
-						ContainerPort: aws.Int64(80),
+						ContainerPort: aws.Int32(80),
 					},
 					PlatformVersion: aws.String("LATEST"),
 					NetworkConfiguration: &appspec.NetworkConfiguration{
 						AwsvpcConfiguration: &appspec.AwsVpcConfiguration{
-							Subnets: []*string{
-								aws.String("subnet-1234abcd"),
-								aws.String("subnet-5678abcd"),
+							Subnets: []string{
+								"subnet-1234abcd",
+								"subnet-5678abcd",
 							},
-							SecurityGroups: []*string{
-								aws.String("sg-12345678"),
+							SecurityGroups: []string{
+								"sg-12345678",
 							},
-							AssignPublicIp: aws.String("ENABLED"),
+							AssignPublicIp: types.AssignPublicIpEnabled,
 						},
 					},
 					CapacityProviderStrategy: []*appspec.CapacityProviderStrategy{
 						{
 							CapacityProvider: aws.String("FARGATE_SPOT"),
-							Base: aws.Int64(1),
-							Weight: aws.Int64(2),
+							Base:             1,
+							Weight:           2,
 						},
 						{
 							CapacityProvider: aws.String("FARGATE"),
-							Base: aws.Int64(0),
-							Weight: aws.Int64(1),
+							Base:             0,
+							Weight:           1,
 						},
 					},
 				},

--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -38,7 +38,7 @@ func _main() int {
 	deploy.Flag("resume-auto-scaling", "resume application auto-scaling attached with the ECS service").IsSetByUser(&isSetResumeAutoScaling).Bool()
 	deployOption := ecspresso.DeployOption{
 		DryRun:               deploy.Flag("dry-run", "dry-run").Bool(),
-		DesiredCount:         deploy.Flag("tasks", "desired count of tasks").Default("-1").Int64(),
+		DesiredCount:         deploy.Flag("tasks", "desired count of tasks").Default("-1").Int32(),
 		SkipTaskDefinition:   deploy.Flag("skip-task-definition", "skip register a new task definition").Bool(),
 		ForceNewDeployment:   deploy.Flag("force-new-deployment", "force a new deployment of the service").Bool(),
 		NoWait:               deploy.Flag("no-wait", "exit ecspresso immediately after just deployed without waiting for service stable").Bool(),
@@ -52,7 +52,7 @@ func _main() int {
 	scale.Flag("resume-auto-scaling", "resume application auto-scaling attached with the ECS service").IsSetByUser(&isSetResumeAutoScaling).Bool()
 	scaleOption := ecspresso.DeployOption{
 		DryRun:               scale.Flag("dry-run", "dry-run").Bool(),
-		DesiredCount:         scale.Flag("tasks", "desired count of tasks").Default("-1").Int64(),
+		DesiredCount:         scale.Flag("tasks", "desired count of tasks").Default("-1").Int32(),
 		SkipTaskDefinition:   boolp(true),
 		SuspendAutoScaling:   scale.Flag("suspend-auto-scaling", "suspend application auto-scaling attached with the ECS service").IsSetByUser(&isSetSuspendAutoScaling).Bool(),
 		ForceNewDeployment:   boolp(false),
@@ -75,7 +75,7 @@ func _main() int {
 	create := kingpin.Command("create", "create service")
 	createOption := ecspresso.CreateOption{
 		DryRun:       create.Flag("dry-run", "dry-run").Bool(),
-		DesiredCount: create.Flag("tasks", "desired count of tasks").Default("-1").Int64(),
+		DesiredCount: create.Flag("tasks", "desired count of tasks").Default("-1").Int32(),
 		NoWait:       create.Flag("no-wait", "exit ecspresso immediately after just created without waiting for service stable").Bool(),
 	}
 
@@ -107,7 +107,7 @@ func _main() int {
 		TaskOverrideStr:      run.Flag("overrides", "task overrides JSON string").Default("").String(),
 		TaskOverrideFile:     run.Flag("overrides-file", "task overrides JSON file path").Default("").String(),
 		SkipTaskDefinition:   run.Flag("skip-task-definition", "skip register a new task definition").Bool(),
-		Count:                run.Flag("count", "the number of tasks (max 10)").Default("1").Int64(),
+		Count:                run.Flag("count", "the number of tasks (max 10)").Default("1").Int32(),
 		WatchContainer:       run.Flag("watch-container", "the container name to watch exit code").String(),
 		LatestTaskDefinition: run.Flag("latest-task-definition", "run with latest task definition without registering new task definition").Default("false").Bool(),
 		PropagateTags:        run.Flag("propagate-tags", "propagate the tags for the task (SERVICE or TASK_DEFINITION)").Default("").Enum("SERVICE", "TASK_DEFINITION", ""),

--- a/config.go
+++ b/config.go
@@ -1,6 +1,7 @@
 package ecspresso
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -14,6 +15,9 @@ import (
 	"github.com/kayac/ecspresso/appspec"
 	gc "github.com/kayac/go-config"
 	"github.com/pkg/errors"
+
+	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
+	awsv2Config "github.com/aws/aws-sdk-go-v2/config"
 )
 
 const (
@@ -38,6 +42,8 @@ type Config struct {
 	dir                string
 	versionConstraints gv.Constraints
 	sess               *session.Session
+
+	awsv2Config awsv2.Config
 }
 
 // Load loads configuration file from file path.
@@ -75,6 +81,15 @@ func (c *Config) Restrict() error {
 		Config:            aws.Config{Region: aws.String(c.Region)},
 		SharedConfigState: session.SharedConfigEnable,
 	})
+	if err != nil {
+		return errors.Wrap(err, "failed to create session")
+	}
+
+	c.awsv2Config, err = awsv2Config.LoadDefaultConfig(context.TODO(), awsv2Config.WithRegion(c.Region))
+	if err != nil {
+		return errors.Wrap(err, "failed to load aws config")
+	}
+
 	return err
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -27,7 +27,7 @@ func TestLoadServiceDefinition(t *testing.T) {
 		}
 
 		if *sv.ServiceName != "test" ||
-			sv.DesiredCount != 2 ||
+			aws.ToInt32(sv.DesiredCount) != 2 ||
 			aws.ToString(sv.LoadBalancers[0].TargetGroupArn) != "arn:aws:elasticloadbalancing:us-east-1:1111111111:targetgroup/test/12345678" ||
 			sv.LaunchType != types.LaunchTypeEc2 ||
 			sv.SchedulingStrategy != types.SchedulingStrategyReplica ||

--- a/config_test.go
+++ b/config_test.go
@@ -5,7 +5,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/kayac/ecspresso"
 )
 
@@ -26,14 +27,14 @@ func TestLoadServiceDefinition(t *testing.T) {
 		}
 
 		if *sv.ServiceName != "test" ||
-			*sv.DesiredCount != 2 ||
-			*sv.LoadBalancers[0].TargetGroupArn != "arn:aws:elasticloadbalancing:us-east-1:1111111111:targetgroup/test/12345678" ||
-			*sv.LaunchType != "EC2" ||
-			*sv.SchedulingStrategy != "REPLICA" ||
-			*sv.PropagateTags != "SERVICE" ||
+			sv.DesiredCount != 2 ||
+			aws.ToString(sv.LoadBalancers[0].TargetGroupArn) != "arn:aws:elasticloadbalancing:us-east-1:1111111111:targetgroup/test/12345678" ||
+			sv.LaunchType != types.LaunchTypeEc2 ||
+			sv.SchedulingStrategy != types.SchedulingStrategyReplica ||
+			sv.PropagateTags != types.PropagateTagsService ||
 			*sv.Tags[0].Key != "cluster" ||
 			*sv.Tags[0].Value != "default2" {
-			t.Errorf("unexpected service definition %s", sv.String())
+			t.Errorf("unexpected service definition %#v", sv)
 		}
 	}
 }
@@ -94,9 +95,9 @@ func testLoadConfigWithPlugin(t *testing.T, path string) {
 	if err != nil {
 		t.Error(err)
 	}
-	t.Log(svd.String())
-	sgID := *svd.NetworkConfiguration.AwsvpcConfiguration.SecurityGroups[0]
-	subnetID := *svd.NetworkConfiguration.AwsvpcConfiguration.Subnets[0]
+	t.Log(svd)
+	sgID := svd.NetworkConfiguration.AwsvpcConfiguration.SecurityGroups[0]
+	subnetID := svd.NetworkConfiguration.AwsvpcConfiguration.Subnets[0]
 	if sgID != "sg-12345678" {
 		t.Errorf("unexpected sg id got:%s", sgID)
 	}
@@ -104,18 +105,18 @@ func testLoadConfigWithPlugin(t *testing.T, path string) {
 		t.Errorf("unexpected subnet id got:%s", subnetID)
 	}
 	cb := *svd.DeploymentConfiguration.DeploymentCircuitBreaker
-	if !aws.BoolValue(cb.Enable) {
-		t.Errorf("unexpected deploymentCircuitBreaker.enable got:%v", *cb.Enable)
+	if !cb.Enable {
+		t.Errorf("unexpected deploymentCircuitBreaker.enable got:%v", cb.Enable)
 	}
-	if !aws.BoolValue(cb.Rollback) {
-		t.Errorf("unexpected deploymentCircuitBreaker.rollback got:%v", *cb.Rollback)
+	if !cb.Rollback {
+		t.Errorf("unexpected deploymentCircuitBreaker.rollback got:%v", cb.Rollback)
 	}
 
 	td, err := app.LoadTaskDefinition(conf.TaskDefinitionPath)
 	if err != nil {
 		t.Error(err)
 	}
-	t.Log(td.String())
+	t.Log(td)
 	image := *td.ContainerDefinitions[0].Image
 	if image != "123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/app:testing" {
 		t.Errorf("unexpected image got:%s", image)

--- a/create.go
+++ b/create.go
@@ -80,7 +80,7 @@ func (d *App) Create(opt CreateOption) error {
 		Tags:                          svd.Tags,
 		TaskDefinition:                newTd.TaskDefinitionArn,
 	}
-	if _, err := d.ecsv2.CreateService(ctx, createServiceInput); err != nil {
+	if _, err := d.ecs.CreateService(ctx, createServiceInput); err != nil {
 		return errors.Wrap(err, "failed to create service")
 	}
 	d.Log("Service is created")

--- a/create.go
+++ b/create.go
@@ -3,18 +3,19 @@ package ecspresso
 import (
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ecs"
+	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/pkg/errors"
 )
 
 type CreateOption struct {
 	DryRun       *bool
-	DesiredCount *int64
+	DesiredCount *int32
 	NoWait       *bool
 }
 
-func (opt CreateOption) getDesiredCount() *int64 {
+func (opt CreateOption) getDesiredCount() *int32 {
 	return opt.DesiredCount
 }
 
@@ -40,8 +41,8 @@ func (d *App) Create(opt CreateOption) error {
 	}
 
 	count := calcDesiredCount(svd, opt)
-	if count == nil && (svd.SchedulingStrategy != nil && *svd.SchedulingStrategy == "REPLICA") {
-		count = aws.Int64(0) // Must provide desired count for replica scheduling strategy
+	if count == nil && (svd.SchedulingStrategy != "" && svd.SchedulingStrategy == types.SchedulingStrategyReplica) {
+		count = aws.Int32(0) // Must provide desired count for replica scheduling strategy
 	}
 
 	if *opt.DryRun {
@@ -79,7 +80,7 @@ func (d *App) Create(opt CreateOption) error {
 		Tags:                          svd.Tags,
 		TaskDefinition:                newTd.TaskDefinitionArn,
 	}
-	if _, err := d.ecs.CreateServiceWithContext(ctx, createServiceInput); err != nil {
+	if _, err := d.ecsv2.CreateService(ctx, createServiceInput); err != nil {
 		return errors.Wrap(err, "failed to create service")
 	}
 	d.Log("Service is created")

--- a/deploy.go
+++ b/deploy.go
@@ -108,7 +108,7 @@ func (d *App) Deploy(opt DeployOption) error {
 
 	// manage auto scaling only when set option --suspend-auto-scaling or --no-suspend-auto-scaling explicitly
 	if suspendState := opt.SuspendAutoScaling; suspendState != nil {
-		if err := d.suspendAutoScaling(*suspendState); err != nil {
+		if err := d.suspendAutoScaling(ctx, *suspendState); err != nil {
 			return err
 		}
 	}

--- a/deploy.go
+++ b/deploy.go
@@ -79,7 +79,7 @@ func (d *App) Deploy(opt DeployOption) error {
 		if err != nil {
 			return errors.Wrap(err, "failed to load service definition")
 		}
-		ds, err := diffServices(sv, newSv, "", d.config.ServiceDefinitionPath, false)
+		ds, err := diffServices(newSv, sv, "", d.config.ServiceDefinitionPath, true)
 		if err != nil {
 			return errors.Wrap(err, "failed to diff of service definitions")
 		}

--- a/deploy.go
+++ b/deploy.go
@@ -159,7 +159,7 @@ func (d *App) UpdateServiceTasks(ctx context.Context, taskDefinitionArn string, 
 	d.Log(msg)
 	d.DebugLog(in)
 
-	_, err := d.ecsv2.UpdateService(ctx, in)
+	_, err := d.ecs.UpdateService(ctx, in)
 	if err != nil {
 		return err
 	}
@@ -212,7 +212,7 @@ func (d *App) UpdateServiceAttributes(ctx context.Context, sv *Service, opt Depl
 	d.Log("Updating service attributes...")
 	d.DebugLog(in)
 
-	if _, err := d.ecsv2.UpdateService(ctx, in); err != nil {
+	if _, err := d.ecs.UpdateService(ctx, in); err != nil {
 		return err
 	}
 	time.Sleep(delayForServiceChanged) // wait for service updated
@@ -223,7 +223,7 @@ func (d *App) DeployByCodeDeploy(ctx context.Context, taskDefinitionArn string, 
 	if count != nil {
 		d.Log("updating desired count to", *count)
 	}
-	_, err := d.ecsv2.UpdateService(
+	_, err := d.ecs.UpdateService(
 		ctx,
 		&ecs.UpdateServiceInput{
 			Service:      aws.String(d.Service),

--- a/deploy.go
+++ b/deploy.go
@@ -22,7 +22,7 @@ const (
 	CodeDeployConsoleURLFmt = "https://%s.console.aws.amazon.com/codesuite/codedeploy/deployments/%s?region=%s"
 )
 
-func calcDesiredCount(sv *types.Service, opt optWithDesiredCount) *int32 {
+func calcDesiredCount(sv *Service, opt optWithDesiredCount) *int32 {
 	if sv.SchedulingStrategy == types.SchedulingStrategyDaemon {
 		return nil
 	}
@@ -39,7 +39,7 @@ func (d *App) Deploy(opt DeployOption) error {
 	ctx, cancel := d.Start()
 	defer cancel()
 
-	var sv *types.Service
+	var sv *Service
 	d.Log("Starting deploy", opt.DryRunString())
 	sv, err := d.DescribeServiceStatus(ctx, 0)
 	if err != nil {
@@ -167,7 +167,7 @@ func (d *App) UpdateServiceTasks(ctx context.Context, taskDefinitionArn string, 
 	return nil
 }
 
-func svToUpdateServiceInput(sv *types.Service) *ecs.UpdateServiceInput {
+func svToUpdateServiceInput(sv *Service) *ecs.UpdateServiceInput {
 	in := &ecs.UpdateServiceInput{
 		CapacityProviderStrategy:      sv.CapacityProviderStrategy,
 		DeploymentConfiguration:       sv.DeploymentConfiguration,
@@ -189,7 +189,7 @@ func svToUpdateServiceInput(sv *types.Service) *ecs.UpdateServiceInput {
 	return in
 }
 
-func (d *App) UpdateServiceAttributes(ctx context.Context, sv *types.Service, opt DeployOption) error {
+func (d *App) UpdateServiceAttributes(ctx context.Context, sv *Service, opt DeployOption) error {
 	in := svToUpdateServiceInput(sv)
 	if sv.DeploymentController != nil && sv.DeploymentController.Type == types.DeploymentControllerTypeCodeDeploy {
 		// unable to update attributes below with a CODE_DEPLOY deployment controller.
@@ -219,7 +219,7 @@ func (d *App) UpdateServiceAttributes(ctx context.Context, sv *types.Service, op
 	return nil
 }
 
-func (d *App) DeployByCodeDeploy(ctx context.Context, taskDefinitionArn string, count *int32, sv *types.Service, opt DeployOption) error {
+func (d *App) DeployByCodeDeploy(ctx context.Context, taskDefinitionArn string, count *int32, sv *Service, opt DeployOption) error {
 	if count != nil {
 		d.Log("updating desired count to", *count)
 	}
@@ -307,7 +307,7 @@ func (d *App) findDeploymentInfo() (*codedeploy.DeploymentInfo, error) {
 	)
 }
 
-func (d *App) createDeployment(ctx context.Context, sv *types.Service, taskDefinitionArn string, rollbackEvents *string) error {
+func (d *App) createDeployment(ctx context.Context, sv *Service, taskDefinitionArn string, rollbackEvents *string) error {
 
 	spec, err := appspec.NewWithService(sv, taskDefinitionArn)
 	if err != nil {

--- a/deploy.go
+++ b/deploy.go
@@ -28,7 +28,7 @@ func calcDesiredCount(sv *Service, opt optWithDesiredCount) *int32 {
 	}
 	if oc := opt.getDesiredCount(); oc != nil {
 		if *oc == DefaultDesiredCount {
-			return &sv.DesiredCount
+			return sv.DesiredCount
 		}
 		return oc // --tasks
 	}
@@ -171,7 +171,7 @@ func svToUpdateServiceInput(sv *Service) *ecs.UpdateServiceInput {
 	in := &ecs.UpdateServiceInput{
 		CapacityProviderStrategy:      sv.CapacityProviderStrategy,
 		DeploymentConfiguration:       sv.DeploymentConfiguration,
-		DesiredCount:                  &sv.DesiredCount,
+		DesiredCount:                  sv.DesiredCount,
 		EnableECSManagedTags:          &sv.EnableECSManagedTags,
 		EnableExecuteCommand:          &sv.EnableExecuteCommand,
 		HealthCheckGracePeriodSeconds: sv.HealthCheckGracePeriodSeconds,
@@ -309,7 +309,7 @@ func (d *App) findDeploymentInfo() (*codedeploy.DeploymentInfo, error) {
 
 func (d *App) createDeployment(ctx context.Context, sv *Service, taskDefinitionArn string, rollbackEvents *string) error {
 
-	spec, err := appspec.NewWithService(sv, taskDefinitionArn)
+	spec, err := appspec.NewWithService(&sv.Service, taskDefinitionArn)
 	if err != nil {
 		return errors.Wrap(err, "failed to create appspec")
 	}

--- a/deploy_test.go
+++ b/deploy_test.go
@@ -16,39 +16,43 @@ type desiredCountTestCase struct {
 
 var desiredCountTestSuite = []desiredCountTestCase{
 	{
-		sv:       &ecspresso.Service{DesiredCount: 0},
+		sv:       &ecspresso.Service{DesiredCount: nil},
 		opt:      ecspresso.DeployOption{DesiredCount: nil},
 		expected: nil,
 	},
 	{
-		sv:       &ecspresso.Service{DesiredCount: 0, SchedulingStrategy: types.SchedulingStrategyDaemon},
+		sv: &ecspresso.Service{
+			Service: types.Service{
+				SchedulingStrategy: types.SchedulingStrategyDaemon,
+			},
+		},
 		opt:      ecspresso.DeployOption{DesiredCount: aws.Int32(10)},
 		expected: nil,
 	},
 	{
-		sv:       &ecspresso.Service{DesiredCount: 2},
+		sv:       &ecspresso.Service{DesiredCount: aws.Int32(2)},
 		opt:      ecspresso.DeployOption{DesiredCount: nil},
 		expected: nil,
 	},
 	{
-		sv:       &ecspresso.Service{DesiredCount: 1},
+		sv:       &ecspresso.Service{DesiredCount: aws.Int32(1)},
 		opt:      ecspresso.DeployOption{DesiredCount: aws.Int32(3)},
 		expected: aws.Int32(3),
 	},
 	{
-		sv:       &ecspresso.Service{DesiredCount: 1},
+		sv:       &ecspresso.Service{DesiredCount: aws.Int32(1)},
 		opt:      ecspresso.DeployOption{DesiredCount: aws.Int32(ecspresso.DefaultDesiredCount)},
 		expected: aws.Int32(1),
 	},
 	{
-		sv:       &ecspresso.Service{DesiredCount: 0},
+		sv:       &ecspresso.Service{DesiredCount: aws.Int32(0)},
 		opt:      ecspresso.DeployOption{DesiredCount: aws.Int32(5)},
 		expected: aws.Int32(5),
 	},
 	{
-		sv:       &ecspresso.Service{DesiredCount: 0},
+		sv:       &ecspresso.Service{DesiredCount: aws.Int32(0)},
 		opt:      ecspresso.DeployOption{DesiredCount: aws.Int32(ecspresso.DefaultDesiredCount)},
-		expected: nil,
+		expected: aws.Int32(0),
 	},
 }
 

--- a/deploy_test.go
+++ b/deploy_test.go
@@ -9,44 +9,44 @@ import (
 )
 
 type desiredCountTestCase struct {
-	sv       *types.Service
+	sv       *ecspresso.Service
 	opt      ecspresso.DeployOption
 	expected *int32
 }
 
 var desiredCountTestSuite = []desiredCountTestCase{
 	{
-		sv:       &types.Service{DesiredCount: 0},
+		sv:       &ecspresso.Service{DesiredCount: 0},
 		opt:      ecspresso.DeployOption{DesiredCount: nil},
 		expected: nil,
 	},
 	{
-		sv:       &types.Service{DesiredCount: 0, SchedulingStrategy: types.SchedulingStrategyDaemon},
+		sv:       &ecspresso.Service{DesiredCount: 0, SchedulingStrategy: types.SchedulingStrategyDaemon},
 		opt:      ecspresso.DeployOption{DesiredCount: aws.Int32(10)},
 		expected: nil,
 	},
 	{
-		sv:       &types.Service{DesiredCount: 2},
+		sv:       &ecspresso.Service{DesiredCount: 2},
 		opt:      ecspresso.DeployOption{DesiredCount: nil},
 		expected: nil,
 	},
 	{
-		sv:       &types.Service{DesiredCount: 1},
+		sv:       &ecspresso.Service{DesiredCount: 1},
 		opt:      ecspresso.DeployOption{DesiredCount: aws.Int32(3)},
 		expected: aws.Int32(3),
 	},
 	{
-		sv:       &types.Service{DesiredCount: 1},
+		sv:       &ecspresso.Service{DesiredCount: 1},
 		opt:      ecspresso.DeployOption{DesiredCount: aws.Int32(ecspresso.DefaultDesiredCount)},
 		expected: aws.Int32(1),
 	},
 	{
-		sv:       &types.Service{DesiredCount: 0},
+		sv:       &ecspresso.Service{DesiredCount: 0},
 		opt:      ecspresso.DeployOption{DesiredCount: aws.Int32(5)},
 		expected: aws.Int32(5),
 	},
 	{
-		sv:       &types.Service{DesiredCount: 0},
+		sv:       &ecspresso.Service{DesiredCount: 0},
 		opt:      ecspresso.DeployOption{DesiredCount: aws.Int32(ecspresso.DefaultDesiredCount)},
 		expected: nil,
 	},

--- a/deploy_test.go
+++ b/deploy_test.go
@@ -3,51 +3,51 @@ package ecspresso_test
 import (
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/kayac/ecspresso"
 )
 
 type desiredCountTestCase struct {
-	sv       *ecs.Service
+	sv       *types.Service
 	opt      ecspresso.DeployOption
-	expected *int64
+	expected *int32
 }
 
 var desiredCountTestSuite = []desiredCountTestCase{
 	{
-		sv:       &ecs.Service{DesiredCount: nil},
+		sv:       &types.Service{DesiredCount: 0},
 		opt:      ecspresso.DeployOption{DesiredCount: nil},
 		expected: nil,
 	},
 	{
-		sv:       &ecs.Service{DesiredCount: nil, SchedulingStrategy: aws.String("DAEMON")},
-		opt:      ecspresso.DeployOption{DesiredCount: aws.Int64(10)},
+		sv:       &types.Service{DesiredCount: 0, SchedulingStrategy: types.SchedulingStrategyDaemon},
+		opt:      ecspresso.DeployOption{DesiredCount: aws.Int32(10)},
 		expected: nil,
 	},
 	{
-		sv:       &ecs.Service{DesiredCount: aws.Int64(2)},
+		sv:       &types.Service{DesiredCount: 2},
 		opt:      ecspresso.DeployOption{DesiredCount: nil},
 		expected: nil,
 	},
 	{
-		sv:       &ecs.Service{DesiredCount: aws.Int64(1)},
-		opt:      ecspresso.DeployOption{DesiredCount: aws.Int64(3)},
-		expected: aws.Int64(3),
+		sv:       &types.Service{DesiredCount: 1},
+		opt:      ecspresso.DeployOption{DesiredCount: aws.Int32(3)},
+		expected: aws.Int32(3),
 	},
 	{
-		sv:       &ecs.Service{DesiredCount: aws.Int64(1)},
-		opt:      ecspresso.DeployOption{DesiredCount: aws.Int64(ecspresso.DefaultDesiredCount)},
-		expected: aws.Int64(1),
+		sv:       &types.Service{DesiredCount: 1},
+		opt:      ecspresso.DeployOption{DesiredCount: aws.Int32(ecspresso.DefaultDesiredCount)},
+		expected: aws.Int32(1),
 	},
 	{
-		sv:       &ecs.Service{DesiredCount: nil},
-		opt:      ecspresso.DeployOption{DesiredCount: aws.Int64(5)},
-		expected: aws.Int64(5),
+		sv:       &types.Service{DesiredCount: 0},
+		opt:      ecspresso.DeployOption{DesiredCount: aws.Int32(5)},
+		expected: aws.Int32(5),
 	},
 	{
-		sv:       &ecs.Service{DesiredCount: nil},
-		opt:      ecspresso.DeployOption{DesiredCount: aws.Int64(ecspresso.DefaultDesiredCount)},
+		sv:       &types.Service{DesiredCount: 0},
+		opt:      ecspresso.DeployOption{DesiredCount: aws.Int32(ecspresso.DefaultDesiredCount)},
 		expected: nil,
 	},
 }

--- a/deregister.go
+++ b/deregister.go
@@ -63,7 +63,7 @@ func (d *App) deregiserRevision(ctx context.Context, opt DeregisterOption, inUse
 	}
 	if aws.ToBool(opt.Force) || prompter.YesNo(fmt.Sprintf("Deregister %s ?", name), false) {
 		d.Log(fmt.Sprintf("Deregistring %s", name))
-		if _, err := d.ecsv2.DeregisterTaskDefinition(ctx, &ecs.DeregisterTaskDefinitionInput{
+		if _, err := d.ecs.DeregisterTaskDefinition(ctx, &ecs.DeregisterTaskDefinitionInput{
 			TaskDefinition: aws.String(name),
 		}); err != nil {
 			return errors.Wrap(err, "failed to deregister task definition")
@@ -85,7 +85,7 @@ func (d *App) deregisterKeeps(ctx context.Context, opt DeregisterOption, inUse m
 	names := []string{}
 	var nextToken *string
 	for {
-		res, err := d.ecsv2.ListTaskDefinitions(ctx, &ecs.ListTaskDefinitionsInput{
+		res, err := d.ecs.ListTaskDefinitions(ctx, &ecs.ListTaskDefinitionsInput{
 			FamilyPrefix: td.Family,
 			NextToken:    nextToken,
 		})
@@ -130,7 +130,7 @@ func (d *App) deregisterKeeps(ctx context.Context, opt DeregisterOption, inUse m
 	if aws.ToBool(opt.Force) || prompter.YesNo(fmt.Sprintf("Deregister %d revisons?", len(deregs)), false) {
 		for _, name := range deregs {
 			d.Log(fmt.Sprintf("Deregistring %s", name))
-			if _, err := d.ecsv2.DeregisterTaskDefinition(ctx, &ecs.DeregisterTaskDefinitionInput{
+			if _, err := d.ecs.DeregisterTaskDefinition(ctx, &ecs.DeregisterTaskDefinitionInput{
 				TaskDefinition: aws.String(name),
 			}); err != nil {
 				return errors.Wrap(err, "failed to deregister task definition")

--- a/deregister.go
+++ b/deregister.go
@@ -150,7 +150,7 @@ func (d *App) deregisterKeeps(ctx context.Context, opt DeregisterOption, inUse m
 
 func (d *App) inUseRevisions(ctx context.Context) (map[string]string, error) {
 	inUse := make(map[string]string)
-	tasks, err := d.listTasks(ctx, nil)
+	tasks, err := d.listTasks(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/deregister.go
+++ b/deregister.go
@@ -7,9 +7,9 @@ import (
 	"time"
 
 	"github.com/Songmu/prompter"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/arn"
-	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	"github.com/pkg/errors"
 )
 
@@ -37,9 +37,9 @@ func (d *App) Deregister(opt DeregisterOption) error {
 		return err
 	}
 
-	if aws.Int64Value(opt.Revision) > 0 {
+	if aws.ToInt64(opt.Revision) > 0 {
 		return d.deregiserRevision(ctx, opt, inUse)
-	} else if aws.IntValue(opt.Keeps) > 0 {
+	} else if aws.ToInt(opt.Keeps) > 0 {
 		return d.deregisterKeeps(ctx, opt, inUse)
 	}
 	return errors.New("--revision or --keeps required")
@@ -50,20 +50,20 @@ func (d *App) deregiserRevision(ctx context.Context, opt DeregisterOption, inUse
 	if err != nil {
 		return errors.Wrap(err, "failed to load task definition")
 	}
-	name := fmt.Sprintf("%s:%d", aws.StringValue(td.Family), aws.Int64Value(opt.Revision))
+	name := fmt.Sprintf("%s:%d", aws.ToString(td.Family), aws.ToInt64(opt.Revision))
 
 	if s := inUse[name]; s != "" {
 		return errors.Errorf("%s is in use by %s", name, s)
 	}
 
-	if aws.BoolValue(opt.DryRun) {
+	if aws.ToBool(opt.DryRun) {
 		d.Log(fmt.Sprintf("task definition %s will be deregistered", name))
 		d.Log("DRY RUN OK")
 		return nil
 	}
-	if aws.BoolValue(opt.Force) || prompter.YesNo(fmt.Sprintf("Deregister %s ?", name), false) {
+	if aws.ToBool(opt.Force) || prompter.YesNo(fmt.Sprintf("Deregister %s ?", name), false) {
 		d.Log(fmt.Sprintf("Deregistring %s", name))
-		if _, err := d.ecs.DeregisterTaskDefinitionWithContext(ctx, &ecs.DeregisterTaskDefinitionInput{
+		if _, err := d.ecsv2.DeregisterTaskDefinition(ctx, &ecs.DeregisterTaskDefinitionInput{
 			TaskDefinition: aws.String(name),
 		}); err != nil {
 			return errors.Wrap(err, "failed to deregister task definition")
@@ -77,7 +77,7 @@ func (d *App) deregiserRevision(ctx context.Context, opt DeregisterOption, inUse
 }
 
 func (d *App) deregisterKeeps(ctx context.Context, opt DeregisterOption, inUse map[string]string) error {
-	keeps := aws.IntValue(opt.Keeps)
+	keeps := aws.ToInt(opt.Keeps)
 	td, err := d.LoadTaskDefinition(d.config.TaskDefinitionPath)
 	if err != nil {
 		return errors.Wrap(err, "failed to load task definition")
@@ -85,7 +85,7 @@ func (d *App) deregisterKeeps(ctx context.Context, opt DeregisterOption, inUse m
 	names := []string{}
 	var nextToken *string
 	for {
-		res, err := d.ecs.ListTaskDefinitionsWithContext(ctx, &ecs.ListTaskDefinitionsInput{
+		res, err := d.ecsv2.ListTaskDefinitions(ctx, &ecs.ListTaskDefinitionsInput{
 			FamilyPrefix: td.Family,
 			NextToken:    nextToken,
 		})
@@ -93,7 +93,7 @@ func (d *App) deregisterKeeps(ctx context.Context, opt DeregisterOption, inUse m
 			return errors.Wrap(err, "failed to list task definitions")
 		}
 		for _, a := range res.TaskDefinitionArns {
-			name, err := taskDefinitionToName(*a)
+			name, err := taskDefinitionToName(a)
 			if err != nil {
 				continue
 			}
@@ -121,16 +121,16 @@ func (d *App) deregisterKeeps(ctx context.Context, opt DeregisterOption, inUse m
 			deregs = append(deregs, name)
 		}
 	}
-	if aws.BoolValue(opt.DryRun) {
+	if aws.ToBool(opt.DryRun) {
 		d.Log("DRY RUN OK")
 		return nil
 	}
 
 	deregistered := 0
-	if aws.BoolValue(opt.Force) || prompter.YesNo(fmt.Sprintf("Deregister %d revisons?", len(deregs)), false) {
+	if aws.ToBool(opt.Force) || prompter.YesNo(fmt.Sprintf("Deregister %d revisons?", len(deregs)), false) {
 		for _, name := range deregs {
 			d.Log(fmt.Sprintf("Deregistring %s", name))
-			if _, err := d.ecs.DeregisterTaskDefinitionWithContext(ctx, &ecs.DeregisterTaskDefinitionInput{
+			if _, err := d.ecsv2.DeregisterTaskDefinition(ctx, &ecs.DeregisterTaskDefinitionInput{
 				TaskDefinition: aws.String(name),
 			}); err != nil {
 				return errors.Wrap(err, "failed to deregister task definition")
@@ -156,9 +156,9 @@ func (d *App) inUseRevisions(ctx context.Context) (map[string]string, error) {
 	}
 	for _, task := range tasks {
 		name, _ := taskDefinitionToName(*task.TaskDefinitionArn)
-		st := aws.StringValue(task.LastStatus)
+		st := aws.ToString(task.LastStatus)
 		if st == "" {
-			st = aws.StringValue(task.DesiredStatus)
+			st = aws.ToString(task.DesiredStatus)
 		}
 		if st != "STOPPED" {
 			// ignore STOPPED tasks for in use

--- a/diff.go
+++ b/diff.go
@@ -21,7 +21,7 @@ func diffServices(local, remote *types.Service, remoteArn string, localPath stri
 	sortServiceDefinitionForDiff(local)
 	sortServiceDefinitionForDiff(remote)
 
-	newSvBytes, err := MarshalJSON(svToUpdateServiceInput(local))
+	newSvBytes, err := MarshalJSONForAPI(svToUpdateServiceInput(local))
 	if err != nil {
 		return "", errors.Wrap(err, "failed to marshal new service definition")
 	}
@@ -29,7 +29,7 @@ func diffServices(local, remote *types.Service, remoteArn string, localPath stri
 		// ignore DesiredCount when it in local is not defined.
 		remote.DesiredCount = 0
 	}
-	remoteSvBytes, err := MarshalJSON(svToUpdateServiceInput(remote))
+	remoteSvBytes, err := MarshalJSONForAPI(svToUpdateServiceInput(remote))
 	if err != nil {
 		return "", errors.Wrap(err, "failed to marshal remote service definition")
 	}
@@ -53,12 +53,12 @@ func diffTaskDefs(local, remote *TaskDefinitionInput, remoteArn string, localPat
 	sortTaskDefinitionForDiff(local)
 	sortTaskDefinitionForDiff(remote)
 
-	newTdBytes, err := MarshalJSON(local)
+	newTdBytes, err := MarshalJSONForAPI(local)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to marshal new task definition")
 	}
 
-	remoteTdBytes, err := MarshalJSON(remote)
+	remoteTdBytes, err := MarshalJSONForAPI(remote)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to marshal remote task definition")
 	}

--- a/diff.go
+++ b/diff.go
@@ -17,7 +17,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func diffServices(local, remote *types.Service, remoteArn string, localPath string, unified bool) (string, error) {
+func diffServices(local, remote *Service, remoteArn string, localPath string, unified bool) (string, error) {
 	sortServiceDefinitionForDiff(local)
 	sortServiceDefinitionForDiff(remote)
 
@@ -216,7 +216,7 @@ func equalString(a *string, b string) bool {
 	return *a == b
 }
 
-func sortServiceDefinitionForDiff(sv *types.Service) {
+func sortServiceDefinitionForDiff(sv *Service) {
 	sortSlicesInDefinition(
 		reflect.TypeOf(*sv), reflect.Indirect(reflect.ValueOf(sv)),
 		"PlacementConstraints",

--- a/diff.go
+++ b/diff.go
@@ -25,9 +25,9 @@ func diffServices(local, remote *Service, remoteArn string, localPath string, un
 	if err != nil {
 		return "", errors.Wrap(err, "failed to marshal new service definition")
 	}
-	if local.DesiredCount == 0 {
+	if aws.ToInt32(local.DesiredCount) == 0 {
 		// ignore DesiredCount when it in local is not defined.
-		remote.DesiredCount = 0
+		remote.DesiredCount = aws.Int32(0)
 	}
 	remoteSvBytes, err := MarshalJSONForAPI(svToUpdateServiceInput(remote))
 	if err != nil {

--- a/diff.go
+++ b/diff.go
@@ -25,7 +25,7 @@ func diffServices(local, remote *Service, remoteArn string, localPath string, un
 	if err != nil {
 		return "", errors.Wrap(err, "failed to marshal new service definition")
 	}
-	if aws.ToInt32(local.DesiredCount) == 0 {
+	if local.DesiredCount == nil {
 		// ignore DesiredCount when it in local is not defined.
 		remote.DesiredCount = aws.Int32(0)
 	}

--- a/diff_test.go
+++ b/diff_test.go
@@ -3,8 +3,8 @@ package ecspresso_test
 import (
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/kayac/ecspresso"
 )
 
@@ -42,11 +42,11 @@ func TestToNumberMemory(t *testing.T) {
 var testTaskDefinition1 = &ecspresso.TaskDefinitionInput{
 	Cpu:    aws.String("0.25 vCPU"),
 	Memory: aws.String("1 GB"),
-	ContainerDefinitions: []*ecs.ContainerDefinition{
+	ContainerDefinitions: []types.ContainerDefinition{
 		{
 			Name:  aws.String("app"),
 			Image: aws.String("debian:buster"),
-			Environment: []*ecs.KeyValuePair{
+			Environment: []types.KeyValuePair{
 				{
 					Name:  aws.String("TZ"),
 					Value: aws.String("UTC"),
@@ -58,14 +58,14 @@ var testTaskDefinition1 = &ecspresso.TaskDefinitionInput{
 			},
 		},
 		{
-			Cpu:   aws.Int64(0),
+			Cpu:   0,
 			Name:  aws.String("web"),
 			Image: aws.String("nginx:latest"),
 		},
 	},
-	ProxyConfiguration: &ecs.ProxyConfiguration{
+	ProxyConfiguration: &types.ProxyConfiguration{
 		ContainerName: aws.String("envoy"),
-		Properties: []*ecs.KeyValuePair{
+		Properties: []types.KeyValuePair{
 			{
 				Name:  aws.String("ProxyIngressPort"),
 				Value: aws.String("15000"),
@@ -76,7 +76,7 @@ var testTaskDefinition1 = &ecspresso.TaskDefinitionInput{
 			},
 		},
 	},
-	Tags: []*ecs.Tag{
+	Tags: []types.Tag{
 		{
 			Key:   aws.String("AppVersion"),
 			Value: aws.String("v1"),
@@ -90,7 +90,7 @@ var testTaskDefinition1 = &ecspresso.TaskDefinitionInput{
 var testTaskDefinition2 = &ecspresso.TaskDefinitionInput{
 	Cpu:    aws.String("256"),
 	Memory: aws.String("1024"),
-	ContainerDefinitions: []*ecs.ContainerDefinition{
+	ContainerDefinitions: []types.ContainerDefinition{
 		{
 			Name:  aws.String("web"),
 			Image: aws.String("nginx:latest"),
@@ -98,7 +98,7 @@ var testTaskDefinition2 = &ecspresso.TaskDefinitionInput{
 		{
 			Name:  aws.String("app"),
 			Image: aws.String("debian:buster"),
-			Environment: []*ecs.KeyValuePair{
+			Environment: []types.KeyValuePair{
 				{
 					Name:  aws.String("LANG"),
 					Value: aws.String("en_US"),
@@ -110,10 +110,10 @@ var testTaskDefinition2 = &ecspresso.TaskDefinitionInput{
 			},
 		},
 	},
-	Volumes: []*ecs.Volume{},
-	ProxyConfiguration: &ecs.ProxyConfiguration{
+	Volumes: []types.Volume{},
+	ProxyConfiguration: &types.ProxyConfiguration{
 		ContainerName: aws.String("envoy"),
-		Properties: []*ecs.KeyValuePair{
+		Properties: []types.KeyValuePair{
 			{
 				Name:  aws.String("ProxyEgressPort"),
 				Value: aws.String("15001"),
@@ -124,7 +124,7 @@ var testTaskDefinition2 = &ecspresso.TaskDefinitionInput{
 			},
 		},
 	},
-	Tags: []*ecs.Tag{
+	Tags: []types.Tag{
 		{
 			Key:   aws.String("Environment"),
 			Value: aws.String("Dev"),
@@ -140,46 +140,46 @@ func TestTaskDefinitionDiffer(t *testing.T) {
 	ecspresso.SortTaskDefinitionForDiff(testTaskDefinition2)
 	if ecspresso.MarshalJSONString(testTaskDefinition1) != ecspresso.MarshalJSONString(testTaskDefinition2) {
 		t.Error("failed to sortTaskDefinitionForDiff")
-		t.Log(testTaskDefinition1.String())
-		t.Log(testTaskDefinition2.String())
+		t.Log(testTaskDefinition1)
+		t.Log(testTaskDefinition2)
 	}
 }
 
-var testServiceDefinition1 = &ecs.Service{
-	LaunchType: aws.String("FARGATE"),
-	NetworkConfiguration: &ecs.NetworkConfiguration{
-		AwsvpcConfiguration: &ecs.AwsVpcConfiguration{
-			Subnets: []*string{
-				aws.String("subnet-876543210"),
-				aws.String("subnet-012345678"),
+var testServiceDefinition1 = &types.Service{
+	LaunchType: types.LaunchTypeFargate,
+	NetworkConfiguration: &types.NetworkConfiguration{
+		AwsvpcConfiguration: &types.AwsVpcConfiguration{
+			Subnets: []string{
+				"subnet-876543210",
+				"subnet-012345678",
 			},
-			SecurityGroups: []*string{
-				aws.String("sg-99999999"),
-				aws.String("sg-11111111"),
+			SecurityGroups: []string{
+				"sg-99999999",
+				"sg-11111111",
 			},
 		},
 	},
 }
 
-var testServiceDefinition2 = &ecs.Service{
-	DeploymentConfiguration: &ecs.DeploymentConfiguration{
-		MaximumPercent:        aws.Int64(200),
-		MinimumHealthyPercent: aws.Int64(100),
+var testServiceDefinition2 = &types.Service{
+	DeploymentConfiguration: &types.DeploymentConfiguration{
+		MaximumPercent:        aws.Int32(200),
+		MinimumHealthyPercent: aws.Int32(100),
 	},
-	NetworkConfiguration: &ecs.NetworkConfiguration{
-		AwsvpcConfiguration: &ecs.AwsVpcConfiguration{
-			Subnets: []*string{
-				aws.String("subnet-012345678"),
-				aws.String("subnet-876543210"),
+	NetworkConfiguration: &types.NetworkConfiguration{
+		AwsvpcConfiguration: &types.AwsVpcConfiguration{
+			Subnets: []string{
+				"subnet-012345678",
+				"subnet-876543210",
 			},
-			SecurityGroups: []*string{
-				aws.String("sg-11111111"),
-				aws.String("sg-99999999"),
+			SecurityGroups: []string{
+				"sg-11111111",
+				"sg-99999999",
 			},
-			AssignPublicIp: aws.String("DISABLED"),
+			AssignPublicIp: types.AssignPublicIpDisabled,
 		},
 	},
-	LaunchType:      aws.String("FARGATE"),
+	LaunchType:      types.LaunchTypeFargate,
 	PlatformVersion: aws.String("LATEST"),
 }
 
@@ -188,7 +188,7 @@ func TestServiceDefinitionDiffer(t *testing.T) {
 	ecspresso.SortServiceDefinitionForDiff(testServiceDefinition2)
 	if ecspresso.MarshalJSONString(testServiceDefinition1) != ecspresso.MarshalJSONString(testServiceDefinition2) {
 		t.Error("failed to SortTaskDefinitionForDiff")
-		t.Log(testServiceDefinition1.String())
-		t.Log(testServiceDefinition2.String())
+		t.Log(testServiceDefinition1)
+		t.Log(testServiceDefinition2)
 	}
 }

--- a/diff_test.go
+++ b/diff_test.go
@@ -146,41 +146,45 @@ func TestTaskDefinitionDiffer(t *testing.T) {
 }
 
 var testServiceDefinition1 = &ecspresso.Service{
-	LaunchType: types.LaunchTypeFargate,
-	NetworkConfiguration: &types.NetworkConfiguration{
-		AwsvpcConfiguration: &types.AwsVpcConfiguration{
-			Subnets: []string{
-				"subnet-876543210",
-				"subnet-012345678",
-			},
-			SecurityGroups: []string{
-				"sg-99999999",
-				"sg-11111111",
+	Service: types.Service{
+		LaunchType: types.LaunchTypeFargate,
+		NetworkConfiguration: &types.NetworkConfiguration{
+			AwsvpcConfiguration: &types.AwsVpcConfiguration{
+				Subnets: []string{
+					"subnet-876543210",
+					"subnet-012345678",
+				},
+				SecurityGroups: []string{
+					"sg-99999999",
+					"sg-11111111",
+				},
 			},
 		},
 	},
 }
 
 var testServiceDefinition2 = &ecspresso.Service{
-	DeploymentConfiguration: &types.DeploymentConfiguration{
-		MaximumPercent:        aws.Int32(200),
-		MinimumHealthyPercent: aws.Int32(100),
-	},
-	NetworkConfiguration: &types.NetworkConfiguration{
-		AwsvpcConfiguration: &types.AwsVpcConfiguration{
-			Subnets: []string{
-				"subnet-012345678",
-				"subnet-876543210",
-			},
-			SecurityGroups: []string{
-				"sg-11111111",
-				"sg-99999999",
-			},
-			AssignPublicIp: types.AssignPublicIpDisabled,
+	Service: types.Service{
+		DeploymentConfiguration: &types.DeploymentConfiguration{
+			MaximumPercent:        aws.Int32(200),
+			MinimumHealthyPercent: aws.Int32(100),
 		},
+		NetworkConfiguration: &types.NetworkConfiguration{
+			AwsvpcConfiguration: &types.AwsVpcConfiguration{
+				Subnets: []string{
+					"subnet-012345678",
+					"subnet-876543210",
+				},
+				SecurityGroups: []string{
+					"sg-11111111",
+					"sg-99999999",
+				},
+				AssignPublicIp: types.AssignPublicIpDisabled,
+			},
+		},
+		LaunchType:      types.LaunchTypeFargate,
+		PlatformVersion: aws.String("LATEST"),
 	},
-	LaunchType:      types.LaunchTypeFargate,
-	PlatformVersion: aws.String("LATEST"),
 }
 
 func TestServiceDefinitionDiffer(t *testing.T) {

--- a/diff_test.go
+++ b/diff_test.go
@@ -145,7 +145,7 @@ func TestTaskDefinitionDiffer(t *testing.T) {
 	}
 }
 
-var testServiceDefinition1 = &types.Service{
+var testServiceDefinition1 = &ecspresso.Service{
 	LaunchType: types.LaunchTypeFargate,
 	NetworkConfiguration: &types.NetworkConfiguration{
 		AwsvpcConfiguration: &types.AwsVpcConfiguration{
@@ -161,7 +161,7 @@ var testServiceDefinition1 = &types.Service{
 	},
 }
 
-var testServiceDefinition2 = &types.Service{
+var testServiceDefinition2 = &ecspresso.Service{
 	DeploymentConfiguration: &types.DeploymentConfiguration{
 		MaximumPercent:        aws.Int32(200),
 		MinimumHealthyPercent: aws.Int32(100),

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Songmu/prompter"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/request"
@@ -21,7 +22,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/applicationautoscaling"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go/service/codedeploy"
-	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/fatih/color"
 	gc "github.com/kayac/go-config"
 	"github.com/mattn/go-isatty"
@@ -61,7 +61,7 @@ type App struct {
 	autoScaling *applicationautoscaling.ApplicationAutoScaling
 	codedeploy  *codedeploy.CodeDeploy
 	cwl         *cloudwatchlogs.CloudWatchLogs
-	iam         *iam.IAM
+	iam         *iam.Client
 
 	sess     *session.Session
 	verifier *verifier
@@ -291,11 +291,11 @@ func NewApp(conf *Config) (*App, error) {
 	d := &App{
 		Service:     conf.Service,
 		Cluster:     conf.Cluster,
-		ecs:       ecs.NewFromConfig(conf.awsv2Config),
+		ecs:         ecs.NewFromConfig(conf.awsv2Config),
 		autoScaling: applicationautoscaling.New(sess),
 		codedeploy:  codedeploy.New(sess),
 		cwl:         cloudwatchlogs.New(sess),
-		iam:         iam.New(sess),
+		iam:         iam.NewFromConfig(conf.awsv2Config),
 
 		sess:   sess,
 		config: conf,

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/Songmu/prompter"
+	ecsv2 "github.com/aws/aws-sdk-go-v2/service/ecs"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/request"
@@ -45,6 +46,7 @@ func taskDefinitionName(t *TaskDefinition) string {
 
 type App struct {
 	ecs         *ecs.ECS
+	ecsv2       *ecsv2.Client
 	autoScaling *applicationautoscaling.ApplicationAutoScaling
 	codedeploy  *codedeploy.CodeDeploy
 	cwl         *cloudwatchlogs.CloudWatchLogs
@@ -279,6 +281,7 @@ func NewApp(conf *Config) (*App, error) {
 		Service:     conf.Service,
 		Cluster:     conf.Cluster,
 		ecs:         ecs.New(sess),
+		ecsv2:       ecsv2.NewFromConfig(conf.awsv2Config),
 		autoScaling: applicationautoscaling.New(sess),
 		codedeploy:  codedeploy.New(sess),
 		cwl:         cloudwatchlogs.New(sess),

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -44,7 +44,17 @@ func taskDefinitionName(t *TaskDefinition) string {
 	return fmt.Sprintf("%s:%d", *t.Family, t.Revision)
 }
 
-type Service = types.Service
+type Service struct {
+	types.Service
+	DesiredCount *int32
+}
+
+func newServiceFromTypes(sv types.Service) *Service {
+	return &Service{
+		Service:      sv,
+		DesiredCount: aws.Int32(sv.DesiredCount),
+	}
+}
 
 type App struct {
 	ecsv2       *ecsv2.Client
@@ -98,7 +108,7 @@ func (d *App) DescribeService(ctx context.Context) (*Service, error) {
 	if len(out.Services) == 0 {
 		return nil, errors.New("service is not found")
 	}
-	return &out.Services[0], nil
+	return newServiceFromTypes(out.Services[0]), nil
 }
 
 func (d *App) DescribeServiceStatus(ctx context.Context, events int) (*Service, error) {

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -563,6 +563,11 @@ func (d *App) LoadServiceDefinition(path string) (*Service, error) {
 	}
 
 	sv.ServiceName = aws.String(d.config.Service)
+	if sv.DesiredCount == nil {
+		d.DebugLog("Loaded DesiredCount: nil (-1)")
+	} else {
+		d.DebugLog("Loaded DesiredCount:", *sv.DesiredCount)
+	}
 	return &sv, nil
 }
 

--- a/ecspresso_test.go
+++ b/ecspresso_test.go
@@ -39,6 +39,12 @@ func TestLoadTaskDefinition(t *testing.T) {
 		if s := td.EphemeralStorage.SizeInGiB; s != 25 {
 			t.Errorf("EphemeralStorage.SizeInGiB expected %d got %d", 25, s)
 		}
+		if td.ContainerDefinitions[0].DockerLabels["name"] != "katsubushi" {
+			t.Errorf("unexpected DockerLabels unexpected got %v", td.ContainerDefinitions[0].DockerLabels)
+		}
+		if td.ContainerDefinitions[0].LogConfiguration.Options["awslogs-group"] != "fargate" {
+			t.Errorf("unexpected LogConfiguration.Options got %v", td.ContainerDefinitions[0].LogConfiguration.Options)
+		}
 	}
 }
 

--- a/ecspresso_test.go
+++ b/ecspresso_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/kayac/ecspresso"
 )
 
@@ -37,7 +36,7 @@ func TestLoadTaskDefinition(t *testing.T) {
 		if err != nil || td == nil {
 			t.Errorf("%s load failed: %s", path, err)
 		}
-		if s := aws.Int64Value(td.EphemeralStorage.SizeInGiB); s != 25 {
+		if s := td.EphemeralStorage.SizeInGiB; s != 25 {
 			t.Errorf("EphemeralStorage.SizeInGiB expected %d got %d", 25, s)
 		}
 	}

--- a/exec.go
+++ b/exec.go
@@ -3,7 +3,7 @@ package ecspresso
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/fujiwara/ecsta"
 	"github.com/pkg/errors"
 )
@@ -31,19 +31,19 @@ func (d *App) Exec(opt ExecOption) error {
 		return errors.Wrap(err, "failed to create ecsta app")
 	}
 
-	if aws.BoolValue(opt.PortForward) {
+	if aws.ToBool(opt.PortForward) {
 		return ecstaApp.RunPortforward(ctx, &ecsta.PortforwardOption{
-			ID:         aws.StringValue(opt.ID),
-			Container:  aws.StringValue(opt.Container),
-			LocalPort:  aws.IntValue(opt.LocalPort),
-			RemotePort: aws.IntValue(opt.Port),
+			ID:         aws.ToString(opt.ID),
+			Container:  aws.ToString(opt.Container),
+			LocalPort:  aws.ToInt(opt.LocalPort),
+			RemotePort: aws.ToInt(opt.Port),
 			RemoteHost: "", // TODO
 		})
 	} else {
 		return ecstaApp.RunExec(ctx, &ecsta.ExecOption{
-			ID:        aws.StringValue(opt.ID),
-			Command:   aws.StringValue(opt.Command),
-			Container: aws.StringValue(opt.Container),
+			ID:        aws.ToString(opt.ID),
+			Command:   aws.ToString(opt.Command),
+			Container: aws.ToString(opt.Container),
 		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go v1.43.15
 	github.com/aws/aws-sdk-go-v2 v1.16.14
 	github.com/aws/aws-sdk-go-v2/config v1.17.1
+	github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.15.16
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.18.15
 	github.com/aws/aws-sdk-go-v2/service/iam v1.18.17
 	github.com/fatih/color v1.12.0

--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,10 @@ require (
 	github.com/Songmu/prompter v0.5.1
 	github.com/alecthomas/kingpin v1.3.8-0.20190930021037-0a108b7f5563
 	github.com/aws/aws-sdk-go v1.43.15
-	github.com/aws/aws-sdk-go-v2 v1.16.11
+	github.com/aws/aws-sdk-go-v2 v1.16.14
 	github.com/aws/aws-sdk-go-v2/config v1.17.1
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.18.15
+	github.com/aws/aws-sdk-go-v2/service/iam v1.18.17
 	github.com/fatih/color v1.12.0
 	github.com/fujiwara/cfn-lookup v0.0.2
 	github.com/fujiwara/ecsta v0.0.5

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,9 @@ require (
 	github.com/Songmu/prompter v0.5.1
 	github.com/alecthomas/kingpin v1.3.8-0.20190930021037-0a108b7f5563
 	github.com/aws/aws-sdk-go v1.43.15
+	github.com/aws/aws-sdk-go-v2 v1.16.11
+	github.com/aws/aws-sdk-go-v2/config v1.17.1
+	github.com/aws/aws-sdk-go-v2/service/ecs v1.18.15
 	github.com/fatih/color v1.12.0
 	github.com/fujiwara/cfn-lookup v0.0.2
 	github.com/fujiwara/ecsta v0.0.5

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,8 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.16.14
 	github.com/aws/aws-sdk-go-v2/config v1.17.1
 	github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.15.16
+	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.15.14
+	github.com/aws/aws-sdk-go-v2/service/codedeploy v1.14.16
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.18.15
 	github.com/aws/aws-sdk-go-v2/service/iam v1.18.17
 	github.com/fatih/color v1.12.0

--- a/go.sum
+++ b/go.sum
@@ -96,8 +96,9 @@ github.com/aws/aws-sdk-go v1.40.28/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm
 github.com/aws/aws-sdk-go v1.43.15 h1:zAOUdqgNgJrkivRZi93NTjPNvuIQ5EcqNHSk0A1jrk8=
 github.com/aws/aws-sdk-go v1.43.15/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/aws/aws-sdk-go-v2 v1.16.8/go.mod h1:6CpKuLXg2w7If3ABZCl/qZ6rEgwtjZTn4eAf4RcEyuw=
-github.com/aws/aws-sdk-go-v2 v1.16.11 h1:xM1ZPSvty3xVmdxiGr7ay/wlqv+MWhH0rMlyLdbC0YQ=
 github.com/aws/aws-sdk-go-v2 v1.16.11/go.mod h1:WTACcleLz6VZTp7fak4EO5b9Q4foxbn+8PIz3PmyKlo=
+github.com/aws/aws-sdk-go-v2 v1.16.14 h1:db6GvO4Z2UqHt5gvT0lr6J5x5P+oQ7bdRzczVaRekMU=
+github.com/aws/aws-sdk-go-v2 v1.16.14/go.mod h1:s/G+UV29dECbF5rf+RNj1xhlmvoNurGSr+McVSRj59w=
 github.com/aws/aws-sdk-go-v2/config v1.15.15/go.mod h1:A1Lzyy/o21I5/s2FbyX5AevQfSVXpvvIDCoVFD0BC4E=
 github.com/aws/aws-sdk-go-v2/config v1.17.1 h1:BWxTjokU/69BZ4DnLrZco6OvBDii6ToEdfBL/y5I1nA=
 github.com/aws/aws-sdk-go-v2/config v1.17.1/go.mod h1:uOxDHjBemNTF2Zos+fgG0NNfE86wn1OAHDTGxjMEYi0=
@@ -108,11 +109,13 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.9/go.mod h1:KDCCm4ONIdHtUloD
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.12 h1:wgJBHO58Pc1V1QAnzdVM3JK3WbE/6eUF0JxCZ+/izz0=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.12/go.mod h1:aZ4vZnyUuxedC7eD4JyEHpGnCz+O2sHQEx3VvAwklSE=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.15/go.mod h1:pWrr2OoHlT7M/Pd2y4HV3gJyPb3qj5qMmnPkKSNPYK4=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.18 h1:OmiwoVyLKEqqD5GvB683dbSqxiOfvx4U2lDZhG2Esc4=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.18/go.mod h1:348MLhzV1GSlZSMusdwQpXKbhD7X2gbI/TxwAPKkYZQ=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.21 h1:gRIXnmAVNyoRQywdNtpAkgY+f30QNzgF53Q5OobNZZs=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.21/go.mod h1:XsmHMV9c512xgsW01q7H0ut+UQQQpWX8QsFbdLHDwaU=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.9/go.mod h1:08tUpeSGN33QKSO7fwxXczNfiwCpbj+GxK6XKwqWVv0=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.12 h1:5mvQDtNWtI6H56+E4LUnLWEmATMB7oEh+Z9RurtIuC0=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.12/go.mod h1:ckaCVTEdGAxO6KwTGzgskxR1xM+iJW4lxMyDFVda2Fc=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.15 h1:noAhOo2mMDyYhTx99aYPvQw16T3fQ/DiKAv9fzpIKH8=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.15/go.mod h1:kjJ4CyD9M3Wq88GYg3IPfj67Rs0Uvz8aXK7MJ8BvE4I=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.16/go.mod h1:CYmI+7x03jjJih8kBEEFKRQc40UjUokT0k7GbvrhhTc=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.19 h1:g5qq9sgtEzt2szMaDqQO6fqKe026T6dHTFJp5NsPzkQ=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.19/go.mod h1:cVHo8KTuHjShb9V8/VjH3S/8+xPu16qx8fdGwmotJhE=
@@ -122,6 +125,8 @@ github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.15.14/go.mod h1:62kPuTAGP
 github.com/aws/aws-sdk-go-v2/service/ecs v1.18.12/go.mod h1:h1UvIIC+fPNj4PkuQ/o9QyRH0/vC+qlHRNGefwwYzv8=
 github.com/aws/aws-sdk-go-v2/service/ecs v1.18.15 h1:dseu9SGI3VepG39If8W1HTyNrI/PFyh8PoJUDjnYCtQ=
 github.com/aws/aws-sdk-go-v2/service/ecs v1.18.15/go.mod h1:KIyoYPeoCLYhO0mA82lUwtZnEyQPVdgg6aPSGQOD0TA=
+github.com/aws/aws-sdk-go-v2/service/iam v1.18.17 h1:2sbycB3YvoTTT6bqT8GmTRRkNnpTh42OeFv5IEBCPkk=
+github.com/aws/aws-sdk-go-v2/service/iam v1.18.17/go.mod h1:P78+32N8FUruwcMQz0YET9NnD991g6Ud2Z9ldLX3OxM=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.9/go.mod h1:yQowTpvdZkFVuHrLBXmczat4W+WJKg/PafBZnGBLga0=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.12 h1:7iPTTX4SAI2U2VOogD7/gmHlsgnYSgoNHt7MSQXtG2M=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.12/go.mod h1:1TODGhheLWjpQWSuhYuAUWYTCKwEjx2iblIFKDHjeTc=
@@ -137,8 +142,9 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.16.10/go.mod h1:cftkHYN6tCDNfkSasAmc
 github.com/aws/aws-sdk-go-v2/service/sts v1.16.13 h1:dl8T0PJlN92rvEGOEUiD0+YPYdPEaCZK0TqHukvSfII=
 github.com/aws/aws-sdk-go-v2/service/sts v1.16.13/go.mod h1:Ru3QVMLygVs/07UQ3YDur1AQZZp2tUNje8wfloFttC0=
 github.com/aws/smithy-go v1.12.0/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
-github.com/aws/smithy-go v1.12.1 h1:yQRC55aXN/y1W10HgwHle01DRuV9Dpf31iGkotjt3Ag=
 github.com/aws/smithy-go v1.12.1/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
+github.com/aws/smithy-go v1.13.2 h1:TBLKyeJfXTrTXRHmsv4qWt9IQGYyWThLYaJWSahTOGE=
+github.com/aws/smithy-go v1.13.2/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=

--- a/go.sum
+++ b/go.sum
@@ -119,6 +119,8 @@ github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.15/go.mod h1:kjJ4CyD9M3W
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.16/go.mod h1:CYmI+7x03jjJih8kBEEFKRQc40UjUokT0k7GbvrhhTc=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.19 h1:g5qq9sgtEzt2szMaDqQO6fqKe026T6dHTFJp5NsPzkQ=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.19/go.mod h1:cVHo8KTuHjShb9V8/VjH3S/8+xPu16qx8fdGwmotJhE=
+github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.15.16 h1:1qvgiz7fkymYtKS0CRl8a7YrTm76I8BIMEcq9lM6AIk=
+github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.15.16/go.mod h1:W6KbRG3mlT0RuZ84+JzfYj5FGRZCrUnKd60qf9VRd2U=
 github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.15.11/go.mod h1:0vT2mfhUL63/UT1RvYF/1wuqvvuvY0e+CiLB1paT+qI=
 github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.15.14 h1:SO5LdqjF9dlURPzk3LNMzCz9RA5K8/yNOf6WpdoffJU=
 github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.15.14/go.mod h1:62kPuTAGPxpvo/0y/+QvaFwHffIe4l8hmStHLwaisLI=

--- a/go.sum
+++ b/go.sum
@@ -124,6 +124,8 @@ github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.15.16/go.mod h1:W
 github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.15.11/go.mod h1:0vT2mfhUL63/UT1RvYF/1wuqvvuvY0e+CiLB1paT+qI=
 github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.15.14 h1:SO5LdqjF9dlURPzk3LNMzCz9RA5K8/yNOf6WpdoffJU=
 github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.15.14/go.mod h1:62kPuTAGPxpvo/0y/+QvaFwHffIe4l8hmStHLwaisLI=
+github.com/aws/aws-sdk-go-v2/service/codedeploy v1.14.16 h1:aERwTws2R3Xn8uj3khpmTv5ts5+5RgUKa0d6XovzOwU=
+github.com/aws/aws-sdk-go-v2/service/codedeploy v1.14.16/go.mod h1:vCAKtnnEccDGzqyB/rPZFLFN137iqVx1iS+OrmKv1/Q=
 github.com/aws/aws-sdk-go-v2/service/ecs v1.18.12/go.mod h1:h1UvIIC+fPNj4PkuQ/o9QyRH0/vC+qlHRNGefwwYzv8=
 github.com/aws/aws-sdk-go-v2/service/ecs v1.18.15 h1:dseu9SGI3VepG39If8W1HTyNrI/PFyh8PoJUDjnYCtQ=
 github.com/aws/aws-sdk-go-v2/service/ecs v1.18.15/go.mod h1:KIyoYPeoCLYhO0mA82lUwtZnEyQPVdgg6aPSGQOD0TA=

--- a/init.go
+++ b/init.go
@@ -120,7 +120,7 @@ func (d *App) Init(opt InitOption) error {
 	return nil
 }
 
-func treatmentServiceDefinition(sv *types.Service) *types.Service {
+func treatmentServiceDefinition(sv *Service) *Service {
 	sv.ClusterArn = nil
 	sv.CreatedAt = nil
 	sv.CreatedBy = nil

--- a/init.go
+++ b/init.go
@@ -55,7 +55,7 @@ func (d *App) Init(opt InitOption) error {
 		return errors.New("service is not found")
 	}
 
-	sv := out.Services[0]
+	sv := newServiceFromTypes(out.Services[0])
 	td, err := d.DescribeTaskDefinition(ctx, *sv.TaskDefinition)
 	if err != nil {
 		return errors.Wrap(err, "failed to describe task definition")
@@ -73,7 +73,7 @@ func (d *App) Init(opt InitOption) error {
 	}
 
 	// service-def
-	treatmentServiceDefinition(&sv)
+	treatmentServiceDefinition(sv)
 	if b, err := MarshalJSON(sv); err != nil {
 		return errors.Wrap(err, "unable to marshal service definition to JSON")
 	} else {

--- a/init.go
+++ b/init.go
@@ -47,7 +47,7 @@ func (d *App) Init(opt InitOption) error {
 		}
 	}
 
-	out, err := d.ecsv2.DescribeServices(ctx, d.DescribeServicesInput())
+	out, err := d.ecs.DescribeServices(ctx, d.DescribeServicesInput())
 	if err != nil {
 		return errors.Wrap(err, "failed to describe service")
 	}
@@ -63,7 +63,7 @@ func (d *App) Init(opt InitOption) error {
 
 	if long, _ := isLongArnFormat(*sv.ServiceArn); long {
 		// Long arn format must be used for tagging operations
-		lt, err := d.ecsv2.ListTagsForResource(ctx, &ecs.ListTagsForResourceInput{
+		lt, err := d.ecs.ListTagsForResource(ctx, &ecs.ListTagsForResourceInput{
 			ResourceArn: sv.ServiceArn,
 		})
 		if err != nil {

--- a/json.go
+++ b/json.go
@@ -53,17 +53,26 @@ func jsonKeyForStruct(s string) string {
 func walkMap(m map[string]interface{}, fn func(string) string) {
 	for key, value := range m {
 		delete(m, key)
+		newKey := key
+		if fn != nil {
+			newKey = fn(key)
+		}
 		if value != nil {
-			m[fn(key)] = value
+			m[newKey] = value
 		}
 		switch value := value.(type) {
 		case map[string]interface{}:
-			walkMap(value, fn)
+			switch strings.ToLower(key) {
+			case "dockerlabels", "options":
+				walkMap(value, nil) // do not rewrite keys for map[string]string
+			default:
+				walkMap(value, fn)
+			}
 		case []interface{}:
 			if len(value) > 0 {
 				walkArray(value, fn)
 			} else {
-				delete(m, fn(key))
+				delete(m, newKey)
 			}
 		default:
 		}

--- a/json.go
+++ b/json.go
@@ -1,0 +1,72 @@
+package ecspresso
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+func MarshalJSONForAPI(v interface{}) ([]byte, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	m := map[string]interface{}{}
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil, err
+	}
+	walkMap(m, jsonKeyForAPI)
+	return json.MarshalIndent(m, "", "  ")
+}
+
+func (d *App) UnmarshalJSONForStruct(src []byte, v interface{}, path string) error {
+	m := map[string]interface{}{}
+	if err := json.Unmarshal(src, &m); err != nil {
+		return err
+	}
+	walkMap(m, jsonKeyForStruct)
+	if b, err := json.Marshal(m); err != nil {
+		return err
+	} else {
+		return d.unmarshalJSON(b, v, path)
+	}
+}
+
+func jsonKeyForAPI(s string) string {
+	if len(s) == 0 {
+		return s
+	}
+	return strings.ToLower(s[:1]) + s[1:]
+}
+
+func jsonKeyForStruct(s string) string {
+	if len(s) == 0 {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+func walkMap(m map[string]interface{}, fn func(string) string) {
+	for key, value := range m {
+		delete(m, key)
+		m[fn(key)] = value
+		switch value := value.(type) {
+		case map[string]interface{}:
+			walkMap(value, fn)
+		case []interface{}:
+			walkArray(value, fn)
+		default:
+		}
+	}
+}
+
+func walkArray(a []interface{}, fn func(string) string) {
+	for _, value := range a {
+		switch value := value.(type) {
+		case map[string]interface{}:
+			walkMap(value, fn)
+		case []interface{}:
+			walkArray(value, fn)
+		default:
+		}
+	}
+}

--- a/options.go
+++ b/options.go
@@ -3,8 +3,8 @@ package ecspresso
 import (
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/pkg/errors"
 )
 
@@ -15,12 +15,12 @@ type DryRunnable interface {
 }
 
 type optWithDesiredCount interface {
-	getDesiredCount() *int64
+	getDesiredCount() *int32
 }
 
 type DeployOption struct {
 	DryRun               *bool
-	DesiredCount         *int64
+	DesiredCount         *int32
 	SkipTaskDefinition   *bool
 	ForceNewDeployment   *bool
 	NoWait               *bool
@@ -30,7 +30,7 @@ type DeployOption struct {
 	LatestTaskDefinition *bool
 }
 
-func (opt DeployOption) getDesiredCount() *int64 {
+func (opt DeployOption) getDesiredCount() *int32 {
 	return opt.DesiredCount
 }
 
@@ -78,7 +78,7 @@ type RunOption struct {
 	TaskOverrideStr      *string
 	TaskOverrideFile     *string
 	SkipTaskDefinition   *bool
-	Count                *int64
+	Count                *int32
 	WatchContainer       *string
 	LatestTaskDefinition *bool
 	PropagateTags        *string
@@ -88,7 +88,7 @@ type RunOption struct {
 }
 
 func (opt RunOption) waitUntilRunning() bool {
-	return aws.StringValue(opt.WaitUntil) == "running"
+	return aws.ToString(opt.WaitUntil) == "running"
 }
 
 func (opt RunOption) DryRunString() string {
@@ -98,8 +98,8 @@ func (opt RunOption) DryRunString() string {
 	return ""
 }
 
-func parseTags(s string) ([]*ecs.Tag, error) {
-	tags := make([]*ecs.Tag, 0)
+func parseTags(s string) ([]types.Tag, error) {
+	tags := make([]types.Tag, 0)
 	if s == "" {
 		return tags, nil
 	}
@@ -116,7 +116,7 @@ func parseTags(s string) ([]*ecs.Tag, error) {
 		if len(pair[0]) == 0 {
 			return tags, errors.Errorf("tag Key is required")
 		}
-		tags = append(tags, &ecs.Tag{
+		tags = append(tags, types.Tag{
 			Key:   aws.String(pair[0]),
 			Value: aws.String(pair[1]),
 		})

--- a/options_test.go
+++ b/options_test.go
@@ -3,34 +3,35 @@ package ecspresso_test
 import (
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/kayac/ecspresso"
 )
 
 type tagsTestSuite struct {
 	src  string
-	tags []*ecs.Tag
+	tags []types.Tag
 	ok   bool
 }
 
 var tagsTestSuites = []tagsTestSuite{
 	{
 		src:  "",
-		tags: []*ecs.Tag{},
+		tags: []types.Tag{},
 		ok:   true,
 	},
 	{
 		src: "Foo=FOO",
-		tags: []*ecs.Tag{
+		tags: []types.Tag{
 			{Key: aws.String("Foo"), Value: aws.String("FOO")},
 		},
 		ok: true,
 	},
 	{
 		src: "Foo=FOO,Bar=BAR",
-		tags: []*ecs.Tag{
+		tags: []types.Tag{
 			{Key: aws.String("Foo"), Value: aws.String("FOO")},
 			{Key: aws.String("Bar"), Value: aws.String("BAR")},
 		},
@@ -38,7 +39,7 @@ var tagsTestSuites = []tagsTestSuite{
 	},
 	{
 		src: "Foo=,Bar=",
-		tags: []*ecs.Tag{
+		tags: []types.Tag{
 			{Key: aws.String("Foo"), Value: aws.String("")},
 			{Key: aws.String("Bar"), Value: aws.String("")},
 		},
@@ -46,7 +47,7 @@ var tagsTestSuites = []tagsTestSuite{
 	},
 	{
 		src: "Foo=FOO,Bar=BAR,Baz=BAZ,",
-		tags: []*ecs.Tag{
+		tags: []types.Tag{
 			{Key: aws.String("Foo"), Value: aws.String("FOO")},
 			{Key: aws.String("Bar"), Value: aws.String("BAR")},
 			{Key: aws.String("Baz"), Value: aws.String("BAZ")},
@@ -66,7 +67,8 @@ func TestParseTags(t *testing.T) {
 				t.Error(err)
 				continue
 			}
-			if d := cmp.Diff(tags, ts.tags); d != "" {
+			opt := cmpopts.IgnoreUnexported(types.Tag{})
+			if d := cmp.Diff(tags, ts.tags, opt); d != "" {
 				t.Error(d)
 			}
 		} else {

--- a/render.go
+++ b/render.go
@@ -27,7 +27,7 @@ func (d *App) Render(opt RenderOption) error {
 		if err != nil {
 			return err
 		}
-		b, err := MarshalJSON(sv)
+		b, _ := MarshalJSONForAPI(sv)
 		_, err = out.Write(b)
 		return err
 	}
@@ -37,7 +37,7 @@ func (d *App) Render(opt RenderOption) error {
 		if err != nil {
 			return err
 		}
-		b, err := MarshalJSON(td)
+		b, _ := MarshalJSONForAPI(td)
 		_, err = out.Write(b)
 		return err
 	}

--- a/render.go
+++ b/render.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"os"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"gopkg.in/yaml.v2"
 )
 
@@ -18,11 +18,11 @@ func (d *App) Render(opt RenderOption) error {
 	out := bufio.NewWriter(os.Stdout)
 	defer out.Flush()
 
-	if aws.BoolValue(opt.ConfigFile) {
+	if aws.ToBool(opt.ConfigFile) {
 		return yaml.NewEncoder(out).Encode(d.config)
 	}
 
-	if aws.BoolValue(opt.ServiceDefinition) {
+	if aws.ToBool(opt.ServiceDefinition) {
 		sv, err := d.LoadServiceDefinition(d.config.ServiceDefinitionPath)
 		if err != nil {
 			return err
@@ -32,7 +32,7 @@ func (d *App) Render(opt RenderOption) error {
 		return err
 	}
 
-	if aws.BoolValue(opt.TaskDefinition) {
+	if aws.ToBool(opt.TaskDefinition) {
 		td, err := d.LoadTaskDefinition(d.config.TaskDefinitionPath)
 		if err != nil {
 			return err

--- a/revisions.go
+++ b/revisions.go
@@ -79,7 +79,7 @@ func (d *App) Revesions(opt RevisionsOption) error {
 
 	if r := aws.ToInt64(opt.Revision); r > 0 {
 		name := fmt.Sprintf("%s:%d", aws.ToString(td.Family), r)
-		res, err := d.ecsv2.DescribeTaskDefinition(ctx, &ecs.DescribeTaskDefinitionInput{
+		res, err := d.ecs.DescribeTaskDefinition(ctx, &ecs.DescribeTaskDefinitionInput{
 			TaskDefinition: &name,
 			Include:        []types.TaskDefinitionField{types.TaskDefinitionFieldTags},
 		})
@@ -97,7 +97,7 @@ func (d *App) Revesions(opt RevisionsOption) error {
 	revs := revisions{}
 	var nextToken *string
 	for {
-		res, err := d.ecsv2.ListTaskDefinitions(ctx, &ecs.ListTaskDefinitionsInput{
+		res, err := d.ecs.ListTaskDefinitions(ctx, &ecs.ListTaskDefinitionsInput{
 			FamilyPrefix: td.Family,
 			NextToken:    nextToken,
 		})

--- a/rollback.go
+++ b/rollback.go
@@ -71,7 +71,7 @@ func (d *App) Rollback(opt RollbackOption) error {
 
 	if *opt.DeregisterTaskDefinition {
 		d.Log("Deregistering the rolled-back task definition", arnToName(currentArn))
-		_, err := d.ecsv2.DeregisterTaskDefinition(
+		_, err := d.ecs.DeregisterTaskDefinition(
 			ctx,
 			&ecs.DeregisterTaskDefinitionInput{
 				TaskDefinition: &currentArn,

--- a/run.go
+++ b/run.go
@@ -92,7 +92,7 @@ func (d *App) RunTask(ctx context.Context, tdArn string, ov *types.TaskOverride,
 
 	switch aws.ToString(opt.PropagateTags) {
 	case "SERVICE":
-		out, err := d.ecsv2.ListTagsForResource(ctx, &ecs.ListTagsForResourceInput{
+		out, err := d.ecs.ListTagsForResource(ctx, &ecs.ListTagsForResourceInput{
 			ResourceArn: sv.ServiceArn,
 		})
 		if err != nil {
@@ -107,7 +107,7 @@ func (d *App) RunTask(ctx context.Context, tdArn string, ov *types.TaskOverride,
 	}
 	d.DebugLog("run task input", in)
 
-	out, err := d.ecsv2.RunTask(ctx, in)
+	out, err := d.ecs.RunTask(ctx, in)
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +165,7 @@ func (d *App) waitTask(ctx context.Context, task *types.Task, untilRunning bool)
 	id := arnToName(*task.TaskArn)
 	if untilRunning {
 		d.Log(fmt.Sprintf("Waiting for task ID %s until running", id))
-		waiter := ecs.NewTasksRunningWaiter(d.ecsv2)
+		waiter := ecs.NewTasksRunningWaiter(d.ecs)
 		if err := waiter.Wait(ctx, d.DescribeTasksInput(task), d.config.Timeout); err != nil {
 			return err
 		}
@@ -174,7 +174,7 @@ func (d *App) waitTask(ctx context.Context, task *types.Task, untilRunning bool)
 	}
 
 	d.Log(fmt.Sprintf("Waiting for task ID %s until stopped", id))
-	waiter := ecs.NewTasksStoppedWaiter(d.ecsv2)
+	waiter := ecs.NewTasksStoppedWaiter(d.ecs)
 	return waiter.Wait(ctx, d.DescribeTasksInput(task), d.config.Timeout)
 }
 

--- a/service.go
+++ b/service.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"time"
 
+	aasTypes "github.com/aws/aws-sdk-go-v2/service/applicationautoscaling/types"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
-	"github.com/aws/aws-sdk-go/service/applicationautoscaling"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 )
 
@@ -68,7 +68,7 @@ func formatLogEvent(e *cloudwatchlogs.OutputLogEvent, chars int) []string {
 	return lines
 }
 
-func formatScalableTarget(t *applicationautoscaling.ScalableTarget) string {
+func formatScalableTarget(t aasTypes.ScalableTarget) string {
 	return strings.Join([]string{
 		fmt.Sprintf(
 			spcIndent+"Capacity min:%d max:%d",
@@ -84,6 +84,6 @@ func formatScalableTarget(t *applicationautoscaling.ScalableTarget) string {
 	}, "\n")
 }
 
-func formatScalingPolicy(p *applicationautoscaling.ScalingPolicy) string {
-	return fmt.Sprintf("  Policy name:%s type:%s", *p.PolicyName, *p.PolicyType)
+func formatScalingPolicy(p aasTypes.ScalingPolicy) string {
+	return fmt.Sprintf("  Policy name:%s type:%s", *p.PolicyName, p.PolicyType)
 }

--- a/service.go
+++ b/service.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/aws/aws-sdk-go/service/applicationautoscaling"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
-	"github.com/aws/aws-sdk-go/service/ecs"
 )
 
 func arnToName(s string) string {
@@ -15,25 +15,25 @@ func arnToName(s string) string {
 	return ns[len(ns)-1]
 }
 
-func formatDeployment(d *ecs.Deployment) string {
+func formatDeployment(d types.Deployment) string {
 	return fmt.Sprintf(
 		"%8s %s desired:%d pending:%d running:%d",
 		*d.Status,
 		arnToName(*d.TaskDefinition),
-		*d.DesiredCount, *d.PendingCount, *d.RunningCount,
+		d.DesiredCount, d.PendingCount, d.RunningCount,
 	)
 }
 
-func formatTaskSet(d *ecs.TaskSet) string {
+func formatTaskSet(d types.TaskSet) string {
 	return fmt.Sprintf(
 		"%8s %s desired:%d pending:%d running:%d",
 		*d.Status,
 		arnToName(*d.TaskDefinition),
-		*d.ComputedDesiredCount, *d.PendingCount, *d.RunningCount,
+		d.ComputedDesiredCount, d.PendingCount, d.RunningCount,
 	)
 }
 
-func formatEvent(e *ecs.ServiceEvent, chars int) []string {
+func formatEvent(e types.ServiceEvent, chars int) []string {
 	line := fmt.Sprintf("%s %s",
 		e.CreatedAt.In(time.Local).Format("2006/01/02 15:04:05"),
 		*e.Message,

--- a/service.go
+++ b/service.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	aasTypes "github.com/aws/aws-sdk-go-v2/service/applicationautoscaling/types"
+	logsTypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
-	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 )
 
 func arnToName(s string) string {
@@ -50,7 +50,7 @@ func formatEvent(e types.ServiceEvent, chars int) []string {
 	return lines
 }
 
-func formatLogEvent(e *cloudwatchlogs.OutputLogEvent, chars int) []string {
+func formatLogEvent(e logsTypes.OutputLogEvent, chars int) []string {
 	t := time.Unix((*e.Timestamp / int64(1000)), 0)
 	line := fmt.Sprintf("%s %s",
 		t.In(time.Local).Format("2006/01/02 15:04:05"),

--- a/tasks.go
+++ b/tasks.go
@@ -90,7 +90,7 @@ func (d *App) listTasks(ctx context.Context) ([]types.Task, error) {
 	}
 	for _, status := range []types.DesiredStatus{types.DesiredStatusRunning, types.DesiredStatusStopped} {
 		tp := ecs.NewListTasksPaginator(
-			d.ecsv2,
+			d.ecs,
 			&ecs.ListTasksInput{
 				Cluster:       &d.config.Cluster,
 				Family:        &family,
@@ -105,7 +105,7 @@ func (d *App) listTasks(ctx context.Context) ([]types.Task, error) {
 			if len(to.TaskArns) == 0 {
 				continue
 			}
-			out, err := d.ecsv2.DescribeTasks(ctx, &ecs.DescribeTasksInput{
+			out, err := d.ecs.DescribeTasks(ctx, &ecs.DescribeTasksInput{
 				Cluster: &d.config.Cluster,
 				Tasks:   to.TaskArns,
 				Include: []types.TaskField{"TAGS"},

--- a/util.go
+++ b/util.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go/private/protocol/json/jsonutil"
 	"github.com/google/go-jsonnet"
 )

--- a/verify.go
+++ b/verify.go
@@ -14,13 +14,13 @@ import (
 	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go/service/ecr"
 	"github.com/aws/aws-sdk-go/service/elbv2"
-	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/aws/aws-sdk-go/service/sts"
@@ -524,7 +524,7 @@ func (d *App) verifyRole(ctx context.Context, arn string) error {
 	if err != nil {
 		return err
 	}
-	out, err := d.iam.GetRoleWithContext(ctx, &iam.GetRoleInput{
+	out, err := d.iam.GetRole(ctx, &iam.GetRoleInput{
 		RoleName: aws.String(roleName),
 	})
 	if err != nil {

--- a/verify.go
+++ b/verify.go
@@ -183,7 +183,7 @@ func (d *App) verifyResource(ctx context.Context, resourceType string, verifyFun
 
 func (d *App) verifyCluster(ctx context.Context) error {
 	cluster := d.config.Cluster
-	out, err := d.ecsv2.DescribeClusters(ctx, &ecs.DescribeClustersInput{
+	out, err := d.ecs.DescribeClusters(ctx, &ecs.DescribeClustersInput{
 		Clusters: []string{cluster},
 	})
 	if err != nil {

--- a/verify.go
+++ b/verify.go
@@ -414,7 +414,7 @@ func NormalizePlatform(p *types.RuntimePlatform, isFargate bool) (arch, os strin
 	} else {
 		arch = "amd64"
 	}
-	if p.OperatingSystemFamily == types.OSFamilyLinux {
+	if p.OperatingSystemFamily == "" || p.OperatingSystemFamily == types.OSFamilyLinux {
 		os = "linux"
 	} else {
 		os = "windows"
@@ -463,6 +463,7 @@ func (d *App) verifyContainer(ctx context.Context, c *types.ContainerDefinition)
 
 func (d *App) verifyLogConfiguration(ctx context.Context, c *types.ContainerDefinition) error {
 	options := c.LogConfiguration.Options
+	d.Log(fmt.Sprintf("LogConfiguration[awslogs] options=%v", options))
 	group, region, prefix := options["awslogs-group"], options["awslogs-region"], options["awslogs-stream-prefix"]
 	if group == "" {
 		return errors.New("awslogs-group is required")

--- a/verify_test.go
+++ b/verify_test.go
@@ -3,8 +3,7 @@ package ecspresso_test
 import (
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/kayac/ecspresso"
 )
 
@@ -61,7 +60,7 @@ type goPlatform struct {
 }
 
 var testRuntimePlatforms = []struct {
-	platform  *ecs.RuntimePlatform
+	platform  types.RuntimePlatform
 	isFargate bool
 	want      goPlatform
 }{
@@ -73,8 +72,8 @@ var testRuntimePlatforms = []struct {
 		},
 	},
 	{
-		platform: &ecs.RuntimePlatform{
-			CpuArchitecture: aws.String(ecs.CPUArchitectureArm64),
+		platform: types.RuntimePlatform{
+			CpuArchitecture: types.CPUArchitectureArm64,
 		},
 		isFargate: true,
 		want: goPlatform{
@@ -83,8 +82,8 @@ var testRuntimePlatforms = []struct {
 		},
 	},
 	{
-		platform: &ecs.RuntimePlatform{
-			OperatingSystemFamily: aws.String(ecs.OSFamilyWindowsServer2019Core),
+		platform: types.RuntimePlatform{
+			OperatingSystemFamily: types.OSFamilyWindowsServer2019Core,
 		},
 		isFargate: true,
 		want: goPlatform{
@@ -93,8 +92,8 @@ var testRuntimePlatforms = []struct {
 		},
 	},
 	{
-		platform: &ecs.RuntimePlatform{
-			CpuArchitecture: aws.String(ecs.CPUArchitectureX8664),
+		platform: types.RuntimePlatform{
+			CpuArchitecture: types.CPUArchitectureX8664,
 		},
 		isFargate: false,
 		want: goPlatform{
@@ -103,8 +102,8 @@ var testRuntimePlatforms = []struct {
 		},
 	},
 	{
-		platform: &ecs.RuntimePlatform{
-			OperatingSystemFamily: aws.String(ecs.OSFamilyWindowsServer2019Core),
+		platform: types.RuntimePlatform{
+			OperatingSystemFamily: types.OSFamilyWindowsServer2019Core,
 		},
 		isFargate: false,
 		want: goPlatform{
@@ -116,7 +115,7 @@ var testRuntimePlatforms = []struct {
 
 func TestNormalizePlatform(t *testing.T) {
 	for _, p := range testRuntimePlatforms {
-		arch, os := ecspresso.NormalizePlatform(p.platform, p.isFargate)
+		arch, os := ecspresso.NormalizePlatform(&p.platform, p.isFargate)
 		if arch != p.want.arch || os != p.want.os {
 			t.Errorf("want arch/os %s/%s but got %s/%s", p.want.arch, p.want.os, arch, os)
 		}

--- a/verify_test.go
+++ b/verify_test.go
@@ -67,8 +67,8 @@ var testRuntimePlatforms = []struct {
 	{
 		isFargate: false,
 		want: goPlatform{
-			arch: "",
-			os:   "",
+			arch: "amd64",
+			os:   "linux",
 		},
 	},
 	{
@@ -93,12 +93,22 @@ var testRuntimePlatforms = []struct {
 	},
 	{
 		platform: types.RuntimePlatform{
+			OperatingSystemFamily: types.OSFamilyWindowsServer2022Full,
+		},
+		isFargate: true,
+		want: goPlatform{
+			arch: "amd64",
+			os:   "windows",
+		},
+	},
+	{
+		platform: types.RuntimePlatform{
 			CpuArchitecture: types.CPUArchitectureX8664,
 		},
 		isFargate: false,
 		want: goPlatform{
 			arch: "amd64",
-			os:   "",
+			os:   "linux",
 		},
 	},
 	{
@@ -107,7 +117,7 @@ var testRuntimePlatforms = []struct {
 		},
 		isFargate: false,
 		want: goPlatform{
-			arch: "",
+			arch: "amd64",
 			os:   "windows",
 		},
 	},


### PR DESCRIPTION
switch to aws-sdk-go-v2

- ecs
- applicationautoscaling
- cloudwatchlogs
- codedeploy
- iam

This PR includes except ssm/*, verify.go.