### PR TITLE
Deprecate create command

### DIFF
--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -73,11 +73,12 @@ func _main() int {
 		LatestTaskDefinition: boolp(false),
 	}
 
-	create := kingpin.Command("create", "create service")
-	createOption := ecspresso.CreateOption{
-		DryRun:       create.Flag("dry-run", "dry-run").Bool(),
-		DesiredCount: create.Flag("tasks", "desired count of tasks").Default("-1").Int32(),
-		NoWait:       create.Flag("no-wait", "exit ecspresso immediately after just created without waiting for service stable").Bool(),
+	create := kingpin.Command("create", "[DEPRECATED] use deploy command instead")
+	{
+		// for backward compatibility
+		create.Flag("dry-run", "dry-run").Bool()
+		create.Flag("tasks", "desired count of tasks").Default("-1").Int32()
+		create.Flag("no-wait", "exit ecspresso immediately after just created without waiting for service stable").Bool()
 	}
 
 	status := kingpin.Command("status", "show status of service")
@@ -270,7 +271,7 @@ func _main() int {
 	case "rollback":
 		err = app.Rollback(ctx, rollbackOption)
 	case "create":
-		err = app.Create(ctx, createOption)
+		err = fmt.Errorf("create command is deprecated. use deploy command instead")
 	case "delete":
 		err = app.Delete(ctx, deleteOption)
 	case "run":

--- a/create.go
+++ b/create.go
@@ -10,27 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
 )
 
-type CreateOption struct {
-	DryRun       *bool
-	DesiredCount *int32
-	NoWait       *bool
-}
-
-func (opt CreateOption) getDesiredCount() *int32 {
-	return opt.DesiredCount
-}
-
-func (opt CreateOption) DryRunString() string {
-	if *opt.DryRun {
-		return dryRunStr
-	}
-	return ""
-}
-
-func (d *App) Create(ctx context.Context, opt CreateOption) error {
-	ctx, cancel := d.Start(ctx)
-	defer cancel()
-
+func (d *App) createService(ctx context.Context, opt DeployOption) error {
 	d.Log("Starting create service %s", opt.DryRunString())
 	svd, err := d.LoadServiceDefinition(d.config.ServiceDefinitionPath)
 	if err != nil {

--- a/deploy.go
+++ b/deploy.go
@@ -2,6 +2,7 @@ package ecspresso
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -43,6 +44,10 @@ func (d *App) Deploy(ctx context.Context, opt DeployOption) error {
 	d.Log("Starting deploy %s", opt.DryRunString())
 	sv, err := d.DescribeServiceStatus(ctx, 0)
 	if err != nil {
+		if errors.As(err, &errNotFound) {
+			d.Log("Service %s not found. Creating a new service %s", d.Service, opt.DryRunString())
+			return d.createService(ctx, opt)
+		}
 		return err
 	}
 

--- a/deploy.go
+++ b/deploy.go
@@ -249,7 +249,7 @@ func (d *App) findDeploymentInfo(ctx context.Context) (*cdTypes.DeploymentInfo, 
 		return nil, fmt.Errorf("failed to list applications in CodeDeploy: %w", err)
 	}
 	if len(la.Applications) == 0 {
-		return nil, fmt.Errorf("no any applications in CodeDeploy")
+		return nil, ErrNotFound("no any applications in CodeDeploy")
 	}
 	// BatchGetApplications accepts applications less than 100
 	for i := 0; i < len(la.Applications); i += 100 {
@@ -275,7 +275,7 @@ func (d *App) findDeploymentInfo(ctx context.Context) (*cdTypes.DeploymentInfo, 
 				return nil, fmt.Errorf("failed to list deployment groups in CodeDeploy: %w", err)
 			}
 			if len(lg.DeploymentGroups) == 0 {
-				d.Log("[DEBUG] no deploymentGroups in application %v", *info.ApplicationName)
+				d.Log("[DEBUG] no deploymentGroups in application %s", *info.ApplicationName)
 				continue
 			}
 			groups, err := d.codedeploy.BatchGetDeploymentGroups(ctx, &codedeploy.BatchGetDeploymentGroupsInput{

--- a/deploy.go
+++ b/deploy.go
@@ -23,11 +23,11 @@ const (
 	CodeDeployConsoleURLFmt = "https://%s.console.aws.amazon.com/codesuite/codedeploy/deployments/%s?region=%s"
 )
 
-func calcDesiredCount(sv *Service, opt optWithDesiredCount) *int32 {
+func calcDesiredCount(sv *Service, opt DeployOption) *int32 {
 	if sv.SchedulingStrategy == types.SchedulingStrategyDaemon {
 		return nil
 	}
-	if oc := opt.getDesiredCount(); oc != nil {
+	if oc := opt.DesiredCount; oc != nil {
 		if *oc == DefaultDesiredCount {
 			return sv.DesiredCount
 		}

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -42,12 +42,6 @@ func taskDefinitionName(t *TaskDefinition) string {
 	return fmt.Sprintf("%s:%d", *t.Family, t.Revision)
 }
 
-type ErrNotFound string
-
-func (e ErrNotFound) Error() string {
-	return string(e)
-}
-
 type Service struct {
 	types.Service
 	DesiredCount *int32

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -109,6 +109,9 @@ func (d *App) DescribeService(ctx context.Context) (*Service, error) {
 	if len(out.Services) == 0 {
 		return nil, ErrNotFound(fmt.Sprintf("service %s is not found", d.Service))
 	}
+	if s := aws.ToString(out.Services[0].Status); s == "INACTIVE" {
+		return nil, ErrNotFound(fmt.Sprintf("service %s is %s", d.Service, s))
+	}
 	return newServiceFromTypes(out.Services[0]), nil
 }
 

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,18 @@
+package ecspresso
+
+type ErrSkipVerify string
+
+func (e ErrSkipVerify) Error() string {
+	return string(e)
+}
+
+type ErrNotFound string
+
+func (e ErrNotFound) Error() string {
+	return string(e)
+}
+
+var (
+	errNotFound   = ErrNotFound("not found")
+	errSkipVerify = ErrSkipVerify("skip verify")
+)

--- a/init.go
+++ b/init.go
@@ -50,7 +50,7 @@ func (d *App) Init(ctx context.Context, opt InitOption) error {
 		return fmt.Errorf("failed to describe service: %w", err)
 	}
 	if len(out.Services) == 0 {
-		return fmt.Errorf("service is not found")
+		return ErrNotFound("service is not found")
 	}
 
 	sv := newServiceFromTypes(out.Services[0])

--- a/options.go
+++ b/options.go
@@ -14,10 +14,6 @@ type DryRunnable interface {
 	DryRunString() bool
 }
 
-type optWithDesiredCount interface {
-	getDesiredCount() *int32
-}
-
 type DeployOption struct {
 	DryRun               *bool
 	DesiredCount         *int32
@@ -28,10 +24,6 @@ type DeployOption struct {
 	RollbackEvents       *string
 	UpdateService        *bool
 	LatestTaskDefinition *bool
-}
-
-func (opt DeployOption) getDesiredCount() *int32 {
-	return opt.DesiredCount
 }
 
 func (opt DeployOption) DryRunString() string {

--- a/verify.go
+++ b/verify.go
@@ -119,12 +119,6 @@ type VerifyOption struct {
 
 type verifyResourceFunc func(context.Context) error
 
-type ErrSkipVerify string
-
-func (v ErrSkipVerify) Error() string {
-	return string(v)
-}
-
 // Verify verifies service / task definitions related resources are valid.
 func (d *App) Verify(ctx context.Context, opt VerifyOption) error {
 	td, err := d.LoadTaskDefinition(d.config.TaskDefinitionPath)
@@ -169,8 +163,7 @@ func (d *App) verifyResource(ctx context.Context, resourceType string, verifyFun
 	print("%s", resourceType)
 	err := verifyFunc(ctx)
 	if err != nil {
-		e := ErrSkipVerify("")
-		if errors.As(err, &e) {
+		if errors.As(err, &errSkipVerify) {
 			print("--> %s [%s] %s", resourceType, color.CyanString("SKIP"), color.CyanString(err.Error()))
 			return nil
 		}

--- a/verify.go
+++ b/verify.go
@@ -189,7 +189,7 @@ func (d *App) verifyCluster(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to describe cluster %s: %w", cluster, err)
 	} else if len(out.Clusters) == 0 {
-		return fmt.Errorf("cluster %s is not found", cluster)
+		return ErrNotFound(fmt.Sprintf("cluster %s is not found", cluster))
 	}
 	return nil
 }
@@ -226,7 +226,7 @@ func (d *App) verifyServiceDefinition(ctx context.Context) error {
 			if err != nil {
 				return err
 			} else if len(out.TargetGroups) == 0 {
-				return fmt.Errorf("target group %s is not found: %w", *lb.TargetGroupArn, err)
+				return ErrNotFound(fmt.Sprintf("target group %s is not found: %s", *lb.TargetGroupArn, err))
 			}
 			tgPort := aws.ToInt32(out.TargetGroups[0].Port)
 			cPort := aws.ToInt32(lb.ContainerPort)


### PR DESCRIPTION
#374 

Deprecate `create` command.

`deploy` creates an ECS service when it is missing.

```console
$ ecspresso create --help
usage: ecspresso create [<flags>]

[DEPRECATED] use deploy command instead
```

```console
$ ecspresso create
2022/09/29 14:34:46.928723 [ERROR] create FAILED. create command is deprecated. use deploy command instead
```