### PR TITLE
Fix panic ecspresso run

### DIFF
--- a/ecspresso.go
+++ b/ecspresso.go
@@ -243,7 +243,7 @@ func (d *App) DescribeTaskDefinition(ctx context.Context, tdArn string) (*TaskDe
 		Include:        []*string{aws.String("TAGS")},
 	})
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to describe taskdefinition")
 	}
 	return tdToTaskDefinitionInput(out.TaskDefinition, out.Tags), nil
 }

--- a/run.go
+++ b/run.go
@@ -207,6 +207,9 @@ func (d *App) taskDefinitionForRun(ctx context.Context, opt RunOption) (tdArn st
 	}
 	family := *td.Family
 	defer func() {
+		if err != nil {
+			return
+		}
 		watchContainer = containerOf(td, opt.WatchContainer)
 		d.Log("Task definition ARN:", tdArn)
 		d.Log("Watch container:", *watchContainer.Name)


### PR DESCRIPTION
`ecspresso run` cause panic and exit since v1.7.1 if IAM Policy do not attach `ecs:DescribeTaskDefinition` .

panic log

```
Running task 
Registering a new task definition...
Task definition is registered task-foo:1
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0xf856df]

goroutine 1 [running]:
github.com/kayac/ecspresso.containerOf(0x0, 0xc00041ab10, 0x1069420)
    /home/runner/work/ecspresso/ecspresso/ecspresso.go:348 +0xdf
github.com/kayac/ecspresso.(*App).taskDefinitionForRun.func1(0xc0005a90c8, 0xc00050c195, 0xc00041aa90, 0xc00050c196, 0xc00041aad0, 0xc00041aaf0, 0xc00050c197, 0xc00050c198, 0xc00041ab10, 0xc00050c1a0, ...)
    /home/runner/work/ecspresso/ecspresso/run.go:210 +0x3f
github.com/kayac/ecspresso.(*App).taskDefinitionForRun(0xc000510980, 0x1706740, 0xc00051e240, 0xc00050c195, 0xc00041aa90, 0xc00050c196, 0xc00041aad0, 0xc00041aaf0, 0xc00050c197, 0xc00050c198, ...)
    /home/runner/work/ecspresso/ecspresso/run.go:248 +0x80a
github.com/kayac/ecspresso.(*App).Run(0xc000510980, 0xc00050c195, 0xc00041aa90, 0xc00050c196, 0xc00041aad0, 0xc00041aaf0, 0xc00050c197, 0xc00050c198, 0xc00041ab10, 0xc00050c1a0, ...)
    /home/runner/work/ecspresso/ecspresso/run.go:36 +0x338
main._main(0xc00003e1d8)
    /home/runner/work/ecspresso/ecspresso/cmd/ecspresso/main.go:264 +0x8159
main.main()
    /home/runner/work/ecspresso/ecspresso/cmd/ecspresso/main.go:18 +0x25
```
