### PR TITLE
render command accepts args instead of flags.

### DIFF
--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -170,7 +170,7 @@ func _main() int {
 
 	render := kingpin.Command("render", "render config, service definition or task definition file to stdout")
 	renderOption := ecspresso.RenderOption{
-		Targets: render.Arg("targets", "render targets").Required().Enums(
+		Targets: render.Arg("targets", "render targets (config, servicedef, taskdef)").Required().Enums(
 			"config",
 			"servicedef", "service-definition",
 			"taskdef", "task-definition",

--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -170,9 +170,11 @@ func _main() int {
 
 	render := kingpin.Command("render", "render config, service definition or task definition file to stdout")
 	renderOption := ecspresso.RenderOption{
-		ServiceDefinition: render.Flag("service-definition", "render service definition").Bool(),
-		TaskDefinition:    render.Flag("task-definition", "render task definition").Bool(),
-		ConfigFile:        render.Flag("config-file", "render config file").Bool(),
+		Targets: render.Arg("targets", "render targets").Required().Enums(
+			"config",
+			"servicedef", "service-definition",
+			"taskdef", "task-definition",
+		),
 	}
 
 	tasks := kingpin.Command("tasks", "list tasks that are in a service or having the same family")

--- a/init.go
+++ b/init.go
@@ -118,7 +118,7 @@ func (d *App) Init(ctx context.Context, opt InitOption) error {
 	return nil
 }
 
-func treatmentServiceDefinition(sv *Service) *Service {
+func treatmentServiceDefinition(sv *Service) {
 	sv.ClusterArn = nil
 	sv.CreatedAt = nil
 	sv.CreatedBy = nil
@@ -136,8 +136,6 @@ func treatmentServiceDefinition(sv *Service) *Service {
 	if sv.PropagateTags != types.PropagateTagsService && sv.PropagateTags != types.PropagateTagsTaskDefinition {
 		sv.PropagateTags = types.PropagateTagsNone
 	}
-
-	return sv
 }
 
 func (d *App) saveFile(path string, b []byte, mode os.FileMode, force bool) error {


### PR DESCRIPTION
#374 

```
usage: ecspresso render <targets>...

render config, service definition, or task definition file to stdout

Args:
  <targets>  render targets (config, servicedef, or taskdef)
```
