### PR TITLE
service events as stream.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,9 +33,9 @@ require (
 	github.com/kayac/go-config v0.6.0
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-isatty v0.0.16
-	github.com/morikuni/aec v1.0.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/opencontainers/image-spec v1.0.2
+	github.com/samber/lo v1.33.0
 	golang.org/x/sys v0.0.0-20220927170352-d9d178bc13c6
 )
 
@@ -106,6 +106,7 @@ require (
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90 // indirect
+	golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17 // indirect
 	golang.org/x/net v0.0.0-20220909164309-bea034e7d591 // indirect
 	golang.org/x/oauth2 v0.0.0-20220909003341-f21342109be1 // indirect
 	golang.org/x/term v0.0.0-20220722155259-a9ba230a4035 // indirect

--- a/go.sum
+++ b/go.sum
@@ -381,8 +381,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
-github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
@@ -402,8 +402,6 @@ github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
-github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
-github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
@@ -422,6 +420,8 @@ github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6L
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/samber/lo v1.33.0 h1:2aKucr+rQV6gHpY3bpeZu69uYoQOzVhGT3J22Op6Cjk=
+github.com/samber/lo v1.33.0/go.mod h1:HLeWcJRRyLKp3+/XBJvOrerCQn9mhdKMHyd7IRlgeQ8=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
@@ -433,6 +433,7 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/thoas/go-funk v0.9.1 h1:O549iLZqPpTUQ10ykd26sZhzD+rmR5pWhuElrhbC20M=
 github.com/urfave/cli/v2 v2.16.3 h1:gHoFIwpPjoyIMbJp/VFd+/vuD0dAgFK4B6DpEMFJfQk=
 github.com/urfave/cli/v2 v2.16.3/go.mod h1:1CNUng3PtjQMtRzJO4FMXBQvkGtuYRxxiR9xMa7jMwI=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
@@ -473,6 +474,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17 h1:3MTrJm4PyNL9NBqvYDSj3DHl46qQakyfqfWo4jgfaEM=
+golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17/go.mod h1:lgLbSvA5ygNOMpwM/9anMpWVlVJ7Z+cHWq/eFuinpGE=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/logger.go
+++ b/logger.go
@@ -34,7 +34,7 @@ func newLogFilter(w io.Writer, minLevel string) *logutils.LevelFilter {
 }
 
 func newLogger() *log.Logger {
-	return log.New(io.Discard, "", log.LstdFlags|log.Lmicroseconds)
+	return log.New(io.Discard, "", log.LstdFlags)
 }
 
 func Log(f string, v ...interface{}) {

--- a/service.go
+++ b/service.go
@@ -33,39 +33,19 @@ func formatTaskSet(d types.TaskSet) string {
 	)
 }
 
-func formatEvent(e types.ServiceEvent, chars int) []string {
-	line := fmt.Sprintf("%s %s",
+func formatEvent(e types.ServiceEvent) string {
+	return fmt.Sprintf("%s %s",
 		e.CreatedAt.In(time.Local).Format("2006/01/02 15:04:05"),
 		*e.Message,
 	)
-	lines := []string{}
-	n := len(line)/chars + 1
-	for i := 0; i < n; i++ {
-		if i == n-1 {
-			lines = append(lines, line[i*chars:])
-		} else {
-			lines = append(lines, line[i*chars:(i+1)*chars])
-		}
-	}
-	return lines
 }
 
-func formatLogEvent(e logsTypes.OutputLogEvent, chars int) []string {
+func formatLogEvent(e logsTypes.OutputLogEvent) string {
 	t := time.Unix((*e.Timestamp / int64(1000)), 0)
-	line := fmt.Sprintf("%s %s",
+	return fmt.Sprintf("%s %s",
 		t.In(time.Local).Format("2006/01/02 15:04:05"),
 		*e.Message,
 	)
-	lines := []string{}
-	n := len(line)/chars + 1
-	for i := 0; i < n; i++ {
-		if i == n-1 {
-			lines = append(lines, line[i*chars:])
-		} else {
-			lines = append(lines, line[i*chars:(i+1)*chars])
-		}
-	}
-	return lines
 }
 
 func formatScalableTarget(t aasTypes.ScalableTarget) string {

--- a/wait.go
+++ b/wait.go
@@ -1,15 +1,17 @@
 package ecspresso
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/codedeploy"
 	cdTypes "github.com/aws/aws-sdk-go-v2/service/codedeploy/types"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
-	"github.com/morikuni/aec"
 )
 
 type WaitOption struct {
@@ -46,18 +48,16 @@ func (d *App) WaitServiceStable(ctx context.Context, startedAt time.Time) error 
 
 	tick := time.NewTicker(10 * time.Second)
 	go func() {
-		var lines int
+		st := &showState{lastEventAt: startedAt}
 		for {
 			select {
 			case <-waitCtx.Done():
 				return
 			case <-tick.C:
-				if isTerminal {
-					for i := 0; i < lines; i++ {
-						fmt.Print(aec.EraseLine(aec.EraseModes.All), aec.PreviousLine(1))
-					}
+				if err := d.showServiceStatus(waitCtx, st); err != nil {
+					d.Log("[WARNING] %s", err.Error())
+					continue
 				}
-				lines, _ = d.DescribeServiceDeployments(waitCtx, startedAt)
 			}
 		}
 	}()
@@ -100,4 +100,49 @@ func (d *App) WaitForCodeDeploy(ctx context.Context, sv *Service) error {
 		&codedeploy.GetDeploymentInput{DeploymentId: &dpID},
 		d.Timeout(),
 	)
+}
+
+type showState struct {
+	lastEventAt     time.Time
+	deploymentsHash []byte
+}
+
+func (d *App) showServiceStatus(ctx context.Context, st *showState) error {
+	out, err := d.ecs.DescribeServices(ctx, d.DescribeServicesInput())
+	if err != nil {
+		return fmt.Errorf("failed to describe service deployments: %w", err)
+	}
+	if len(out.Services) == 0 {
+		return ErrNotFound(fmt.Sprintf("service %s is not found", d.Service))
+	}
+	sv := out.Services[0]
+
+	// show events
+	sort.SliceStable(sv.Events, func(i, j int) bool {
+		return sv.Events[i].CreatedAt.Before(*sv.Events[j].CreatedAt)
+	})
+	for _, event := range sv.Events {
+		if (*event.CreatedAt).After(st.lastEventAt) {
+			fmt.Println(formatEvent(event))
+			st.lastEventAt = *event.CreatedAt
+		}
+	}
+
+	// show deployments
+	h := sha256.New()
+	lines := make([]string, 0, len(sv.Deployments))
+	for _, dep := range sv.Deployments {
+		line := formatDeployment(dep)
+		lines = append(lines, line)
+		h.Write([]byte(line))
+	}
+	hash := h.Sum(nil)
+	// if the deployments are not changed, do not show the deployments.
+	if !bytes.Equal(st.deploymentsHash, hash) {
+		for _, line := range lines {
+			d.Log(line)
+		}
+	}
+	st.deploymentsHash = hash
+	return nil
 }


### PR DESCRIPTION
Do not erase terminal output. Show deployments events as stream.

resolves #344.