### PR TITLE
Fix run td without service

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ https://circleci.com/orbs/registry/orb/fujiwara/ecspresso
 ```yaml
 version: 2.1
 orbs:
-  ecspresso: fujiwara/ecspresso@0.0.15
+  ecspresso: fujiwara/ecspresso@1.0.0
 jobs:
   install:
     steps:

--- a/orb.yml
+++ b/orb.yml
@@ -18,7 +18,7 @@ commands:
           command: |
             VERSION="<< parameters.version >>"
             if [ "${VERSION}" = "latest" ]; then
-              DOWNLOAD_URL=$(curl -sS https://api.github.com/repos/kayac/ecspresso/releases/latest|jq -r '.assets[].browser_download_url|select(match("linux.amd64."))')
+              DOWNLOAD_URL=$(curl -sS https://api.github.com/repos/kayac/ecspresso/releases | jq -r '[.[]|select(.tag_name < "v1.99")|select(.prerelease == false)][0].assets[].browser_download_url|select(match("linux.amd64."))')
             else
               DOWNLOAD_URL=$(curl -sS https://api.github.com/repos/kayac/ecspresso/releases/tags/${VERSION}|jq -r '.assets[].browser_download_url|select(match("linux.amd64."))')
             fi

--- a/run.go
+++ b/run.go
@@ -208,6 +208,7 @@ func (d *App) taskDefinitionArnForRun(ctx context.Context, opt RunOption) (strin
 	case *opt.SkipTaskDefinition, *opt.LatestTaskDefinition:
 		var family string
 		if d.config.Service != "" {
+			d.DebugLog("loading service")
 			sv, err := d.DescribeService(ctx)
 			if err != nil {
 				return "", err
@@ -216,6 +217,7 @@ func (d *App) taskDefinitionArnForRun(ctx context.Context, opt RunOption) (strin
 			p := strings.SplitN(arnToName(tdArn), ":", 2)
 			family = p[0]
 		} else {
+			d.DebugLog("loading task definition")
 			in, err := d.LoadTaskDefinition(d.config.TaskDefinitionPath)
 			if err != nil {
 				return "", err

--- a/run.go
+++ b/run.go
@@ -214,6 +214,9 @@ func (d *App) taskDefinitionArnForRun(ctx context.Context, opt RunOption) (strin
 				return "", err
 			}
 			tdArn := *sv.TaskDefinition
+			if *opt.SkipTaskDefinition {
+				return tdArn, nil
+			}
 			p := strings.SplitN(arnToName(tdArn), ":", 2)
 			family = p[0]
 		} else {

--- a/run.go
+++ b/run.go
@@ -206,13 +206,22 @@ func (d *App) waitTask(ctx context.Context, task *ecs.Task, untilRunning bool) e
 func (d *App) taskDefinitionArnForRun(ctx context.Context, opt RunOption) (string, error) {
 	switch {
 	case *opt.SkipTaskDefinition, *opt.LatestTaskDefinition:
-		sv, err := d.DescribeService(ctx)
-		if err != nil {
-			return "", err
+		var family string
+		if d.config.Service != "" {
+			sv, err := d.DescribeService(ctx)
+			if err != nil {
+				return "", err
+			}
+			tdArn := *sv.TaskDefinition
+			p := strings.SplitN(arnToName(tdArn), ":", 2)
+			family = p[0]
+		} else {
+			in, err := d.LoadTaskDefinition(d.config.TaskDefinitionPath)
+			if err != nil {
+				return "", err
+			}
+			family = *in.Family
 		}
-		tdArn := *sv.TaskDefinition
-		p := strings.SplitN(arnToName(tdArn), ":", 2)
-		family := p[0]
 		if rev := aws.Int64Value(opt.Revision); rev > 0 {
 			return fmt.Sprintf("%s:%d", family, rev), nil
 		}


### PR DESCRIPTION
v1.7.14 fails to run --latest-task-definition (or --skip-task-definition) with the error "service is not found" if the ECS service is not defined in config.
