### PR TITLE
Set default values into config.

### DIFF
--- a/config.go
+++ b/config.go
@@ -125,6 +125,12 @@ func (c *Config) Restrict(ctx context.Context) error {
 		}
 		c.versionConstraints = constraints
 	}
+	if c.Timeout == nil {
+		c.Timeout = &Duration{Duration: DefaultTimeout}
+	}
+	if c.Region == "" {
+		c.Region = os.Getenv("AWS_REGION")
+	}
 	var err error
 	c.awsv2Config, err = awsConfig.LoadDefaultConfig(ctx, awsConfig.WithRegion(c.Region))
 	if err != nil {

--- a/config_test.go
+++ b/config_test.go
@@ -246,3 +246,27 @@ func TestConfigWithInvalidRequiredVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestLoadConfigWithoutTimeout(t *testing.T) {
+	region := os.Getenv("AWS_REGION")
+	os.Setenv("AWS_REGION", "ap-northeast-2")
+	defer func() { os.Setenv("AWS_REGION", region) }()
+
+	ctx := context.Background()
+	loader := ecspresso.NewConfigLoader(nil, nil)
+	conf, err := loader.Load(ctx, "tests/notimeout.yml", "")
+	if err != nil {
+		t.Log("unexpected an error", err)
+		t.FailNow()
+	}
+	if conf.Timeout == nil {
+		t.Error("expected default timeout, but nil")
+	}
+	if conf.Timeout.Duration != ecspresso.DefaultTimeout {
+		t.Errorf("expected default timeout, but %v", conf.Timeout.Duration)
+	}
+
+	if conf.Region != "ap-northeast-2" {
+		t.Errorf("expected region from AWS_REGION, but %v", conf.Region)
+	}
+}

--- a/orb.yml
+++ b/orb.yml
@@ -18,7 +18,7 @@ commands:
           command: |
             VERSION="<< parameters.version >>"
             if [ "${VERSION}" = "latest" ]; then
-              DOWNLOAD_URL=$(curl -sS https://api.github.com/repos/kayac/ecspresso/releases/latest|jq -r '.assets[].browser_download_url|select(match("linux.amd64."))')
+              DOWNLOAD_URL=$(curl -sS https://api.github.com/repos/kayac/ecspresso/releases | jq -r '[.[]|select(.tag_name > "v1.99")][0].assets[].browser_download_url|select(match("linux.amd64."))')
             else
               DOWNLOAD_URL=$(curl -sS https://api.github.com/repos/kayac/ecspresso/releases/tags/${VERSION}|jq -r '.assets[].browser_download_url|select(match("linux.amd64."))')
             fi

--- a/tests/notimeout.yml
+++ b/tests/notimeout.yml
@@ -1,0 +1,4 @@
+cluster: default
+service: test
+service_definition: ecs-service-def.json
+task_definition: ecs-task-def.json


### PR DESCRIPTION
fixes https://github.com/kayac/ecspresso/issues/457#issuecomment-1313426696

If a config file does not contains `region` and `timeout`, set default values.

- Set default timeout.
- Set a region from `AWS_REGION` environment variable.

