### PR TITLE
fix: deploy --(skip|latest)-task-definition works valid.

### DIFF
--- a/deploy.go
+++ b/deploy.go
@@ -105,8 +105,7 @@ func (d *App) Deploy(ctx context.Context, opt DeployOption) error {
 			return err
 		}
 		if *opt.DryRun {
-			d.Log("task definition:")
-			d.LogJSON(td)
+			d.Log("[INFO] task definition: %s", MustMarshalJSONStringForAPI(td))
 		} else {
 			newTd, err := d.RegisterTaskDefinition(ctx, td)
 			if err != nil {
@@ -239,8 +238,7 @@ func (d *App) UpdateServiceAttributes(ctx context.Context, sv *Service, taskDefi
 	in.Cluster = aws.String(d.Cluster)
 
 	if *opt.DryRun {
-		d.Log("update service input:")
-		d.LogJSON(in)
+		d.Log("[INFO] update service input: %s", MustMarshalJSONStringForAPI(in))
 		return nil
 	}
 	d.Log("Updating service attributes...")

--- a/tests/ci/ecs-service-def.json
+++ b/tests/ci/ecs-service-def.json
@@ -22,6 +22,7 @@
   "desiredCount": 1,
   "enableECSManagedTags": false,
   "enableExecuteCommand": true,
+  "healthCheckGracePeriodSeconds": 0,
   "loadBalancers": [
     {
       "containerName": "nginx",


### PR DESCRIPTION
When a new service was created on deployment, these options did not work.