### PR TITLE
Add config.codedeploy to reduce API calls for CodeDeploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,18 @@ Events:
 
 Currently, ecspresso doesn't create any resources on CodeDeploy. You must create an application and a deployment group for your ECS service on CodeDeploy in the other way.
 
+ecspresso finds a CodeDeploy deployment setting for the ECS service automatically.
+But, if you have too many CodeDeploy applications, API calls of that finding process may cause throttling.
+
+In this case, you may specify CodeDeploy application_name and deployment_group_name in a config file.
+
+```yaml
+# ecspresso.yml
+codedeploy:
+  application_name: myapp
+  deployment_group_name: mydeployment
+```
+
 `ecspresso deploy` creates a new deployment for CodeDeploy, and it continues on CodeDeploy.
 
 ```console

--- a/config.go
+++ b/config.go
@@ -54,12 +54,18 @@ type Config struct {
 	AppSpec               *appspec.AppSpec `yaml:"appspec,omitempty" json:"appspec,omitempty"`
 	FilterCommand         string           `yaml:"filter_command,omitempty" json:"filter_command,omitempty"`
 	Timeout               *Duration        `yaml:"timeout,omitempty" json:"timeout,omitempty"`
+	CodeDeploy            CodeDeployConfig `yaml:"codedeploy,omitempty" json:"codedeploy,omitempty"`
 
 	path               string
 	templateFuncs      []template.FuncMap
 	dir                string
 	versionConstraints goVersion.Constraints
 	awsv2Config        aws.Config
+}
+
+type CodeDeployConfig struct {
+	ApplicationName     string `yaml:"application_name" json:"application_name"`
+	DeploymentGroupName string `yaml:"deployment_group_name" json:"deployment_group_name"`
 }
 
 // Load loads configuration file from file path.

--- a/config.go
+++ b/config.go
@@ -52,7 +52,7 @@ type Config struct {
 	AppSpec               *appspec.AppSpec `yaml:"appspec,omitempty" json:"appspec,omitempty"`
 	FilterCommand         string           `yaml:"filter_command,omitempty" json:"filter_command,omitempty"`
 	Timeout               *Duration        `yaml:"timeout,omitempty" json:"timeout,omitempty"`
-	CodeDeploy            CodeDeployConfig `yaml:"codedeploy,omitempty" json:"codedeploy,omitempty"`
+	CodeDeploy            ConfigCodeDeploy `yaml:"codedeploy,omitempty" json:"codedeploy,omitempty"`
 
 	path               string
 	templateFuncs      []template.FuncMap
@@ -61,7 +61,7 @@ type Config struct {
 	awsv2Config        aws.Config
 }
 
-type CodeDeployConfig struct {
+type ConfigCodeDeploy struct {
 	ApplicationName     string `yaml:"application_name" json:"application_name"`
 	DeploymentGroupName string `yaml:"deployment_group_name" json:"deployment_group_name"`
 }

--- a/config.go
+++ b/config.go
@@ -2,7 +2,6 @@ package ecspresso
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,7 +10,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsConfig "github.com/aws/aws-sdk-go-v2/config"
-	"github.com/goccy/go-yaml"
 	"github.com/google/go-jsonnet"
 	goVersion "github.com/hashicorp/go-version"
 	"github.com/kayac/ecspresso/v2/appspec"
@@ -78,7 +76,7 @@ func (l *configLoader) Load(ctx context.Context, path string, version string) (*
 		if err != nil {
 			return nil, err
 		}
-		if err := yaml.Unmarshal(b, conf); err != nil {
+		if err := unmarshalYAML(b, conf, path); err != nil {
 			return nil, fmt.Errorf("failed to parse yaml: %w", err)
 		}
 	case jsonExt, jsonnetExt:
@@ -90,7 +88,7 @@ func (l *configLoader) Load(ctx context.Context, path string, version string) (*
 		if err != nil {
 			return nil, fmt.Errorf("failed to read template file: %w", err)
 		}
-		if err := json.Unmarshal(b, conf); err != nil {
+		if err := unmarshalJSON(b, conf, path); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal json: %w", err)
 		}
 	default:

--- a/config_test.go
+++ b/config_test.go
@@ -270,3 +270,21 @@ func TestLoadConfigWithoutTimeout(t *testing.T) {
 		t.Errorf("expected region from AWS_REGION, but %v", conf.Region)
 	}
 }
+
+func TestLoadConfigForCodeDeploy(t *testing.T) {
+	ctx := context.Background()
+	loader := ecspresso.NewConfigLoader(nil, nil)
+	for _, ext := range []string{"yml", "json", "jsonnet"} {
+		name := "tests/config_codedeploy." + ext
+		conf, err := loader.Load(ctx, name, "")
+		if err != nil {
+			t.Error(err)
+		}
+		if conf.CodeDeploy.ApplicationName != "myapp" {
+			t.Errorf("expected application name, but %v", conf.CodeDeploy.ApplicationName)
+		}
+		if conf.CodeDeploy.DeploymentGroupName != "mydeployment" {
+			t.Errorf("expected deployment group name, but %v", conf.CodeDeploy.DeploymentGroupName)
+		}
+	}
+}

--- a/deploy.go
+++ b/deploy.go
@@ -283,7 +283,6 @@ func (d *App) findDeploymentInfo(ctx context.Context) (*cdTypes.DeploymentInfo, 
 	if err != nil {
 		return nil, err
 	}
-	d.Log("[DEBUG] CodeDeploy applications: %v", apps)
 
 	for _, app := range apps {
 		groups, err := d.findCodeDeployDeploymentGroups(ctx, *app.ApplicationName)
@@ -324,6 +323,7 @@ func (d *App) findCodeDeployApplications(ctx context.Context) ([]cdTypes.Applica
 			appNames = append(appNames, p.Applications...)
 		}
 	}
+	d.Log("[DEBUG] found CodeDeploy applications: %v", appNames)
 
 	var apps []cdTypes.ApplicationInfo
 	// BatchGetApplications accepts applications less than 100
@@ -335,7 +335,7 @@ func (d *App) findCodeDeployApplications(ctx context.Context) ([]cdTypes.Applica
 			return nil, fmt.Errorf("failed to batch get applications in CodeDeploy: %w", err)
 		}
 		for _, info := range res.ApplicationsInfo {
-			d.Log("[DEBUG] application %v", info)
+			d.Log("[DEBUG] application %s compute platform %s", *info.ApplicationName, info.ComputePlatform)
 			if info.ComputePlatform != cdTypes.ComputePlatformEcs {
 				continue
 			}
@@ -361,7 +361,7 @@ func (d *App) findCodeDeployDeploymentGroups(ctx context.Context, appName string
 			groupNames = append(groupNames, p.DeploymentGroups...)
 		}
 	}
-	d.Log("[DEBUG] CodeDeploy deploymentGroups: %v", groupNames)
+	d.Log("[DEBUG] CodeDeploy found deploymentGroups: %v", groupNames)
 
 	var groups []cdTypes.DeploymentGroupInfo
 	// BatchGetDeploymentGroups accepts applications less than 100

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/mattn/go-isatty v0.0.16
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/opencontainers/image-spec v1.0.2
+	github.com/samber/lo v1.35.0
 	github.com/schollz/progressbar/v3 v3.11.0
 	github.com/shogo82148/go-retry v1.1.1
 	golang.org/x/sys v0.0.0-20220927170352-d9d178bc13c6
@@ -95,7 +96,6 @@ require (
 	github.com/itchyny/gojq v0.12.9 // indirect
 	github.com/itchyny/timefmt-go v0.1.4 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
-	github.com/kr/text v0.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-ieproxy v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.13 // indirect
@@ -106,6 +106,7 @@ require (
 	github.com/rivo/uniseg v0.4.2 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90 // indirect
+	golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17 // indirect
 	golang.org/x/net v0.0.0-20220909164309-bea034e7d591 // indirect
 	golang.org/x/oauth2 v0.0.0-20220909003341-f21342109be1 // indirect
 	golang.org/x/term v0.0.0-20220722155259-a9ba230a4035 // indirect

--- a/go.sum
+++ b/go.sum
@@ -200,7 +200,6 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
-github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -387,7 +386,6 @@ github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
-github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
@@ -425,6 +423,8 @@ github.com/rivo/uniseg v0.4.2 h1:YwD0ulJSJytLpiaWua0sBDusfsCZohxjxzVTYjwxfV8=
 github.com/rivo/uniseg v0.4.2/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/samber/lo v1.35.0 h1:GlT8CV1GE+v97Y7MLF1wXvX6mjoxZ+hi61tj/ZcQwY0=
+github.com/samber/lo v1.35.0/go.mod h1:HLeWcJRRyLKp3+/XBJvOrerCQn9mhdKMHyd7IRlgeQ8=
 github.com/schollz/progressbar/v3 v3.11.0 h1:3nIBUF1Zw/pGUaRHP7PZWmARP7ZQbWQ6vL6hwoQiIvU=
 github.com/schollz/progressbar/v3 v3.11.0/go.mod h1:R2djRgv58sn00AGysc4fN0ip4piOGd3z88K+zVBjczs=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
@@ -440,6 +440,7 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/thoas/go-funk v0.9.1 h1:O549iLZqPpTUQ10ykd26sZhzD+rmR5pWhuElrhbC20M=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -476,6 +477,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17 h1:3MTrJm4PyNL9NBqvYDSj3DHl46qQakyfqfWo4jgfaEM=
+golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17/go.mod h1:lgLbSvA5ygNOMpwM/9anMpWVlVJ7Z+cHWq/eFuinpGE=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/init.go
+++ b/init.go
@@ -20,7 +20,7 @@ var CreateFileMode = os.FileMode(0644)
 type InitOption struct {
 	Region                *string `help:"AWS region" env:"AWS_REGION" default:""`
 	Cluster               *string `help:"ECS cluster name" default:"default"`
-	Service               *string `help:"ECS service name" default:"" required:""`
+	Service               *string `help:"ECS service name" required:""`
 	TaskDefinitionPath    *string `help:"path to output task definition file" default:"ecs-task-def.json"`
 	ServiceDefinitionPath *string `help:"path to output service definition file" default:"ecs-service-def.json"`
 	ConfigFilePath        *string
@@ -129,6 +129,18 @@ func (d *App) Init(ctx context.Context, opt InitOption) error {
 	}
 
 	// config
+	if sv.isCodeDeploy() {
+		info, err := d.findDeploymentInfo(ctx)
+		if err != nil {
+			Log("[WARNING] failed to find CodeDeploy deployment info: %s", err)
+			Log("[WARNING] you need to set config.codedeploy section manually")
+		} else {
+			conf.CodeDeploy = CodeDeployConfig{
+				ApplicationName:     *info.ApplicationName,
+				DeploymentGroupName: *info.DeploymentGroupName,
+			}
+		}
+	}
 	{
 		var b []byte
 		var err error

--- a/init.go
+++ b/init.go
@@ -135,7 +135,7 @@ func (d *App) Init(ctx context.Context, opt InitOption) error {
 			Log("[WARNING] failed to find CodeDeploy deployment info: %s", err)
 			Log("[WARNING] you need to set config.codedeploy section manually")
 		} else {
-			conf.CodeDeploy = CodeDeployConfig{
+			conf.CodeDeploy = ConfigCodeDeploy{
 				ApplicationName:     *info.ApplicationName,
 				DeploymentGroupName: *info.DeploymentGroupName,
 			}

--- a/json.go
+++ b/json.go
@@ -40,7 +40,7 @@ func (d *App) UnmarshalJSONForStruct(src []byte, v interface{}, path string) err
 	if b, err := json.Marshal(m); err != nil {
 		return err
 	} else {
-		return d.unmarshalJSON(b, v, path)
+		return unmarshalJSON(b, v, path)
 	}
 }
 

--- a/plugin.go
+++ b/plugin.go
@@ -15,9 +15,9 @@ import (
 )
 
 type ConfigPlugin struct {
-	Name       string                 `yaml:"name"`
-	Config     map[string]interface{} `yaml:"config"`
-	FuncPrefix string                 `yaml:"func_prefix"`
+	Name       string                 `yaml:"name" json:"name"`
+	Config     map[string]interface{} `yaml:"config" json:"config"`
+	FuncPrefix string                 `yaml:"func_prefix,omitempty" json:"func_prefix,omitempty"`
 }
 
 func (p ConfigPlugin) Setup(ctx context.Context, c *Config) error {

--- a/run.go
+++ b/run.go
@@ -54,7 +54,7 @@ func (d *App) Run(ctx context.Context, opt RunOption) error {
 		if err != nil {
 			return fmt.Errorf("failed to read overrides-file %s: %w", ovFile, err)
 		}
-		if err := d.unmarshalJSON(src, &ov, ovFile); err != nil {
+		if err := unmarshalJSON(src, &ov, ovFile); err != nil {
 			return fmt.Errorf("failed to read overrides-file %s: %w", ovFile, err)
 		}
 	}

--- a/tasks.go
+++ b/tasks.go
@@ -12,7 +12,7 @@ import (
 
 type TasksOption struct {
 	ID     *string `help:"task ID" default:""`
-	Output *string `help:"output format" default:"table" enum:"table,json,tsv" default:"table"`
+	Output *string `help:"output format" enum:"table,json,tsv" default:"table"`
 	Find   *bool   `help:"find a task from tasks list and dump it as JSON" default:"false"`
 	Stop   *bool   `help:"stop the task" default:"false"`
 	Force  *bool   `help:"stop the task without confirmation" default:"false"`

--- a/tests/config_codedeploy.json
+++ b/tests/config_codedeploy.json
@@ -1,0 +1,10 @@
+{
+  "cluster": "default",
+  "service": "test",
+  "service_definition": "ecs-service-def.json",
+  "task_definition": "ecs-task-def.json",
+  "codedeploy": {
+    "application_name": "myapp",
+    "deployment_group_name": "mydeployment"
+  }
+}

--- a/tests/config_codedeploy.jsonnet
+++ b/tests/config_codedeploy.jsonnet
@@ -1,0 +1,10 @@
+{
+  cluster: 'default',
+  service: 'test',
+  service_definition: 'ecs-service-def.json',
+  task_definition: 'ecs-task-def.json',
+  codedeploy: {
+    application_name: 'myapp',
+    deployment_group_name: 'mydeployment',
+  },
+}

--- a/tests/config_codedeploy.yml
+++ b/tests/config_codedeploy.yml
@@ -1,0 +1,7 @@
+cluster: default
+service: test
+service_definition: ecs-service-def.json
+task_definition: ecs-task-def.json
+codedeploy:
+  application_name: myapp
+  deployment_group_name: mydeployment


### PR DESCRIPTION
refs #403

ecspresso finds a CodeDeploy deployment setting for the ECS service automatically.

But, with too many CodeDeploy applications available, API calls of that finding process may cause throttling.

This PR enables to specify CodeDeploy application_name and deployment_group_name in a config file.


```yaml
# ecspresso.yml
codedeploy:
  application_name: myapp
  deployment_group_name: mydeployment
```
