### PR TITLE
remove filter_command from configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,10 +522,10 @@ Flags:
 
 When `--find` option is set, you can select a task in a list of tasks and show the task as JSON.
 
-`filter_command` in ecspresso.yml can define a command to filter tasks. For example [peco](https://github.com/peco/peco), [fzf](https://github.com/junegunn/fzf) and etc.
+`ECSPRESSO_FILTER_COMMAND` environment variable can define a command to filter tasks. For example [peco](https://github.com/peco/peco), [fzf](https://github.com/junegunn/fzf) and etc.
 
-```yaml
-filter_command: peco
+```console
+$ ECSPRESSO_FILTER_COMMAND=peco ecspresso tasks --find
 ```
 
 When `--stop` option is set, you can select a task in a list of tasks and stop the task.
@@ -545,7 +545,7 @@ Flags:
 
 If `--id` is not set, the command shows a list of tasks to select a task to execute.
 
-`filter_command` in ecspresso.yml works the same as tasks command.
+`ECSPRESSO_FILTER_COMMAND` environment variable works the same as tasks command.
 
 See also the official document [Using Amazon ECS Exec for debugging](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html).
 

--- a/config.go
+++ b/config.go
@@ -143,6 +143,10 @@ func (c *Config) Restrict(ctx context.Context) error {
 	if err := c.setupPlugins(ctx); err != nil {
 		return fmt.Errorf("failed to setup plugins: %w", err)
 	}
+
+	if c.FilterCommand != "" {
+		Log("[WARNING] filter_command is deprecated. Use %s environment variable instead.", FilterCommandEnv)
+	}
 	return nil
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -288,3 +288,28 @@ func TestLoadConfigForCodeDeploy(t *testing.T) {
 		}
 	}
 }
+
+var FilterCommandTests = []struct {
+	Env      string
+	Expected string
+}{
+	{"", "fzf"},
+	{"peco", "peco"},
+}
+
+func TestFilterCommandDeprecated(t *testing.T) {
+	ctx := context.Background()
+	defer os.Setenv("ECSPRESSO_FILTER_COMMAND", "")
+	for _, ts := range FilterCommandTests {
+		os.Setenv("ECSPRESSO_FILTER_COMMAND", ts.Env)
+		app, err := ecspresso.New(ctx, &ecspresso.Option{
+			ConfigFilePath: "tests/filter_command.yml",
+		})
+		if err != nil {
+			t.Error(err)
+		}
+		if app.FilterCommand() != ts.Expected {
+			t.Errorf("expected %s, but got %s", ts.Expected, app.FilterCommand())
+		}
+	}
+}

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -27,6 +27,7 @@ import (
 const DefaultDesiredCount = -1
 const DefaultConfigFilePath = "ecspresso.yml"
 const dryRunStr = "DRY RUN"
+const FilterCommandEnv = "ECSPRESSO_FILTER_COMMAND"
 
 var Version string
 var delayForServiceChanged = 3 * time.Second
@@ -517,4 +518,11 @@ func (d *App) suspendAutoScaling(ctx context.Context, suspendState bool) error {
 		}
 	}
 	return nil
+}
+
+func (d *App) FilterCommand() string {
+	if fc := os.Getenv(FilterCommandEnv); fc != "" {
+		return fc
+	}
+	return d.config.FilterCommand
 }

--- a/exec.go
+++ b/exec.go
@@ -24,7 +24,7 @@ func (d *App) NewEcsta(ctx context.Context) (*ecsta.Ecsta, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create ecsta application: %w", err)
 	}
-	if fc := d.config.FilterCommand; fc != "" {
+	if fc := d.FilterCommand(); fc != "" {
 		app.Config.Set("filter_command", fc)
 	}
 	return app, nil

--- a/tests/ci/ecspresso.yml
+++ b/tests/ci/ecspresso.yml
@@ -4,4 +4,3 @@ service: "{{ must_env `SERVICE` }}"
 service_definition: ecs-service-def.json
 task_definition: ecs-task-def.json
 timeout: 10m0s
-filter_command: peco --select-1

--- a/tests/filter_command.yml
+++ b/tests/filter_command.yml
@@ -1,0 +1,5 @@
+cluster: default
+service: test
+service_definition: ecs-service-def.json
+task_definition: ecs-task-def.json
+filter_command: fzf


### PR DESCRIPTION
`filter_command` is a personal setting that depends on the installed command. So it should not be included in a configuration file that is commonly used for multi-users.

Use the `ECSPRESSO_FITLER_COMMAND` environment variable instead.
