### PR TITLE
ignore errors when the external registry outage.

### DIFF
--- a/registry/client_test.go
+++ b/registry/client_test.go
@@ -70,7 +70,8 @@ func TestFailImages(t *testing.T) {
 	for _, c := range testFailImages {
 		t.Logf("testing (will be fail) %s:%s", c.image, c.tag)
 		client := registry.New(c.image, "", "")
-		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
 		if ok, err := client.HasImage(ctx, c.tag); err == nil {
 			t.Errorf("HasImage %s:%s error %s", c.image, c.tag, err)
 		} else if ok {

--- a/registry/client_test.go
+++ b/registry/client_test.go
@@ -2,7 +2,10 @@ package registry_test
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/kayac/ecspresso/v2/registry"
 )
@@ -40,13 +43,22 @@ func TestImages(t *testing.T) {
 	for _, c := range testImages {
 		t.Logf("testing %s:%s", c.image, c.tag)
 		client := registry.New(c.image, "", "")
-		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
 		if ok, err := client.HasImage(ctx, c.tag); err != nil {
+			if isTemporary(err) {
+				t.Logf("skip testing for %s: %s", c.image, err)
+				continue
+			}
 			t.Errorf("%s:%s error %s", c.image, c.tag, err)
 		} else if !ok {
 			t.Errorf("%s:%s not found", c.image, c.tag)
 		}
 		if ok, err := client.HasPlatformImage(ctx, c.tag, c.arch, c.os); err != nil {
+			if isTemporary(err) {
+				t.Logf("skip testing for %s: %s", c.image, err)
+				continue
+			}
 			t.Errorf("%s:%s %s/%s error %s", c.image, c.tag, c.arch, c.os, err)
 		} else if !ok {
 			t.Errorf("%s:%s %s/%s not found", c.image, c.tag, c.arch, c.os)
@@ -70,4 +82,18 @@ func TestFailImages(t *testing.T) {
 			t.Errorf("HasPlatformImage %s:%s %s/%s should not be found", c.image, c.tag, c.arch, c.os)
 		}
 	}
+}
+
+func isTemporary(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) {
+		// timed out
+		return true
+	}
+	if strings.Contains(err.Error(), "503") {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
Timeout or 503 errors should be ignored.