### PR TITLE
CapacityProviderStrategy set nil when CodeDeploy

### DIFF
--- a/deploy.go
+++ b/deploy.go
@@ -197,6 +197,7 @@ func (d *App) UpdateServiceAttributes(ctx context.Context, sv *ecs.Service, opt 
 		in.ForceNewDeployment = nil
 		in.LoadBalancers = nil
 		in.ServiceRegistries = nil
+		in.CapacityProviderStrategy = nil
 	} else {
 		in.ForceNewDeployment = opt.ForceNewDeployment
 	}


### PR DESCRIPTION
### Description

When trying to deploy with AWS CodeDeploy, you must set the CapacityProviderStrategy in the appspec in order to prevent the error `failed to update service attributes: InvalidParameterException: When switching from launch type to capacity provider strategy on an existing service, or making a change to a capacity provider strategy on a service that is already using one, you must force a new deployment`.