### PR TITLE
Fix for CodeDeploy

### DIFF
--- a/deploy.go
+++ b/deploy.go
@@ -317,8 +317,8 @@ func (d *App) findDeploymentInfo(ctx context.Context) (*cdTypes.DeploymentInfo, 
 
 func (d *App) findCodeDeployApplications(ctx context.Context) ([]cdTypes.ApplicationInfo, error) {
 	var appNames []string
-	if d.config.CodeDeploy.ApplicationName != "" {
-		appNames = []string{d.config.CodeDeploy.ApplicationName}
+	if cd := d.config.CodeDeploy; cd != nil && cd.ApplicationName != "" {
+		appNames = []string{cd.ApplicationName}
 	} else {
 		pager := codedeploy.NewListApplicationsPaginator(d.codedeploy, &codedeploy.ListApplicationsInput{})
 		for pager.HasMorePages() {
@@ -353,8 +353,8 @@ func (d *App) findCodeDeployApplications(ctx context.Context) ([]cdTypes.Applica
 
 func (d *App) findCodeDeployDeploymentGroups(ctx context.Context, appName string) ([]cdTypes.DeploymentGroupInfo, error) {
 	var groupNames []string
-	if d.config.CodeDeploy.DeploymentGroupName != "" {
-		groupNames = []string{d.config.CodeDeploy.DeploymentGroupName}
+	if cd := d.config.CodeDeploy; cd != nil && cd.DeploymentGroupName != "" {
+		groupNames = []string{cd.DeploymentGroupName}
 	} else {
 		pager := codedeploy.NewListDeploymentGroupsPaginator(d.codedeploy, &codedeploy.ListDeploymentGroupsInput{
 			ApplicationName: &appName,

--- a/deploy.go
+++ b/deploy.go
@@ -237,6 +237,7 @@ func (d *App) UpdateServiceAttributes(ctx context.Context, sv *Service, taskDefi
 		in.LoadBalancers = nil
 		in.ServiceRegistries = nil
 		in.TaskDefinition = nil
+		in.CapacityProviderStrategy = nil
 	} else {
 		d.Log("[INFO] deployment by ECS rolling update")
 		in.ForceNewDeployment = aws.ToBool(opt.ForceNewDeployment)

--- a/docs/v1-v2.md
+++ b/docs/v1-v2.md
@@ -11,6 +11,7 @@ See also [#374](https://github.com/kayac/ecspresso/issues/374), issues and pull 
 - `diff --unified` true by default. (#419 @cohalz)
 - Outputs of log messages never refresh the terminal and break lines. These messages flow simply. (#449, #380, #344 @winebarrel)
 - `filter_command` in a configuration file is deprecated. Use `ECSPRESSO_FILTER_COMMAND` environment variable instead. (#469)
+- When using CodeDeploy, `deploy` command waits to complete the deployment. Use `--no-wait` option if you want to break at deployment started the same as v1.
 
 ## Enhanced
 


### PR DESCRIPTION
- Ports #481 into v2.
- Fix panic  when `code_deploy` is not defined in a configuration file.