### PR TITLE
Set download URL without API call

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ runs:
         if [ "${VERSION}" = "latest" ]; then
           DOWNLOAD_URL=$(curl -sS https://api.github.com/repos/kayac/ecspresso/releases | jq -r '[.[]|select(.tag_name < "v1.99")|select(.prerelease == false)][0].assets[].browser_download_url|select(match("linux.amd64."))')
         else
-          DOWNLOAD_URL=$(curl -sS https://api.github.com/repos/kayac/ecspresso/releases/tags/${VERSION}|jq -r '.assets[].browser_download_url|select(match("linux.amd64."))')
+          DOWNLOAD_URL=https://github.com/kayac/ecspresso/releases/download/v${VERSION}/ecspresso_${VERSION}_linux_amd64.tar.gz
         fi
         cd /tmp
         curl -sfLO ${DOWNLOAD_URL}


### PR DESCRIPTION
Calls to the GitHub API sometimes fail, so if VERSION is specified, set DOWNLOAD_URL without using the GitHub API.
(I am guessing that this is due to the status code 403 being returned at the rate limit.)

![スクリーンショット 2022-12-20 13 33 19](https://user-images.githubusercontent.com/117768/208584423-8fc6759c-f291-4aff-a655-61f4ee65f6e5.png)

Could you please do a review?