### PR TITLE
Feature Request: Support version-file for Composite Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ jobs:
       - uses: kayac/ecspresso@v2
         with:
           version: v2.0.0 # or latest
+          # version-file: .ecspresso-version
       - run: |
           ecspresso deploy --config ecspresso.yml
 ```

--- a/action.yml
+++ b/action.yml
@@ -3,6 +3,9 @@ inputs:
     description: "A version to install ecspresso"
     default: latest
     required: false
+  version-file:
+    description: "File containing the ecspresso version. Example: .ecspresso-version"
+    required: false
 runs:
   using: "composite"
   steps:
@@ -11,6 +14,9 @@ runs:
       run: |
         set -e
         VERSION="${{ inputs.version }}"
+        if [ -n "${{ inputs.version-file }}" ]; then
+          VERSION=$(cat ${{ inputs.version-file }})
+        fi
         if [ "${VERSION}" = "latest" ]; then
           DOWNLOAD_URL=$(curl -sS https://api.github.com/repos/kayac/ecspresso/releases | jq -r '[.[]|select(.tag_name > "v2.0")|select(.prerelease==false)][0].assets[].browser_download_url|select(match("linux.amd64."))')
         else

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ runs:
         set -e
         VERSION="${{ inputs.version }}"
         if [ -n "${{ inputs.version-file }}" ]; then
-          VERSION=$(cat ${{ inputs.version-file }})
+          VERSION="v$(cat ${{ inputs.version-file }})"
         fi
         if [ "${VERSION}" = "latest" ]; then
           DOWNLOAD_URL=$(curl -sS https://api.github.com/repos/kayac/ecspresso/releases | jq -r '[.[]|select(.tag_name > "v2.0")|select(.prerelease==false)][0].assets[].browser_download_url|select(match("linux.amd64."))')

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,6 @@ runs:
   using: "composite"
   steps:
     - shell: bash
-      working-directory: /tmp
       run: |
         set -e
         VERSION="${{ inputs.version }}"


### PR DESCRIPTION
Added input to GitHub's Composite Action to use a version file.

```yaml
- uses: kayac/ecspresso@v2
  with:
    version-file: .ecspresso-version
``` 


## Use Case
By using the `.ecspresso-version` file in GitHub Actions and `required_version` of ecspresso.jsonnet, you can fix the version, and you only need to change this file when upgrading.

```jsonnet
{
  required_version: '= v' + importstr '.ecspresso-version',
}
```
You can still write it as below, but it is redundant and difficult to manage if it is used in multiple workflows.

```yaml
-  run: |
    echo "ECSPRESSO_VERSION=v$(cat .ecspresso-version)" >> "$GITHUB_ENV"
- uses: kayac/ecspresso@v2
  with:
    version: ${{ env.ECSPRESSO_VERSION }}
```

Also, by changing https://github.com/koluku/asdf-ecspresso/pull/1, it is expected that asdf will be able to use this file.
