### PR TITLE
V1 action testing

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -18,11 +18,6 @@ jobs:
           ecspresso version 2>&1 | fgrep v1.5.0
       - uses: kayac/ecspresso@v1-action-testing
         with:
-          version: v1.5.0
-      - run: |
-          ecspresso version 2>&1 | fgrep v1.5.0
-      - uses: kayac/ecspresso@v1-action-testing
-        with:
           version: v1.6.0
       - run: |
           ecspresso version 2>&1 | fgrep v1.6.0

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -16,17 +16,17 @@ jobs:
           version: v1.5.0
       - run: |
           ecspresso version 2>&1 | fgrep v1.5.0
-      - uses: kayac/ecspresso@v1
+      - uses: kayac/ecspresso@v1-action-testing
         with:
           version: v1.5.0
       - run: |
           ecspresso version 2>&1 | fgrep v1.5.0
-      - uses: kayac/ecspresso@v1
+      - uses: kayac/ecspresso@v1-action-testing
         with:
           version: v1.6.0
       - run: |
           ecspresso version 2>&1 | fgrep v1.6.0
-      - uses: kayac/ecspresso@v1
+      - uses: kayac/ecspresso@v1-action-testing
         with:
           version: latest
       - run: |

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - v1
-      - v1-fixed-url
+      - v1-action-testing
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - v1
+      - v1-fixed-url
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -21,12 +21,12 @@ jobs:
           version: v1.5.0
       - run: |
           ecspresso version 2>&1 | fgrep v1.5.0
-      - uses: kayac/ecspresso@v1-action-testing
+      - uses: kayac/ecspresso@v1
         with:
           version: v1.6.0
       - run: |
           ecspresso version 2>&1 | fgrep v1.6.0
-      - uses: kayac/ecspresso@v1-action-testing
+      - uses: kayac/ecspresso@v1
         with:
           version: latest
       - run: |

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -16,6 +16,11 @@ jobs:
           version: v1.5.0
       - run: |
           ecspresso version 2>&1 | fgrep v1.5.0
+      - uses: kayac/ecspresso@v1.7.15
+        with:
+          version: v1.5.0
+      - run: |
+          ecspresso version 2>&1 | fgrep v1.5.0
       - uses: kayac/ecspresso@v1-action-testing
         with:
           version: v1.6.0

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ runs:
         if [ "${VERSION}" = "latest" ]; then
           DOWNLOAD_URL=$(curl -sS https://api.github.com/repos/kayac/ecspresso/releases | jq -r '[.[]|select(.tag_name < "v1.99")|select(.prerelease == false)][0].assets[].browser_download_url|select(match("linux.amd64."))')
         else
-          DOWNLOAD_URL=$(curl -sS https://api.github.com/repos/kayac/ecspresso/releases/tags/${VERSION}|jq -r '.assets[].browser_download_url|select(match("linux.amd64."))')
+          DOWNLOAD_URL=https://github.com/kayac/ecspresso/releases/download/v${VERSION}/ecspresso_${VERSION}_linux_amd64.tar.gz
         fi
         cd /tmp
         curl -sfLO ${DOWNLOAD_URL}

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ runs:
         if [ "${VERSION}" = "latest" ]; then
           DOWNLOAD_URL=$(curl -sS https://api.github.com/repos/kayac/ecspresso/releases | jq -r '[.[]|select(.tag_name < "v1.99")|select(.prerelease == false)][0].assets[].browser_download_url|select(match("linux.amd64."))')
         else
-          DOWNLOAD_URL=https://github.com/kayac/ecspresso/releases/download/v${VERSION}/ecspresso_${VERSION}_linux_amd64.tar.gz
+          DOWNLOAD_URL=https://github.com/kayac/ecspresso/releases/download/${VERSION}/ecspresso_${VERSION:1}_linux_amd64.tar.gz
         fi
         cd /tmp
         curl -sfLO ${DOWNLOAD_URL}


### PR DESCRIPTION
refs #489 

- `kayac/ecspresso@v1` supports v1.6 or later when specify `version`.
- `kayac/ecspresso@v1.7.15` supports v1.5.
