### PR TITLE
Fix supend / resume autoscaling

### DIFF
--- a/deploy.go
+++ b/deploy.go
@@ -149,9 +149,15 @@ func (d *App) Deploy(ctx context.Context, opt DeployOption) error {
 		return nil
 	}
 
-	// manage auto scaling only when set option --suspend-auto-scaling or --no-suspend-auto-scaling explicitly
-	if suspendState := opt.SuspendAutoScaling; suspendState != nil {
-		if err := d.suspendAutoScaling(ctx, *suspendState); err != nil {
+	// manage auto scaling only when set option --suspend-auto-scaling or --resume-auto-scaling explicitly
+	if opt.SuspendAutoScaling != nil && *opt.SuspendAutoScaling {
+		d.Log("suspending auto scaling")
+		if err := d.suspendAutoScaling(ctx, true); err != nil {
+			return err
+		}
+	} else if opt.ResumeAutoScaling != nil && *opt.ResumeAutoScaling {
+		d.Log("resuming auto scaling")
+		if err := d.suspendAutoScaling(ctx, false); err != nil {
 			return err
 		}
 	}

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -543,7 +543,12 @@ func (d *App) suspendAutoScaling(ctx context.Context, suspendState bool) error {
 		return fmt.Errorf("failed to describe scalable targets: %w", err)
 	}
 	if len(out.ScalableTargets) == 0 {
-		d.Log("No scalable target for %s", resourceId)
+		d.Log("[WARNING] No scalable target for %s", resourceId)
+		if suspendState {
+			d.Log("[WARNING] Skip suspend auto scaling")
+		} else {
+			d.Log("[WARNING] Skip resume auto scaling")
+		}
 		return nil
 	}
 	for _, target := range out.ScalableTargets {

--- a/scale.go
+++ b/scale.go
@@ -18,5 +18,7 @@ func (o *ScaleOption) DeployOption() DeployOption {
 		RollbackEvents:       ptr(""),
 		UpdateService:        ptr(false),
 		LatestTaskDefinition: ptr(false),
+		SuspendAutoScaling:   o.SuspendAutoScaling,
+		ResumeAutoScaling:    o.ResumeAutoScaling,
 	}
 }


### PR DESCRIPTION
- Fix `ecspresso scale` with `--suspend-auto-scaling` or `--resume-auto-scaling` didn't work.
  - Pass these options to Deploy().
- Fix `ecspresso deploy --resume-auto-scaling` didn't work.
