### PR TITLE
Fix for confusing flags of run.

### DIFF
--- a/config.go
+++ b/config.go
@@ -141,12 +141,12 @@ func (c *Config) Restrict(ctx context.Context) error {
 	var optsFunc []func(*awsConfig.LoadOptions) error
 	if len(awsv2ConfigLoadOptionsFunc) == 0 {
 		// default
-		Log("[INFO] use default aws config load options")
+		// Log("[INFO] use default aws config load options")
 		optsFunc = []func(*awsConfig.LoadOptions) error{
 			awsConfig.WithRegion(c.Region),
 		}
 	} else {
-		Log("[INFO] override aws config load options")
+		// Log("[INFO] override aws config load options")
 		optsFunc = awsv2ConfigLoadOptionsFunc
 	}
 	c.awsv2Config, err = awsConfig.LoadDefaultConfig(ctx, optsFunc...)

--- a/errors.go
+++ b/errors.go
@@ -12,6 +12,12 @@ func (e ErrNotFound) Error() string {
 	return string(e)
 }
 
+type ErrConflictOptions string
+
+func (e ErrConflictOptions) Error() string {
+	return string(e)
+}
+
 var (
 	errNotFound   = ErrNotFound("not found")
 	errSkipVerify = ErrSkipVerify("skip verify")

--- a/export_test.go
+++ b/export_test.go
@@ -21,6 +21,7 @@ var (
 	NewLogger                    = newLogger
 	NewLogFilter                 = newLogFilter
 	NewConfigLoader              = newConfigLoader
+	ArnToName                    = arnToName
 )
 
 func (d *App) SetLogger(logger *log.Logger) {
@@ -31,8 +32,12 @@ func SetLogger(logger *log.Logger) {
 	commonLogger = logger
 }
 
-func (c *Config) SetAWSv2ConfigLoadOptionsFunc(fns []func(*config.LoadOptions) error) {
-	c.awsv2ConfigLoadOptionsFunc = fns
+func SetAWSV2ConfigLoadOptionsFunc(f []func(*config.LoadOptions) error) {
+	awsv2ConfigLoadOptionsFunc = f
+}
+
+func ResetAWSV2ConfigLoadOptionsFunc() {
+	awsv2ConfigLoadOptionsFunc = nil
 }
 
 func (d *App) TaskDefinitionArnForRun(ctx context.Context, opt RunOption) (string, error) {

--- a/export_test.go
+++ b/export_test.go
@@ -1,6 +1,11 @@
 package ecspresso
 
-import "log"
+import (
+	"context"
+	"log"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+)
 
 var (
 	SortTaskDefinitionForDiff    = sortTaskDefinitionForDiff
@@ -24,4 +29,12 @@ func (d *App) SetLogger(logger *log.Logger) {
 
 func SetLogger(logger *log.Logger) {
 	commonLogger = logger
+}
+
+func (c *Config) SetAWSv2ConfigLoadOptionsFunc(fns []func(*config.LoadOptions) error) {
+	c.awsv2ConfigLoadOptionsFunc = fns
+}
+
+func (d *App) TaskDefinitionArnForRun(ctx context.Context, opt RunOption) (string, error) {
+	return d.taskDefinitionArnForRun(ctx, opt)
 }

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -18,6 +18,18 @@ var middlewareResults = map[string]interface{}{
 			},
 		},
 	},
+	"ListTaskDefinitions": &ecs.ListTaskDefinitionsOutput{
+		TaskDefinitionArns: []string{
+			"arn:aws:ecs:ap-northeast-1:123456789012:task-definition/test:45",
+			"arn:aws:ecs:ap-northeast-1:123456789012:task-definition/test:44",
+			"arn:aws:ecs:ap-northeast-1:123456789012:task-definition/test:43",
+			"arn:aws:ecs:ap-northeast-1:123456789012:task-definition/test:42",
+			"arn:aws:ecs:ap-northeast-1:123456789012:task-definition/test:41",
+			"arn:aws:ecs:ap-northeast-1:123456789012:task-definition/test:40",
+			"arn:aws:ecs:ap-northeast-1:123456789012:task-definition/test:39",
+			"arn:aws:ecs:ap-northeast-1:123456789012:task-definition/test:38",
+		},
+	},
 }
 
 func SDKTestingMiddleware() func(*middleware.Stack) error {

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -1,0 +1,39 @@
+package ecspresso_test
+
+import (
+	"context"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/service/ecs"
+	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	"github.com/aws/smithy-go/middleware"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+)
+
+var middlewareResults = map[string]interface{}{
+	"DescribeServices": &ecs.DescribeServicesOutput{
+		Services: []types.Service{
+			{
+				TaskDefinition: ptr("arn:aws:ecs:ap-northeast-1:123456789012:task-definition/test:39"),
+			},
+		},
+	},
+}
+
+func SDKTestingMiddleware() func(*middleware.Stack) error {
+	return func(stack *middleware.Stack) error {
+		return stack.Finalize.Add(
+			middleware.FinalizeMiddlewareFunc(
+				"test",
+				func(ctx context.Context, in middleware.FinalizeInput, handler middleware.FinalizeHandler) (middleware.FinalizeOutput, middleware.Metadata, error) {
+					req := in.Request.(*smithyhttp.Request)
+					target := strings.SplitN(req.Header.Get("X-Amz-Target"), ".", 2)[1]
+					return middleware.FinalizeOutput{
+						Result: middlewareResults[target],
+					}, middleware.Metadata{}, nil
+				},
+			),
+			middleware.Before,
+		)
+	}
+}

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -12,11 +12,11 @@ import (
 )
 
 var middlewareResults = map[string]func(string) any{
-	"DescribeServices": func(_ string) any {
+	"DescribeServices": func(family string) any {
 		return &ecs.DescribeServicesOutput{
 			Services: []types.Service{
 				{
-					TaskDefinition: ptr("arn:aws:ecs:ap-northeast-1:123456789012:task-definition/test:39"),
+					TaskDefinition: ptr(fmt.Sprintf("arn:aws:ecs:ap-northeast-1:123456789012:task-definition/%s:39", family)),
 				},
 			},
 		}

--- a/run.go
+++ b/run.go
@@ -221,33 +221,30 @@ func (d *App) waitTask(ctx context.Context, task *types.Task, untilRunning bool)
 }
 
 func (d *App) taskDefinitionArnForRun(ctx context.Context, opt RunOption) (string, error) {
+	if *opt.SkipTaskDefinition && *opt.LatestTaskDefinition {
+		return "", fmt.Errorf("skip-task-definition and latest-task-definition are exclusive")
+	}
 	switch {
-	case *opt.SkipTaskDefinition, *opt.LatestTaskDefinition:
-		var family string
-		if d.config.Service != "" {
-			d.Log("[DEBUG] loading service")
-			sv, err := d.DescribeService(ctx)
-			if err != nil {
-				return "", err
-			}
-			tdArn := *sv.TaskDefinition
-			if *opt.SkipTaskDefinition {
-				return tdArn, nil
-			}
-			p := strings.SplitN(arnToName(tdArn), ":", 2)
-			family = p[0]
-		} else {
-			d.Log("[DEBUG] loading task definition")
-			td, err := d.LoadTaskDefinition(d.config.TaskDefinitionPath)
-			if err != nil {
-				return "", err
-			}
-			family = *td.Family
+	case *opt.Revision > 0:
+		family, _, err := d.resolveTaskdefinition(ctx)
+		if err != nil {
+			return "", err
 		}
-		if rev := aws.ToInt64(opt.Revision); rev > 0 {
-			return fmt.Sprintf("%s:%d", family, rev), nil
+		return fmt.Sprintf("%s:%d", family, *opt.Revision), nil
+	case *opt.SkipTaskDefinition:
+		family, rev, err := d.resolveTaskdefinition(ctx)
+		if err != nil {
+			return "", err
 		}
-
+		if rev == "" {
+			return "", fmt.Errorf("revision is not specified")
+		}
+		return fmt.Sprintf("%s:%s", family, rev), nil
+	case *opt.LatestTaskDefinition:
+		family, _, err := d.resolveTaskdefinition(ctx)
+		if err != nil {
+			return "", err
+		}
 		d.Log("Revision is not specified. Use latest task definition family" + family)
 		latestTdArn, err := d.findLatestTaskDefinitionArn(ctx, family)
 		if err != nil {
@@ -271,5 +268,29 @@ func (d *App) taskDefinitionArnForRun(ctx context.Context, opt RunOption) (strin
 			return "", err
 		}
 		return *newTd.TaskDefinitionArn, nil
+	}
+}
+
+func (d *App) resolveTaskdefinition(ctx context.Context) (family string, revision string, err error) {
+	if d.config.Service != "" {
+		d.Log("[DEBUG] loading service")
+		sv, err := d.DescribeService(ctx)
+		if err != nil {
+			return "", "", err
+		}
+		tdArn := *sv.TaskDefinition
+		p := strings.SplitN(arnToName(tdArn), ":", 2)
+		if len(p) != 2 {
+			return "", "", fmt.Errorf("invalid task definition arn: %s", tdArn)
+		}
+		return p[0], p[1], nil
+	} else {
+		d.Log("[DEBUG] loading task definition")
+		td, err := d.LoadTaskDefinition(d.config.TaskDefinitionPath)
+		if err != nil {
+			return "", "", err
+		}
+		family = *td.Family
+		return family, "", nil
 	}
 }

--- a/run_test.go
+++ b/run_test.go
@@ -10,9 +10,10 @@ import (
 )
 
 var testTaskDefinitionArnForRunSuite = []struct {
-	config string
-	opts   []string
-	td     string
+	config   string
+	opts     []string
+	td       string
+	raiseErr bool
 }{
 	{
 		config: "tests/run-with-sv.yaml",
@@ -49,6 +50,41 @@ var testTaskDefinitionArnForRunSuite = []struct {
 		opts:   []string{"--task-def=tests/run-test-td.json"},
 		td:     "family test will be registered",
 	},
+	{
+		config:   "tests/run-without-sv.yaml",
+		opts:     []string{"--skip-task-definition"},
+		raiseErr: true, // without service, --skip-task-definition is not allowed
+	},
+	{
+		config: "tests/run-without-sv.yaml",
+		opts:   []string{"--skip-task-definition", "--revision=42"},
+		td:     "katsubushi:42",
+	},
+	{
+		config: "tests/run-without-sv.yaml",
+		opts:   []string{"--latest-task-definition"},
+		td:     "katsubushi:45",
+	},
+	{
+		config:   "tests/run-without-sv.yaml",
+		opts:     []string{"--latest-task-definition", "--skip-task-definition"},
+		raiseErr: true, // without service, --skip-task-definition is not allowed
+	},
+	{
+		config: "tests/run-without-sv.yaml",
+		opts:   []string{"--latest-task-definition", "--revision=42"},
+		td:     "katsubushi:42",
+	},
+	{
+		config: "tests/run-without-sv.yaml",
+		opts:   nil,
+		td:     "family katsubushi will be registered",
+	},
+	{
+		config: "tests/run-without-sv.yaml",
+		opts:   []string{"--task-def=tests/run-test-td.json"},
+		td:     "family test will be registered",
+	},
 }
 
 func TestTaskDefinitionArnForRun(t *testing.T) {
@@ -76,10 +112,10 @@ func TestTaskDefinitionArnForRun(t *testing.T) {
 		opts := *cliopts.Run
 		tdArn, err := app.TaskDefinitionArnForRun(ctx, opts)
 		if err != nil {
-			t.Errorf("%s unexpected error: %s", args, err)
+			t.Errorf("%s %s unexpected error: %s", s.config, args, err)
 		}
 		if ecspresso.ArnToName(tdArn) != s.td {
-			t.Errorf("%s expected %s, got %s", args, s.td, tdArn)
+			t.Errorf("%s %s expected %s, got %s", s.config, args, s.td, tdArn)
 		}
 	}
 }

--- a/run_test.go
+++ b/run_test.go
@@ -10,16 +10,44 @@ import (
 )
 
 var testTaskDefinitionArnForRunSuite = []struct {
-	opts []string
-	td   string
+	config string
+	opts   []string
+	td     string
 }{
 	{
-		opts: []string{"--skip-task-definition"},
-		td:   "test:39",
+		config: "tests/run-with-sv.yaml",
+		opts:   []string{"--skip-task-definition"},
+		td:     "test:39",
 	},
 	{
-		opts: []string{"--skip-task-definition", "--revision=42"},
-		td:   "test:42",
+		config: "tests/run-with-sv.yaml",
+		opts:   []string{"--skip-task-definition", "--revision=42"},
+		td:     "test:42",
+	},
+	{
+		config: "tests/run-with-sv.yaml",
+		opts:   []string{"--latest-task-definition"},
+		td:     "test:45",
+	},
+	{
+		config: "tests/run-with-sv.yaml",
+		opts:   []string{"--latest-task-definition", "--skip-task-definition"},
+		td:     "test:45",
+	},
+	{
+		config: "tests/run-with-sv.yaml",
+		opts:   []string{"--latest-task-definition", "--skip-task-definition", "--revision=42"},
+		td:     "test:42",
+	},
+	{
+		config: "tests/run-with-sv.yaml",
+		opts:   nil,
+		td:     "family katsubushi will be registered",
+	},
+	{
+		config: "tests/run-with-sv.yaml",
+		opts:   []string{"--task-def=tests/run-test-td.json"},
+		td:     "family test will be registered",
 	},
 }
 
@@ -33,12 +61,12 @@ func TestTaskDefinitionArnForRun(t *testing.T) {
 	})
 	defer ecspresso.ResetAWSV2ConfigLoadOptionsFunc()
 
-	app, err := ecspresso.New(ctx, &ecspresso.Option{ConfigFilePath: "tests/run-with-sv.yaml"})
-	if err != nil {
-		t.Error(err)
-	}
-
 	for _, s := range testTaskDefinitionArnForRunSuite {
+		app, err := ecspresso.New(ctx, &ecspresso.Option{ConfigFilePath: s.config})
+		if err != nil {
+			t.Error(err)
+			continue
+		}
 		args := []string{"run", "--dry-run"}
 		args = append(args, s.opts...)
 		_, cliopts, _, err := ecspresso.ParseCLIv2(args)

--- a/run_test.go
+++ b/run_test.go
@@ -9,81 +9,72 @@ import (
 	"github.com/kayac/ecspresso/v2"
 )
 
-var testTaskDefinitionArnForRunSuite = []struct {
-	config   string
+type taskDefinitionArnForRunSuite struct {
 	opts     []string
 	td       string
 	raiseErr bool
-}{
-	{
-		config: "tests/run-with-sv.yaml",
-		opts:   []string{"--skip-task-definition"},
-		td:     "test:39",
+}
+
+var testTaskDefinitionArnForRunSuite = map[string][]taskDefinitionArnForRunSuite{
+	"tests/run-with-sv.yaml": {
+		{
+			opts: []string{"--skip-task-definition"},
+			td:   "test:39",
+		},
+		{
+			opts: []string{"--skip-task-definition", "--revision=42"},
+			td:   "test:42",
+		},
+		{
+			opts: []string{"--latest-task-definition"},
+			td:   "test:45",
+		},
+		{
+			opts:     []string{"--latest-task-definition", "--skip-task-definition"},
+			raiseErr: true,
+		},
+		{
+			opts:     []string{"--latest-task-definition", "--skip-task-definition", "--revision=42"},
+			raiseErr: true,
+		},
+		{
+			opts: nil,
+			td:   "family katsubushi will be registered",
+		},
+		{
+			opts: []string{"--task-def=tests/run-test-td.json"},
+			td:   "family test will be registered",
+		},
 	},
-	{
-		config: "tests/run-with-sv.yaml",
-		opts:   []string{"--skip-task-definition", "--revision=42"},
-		td:     "test:42",
-	},
-	{
-		config: "tests/run-with-sv.yaml",
-		opts:   []string{"--latest-task-definition"},
-		td:     "test:45",
-	},
-	{
-		config: "tests/run-with-sv.yaml",
-		opts:   []string{"--latest-task-definition", "--skip-task-definition"},
-		td:     "test:45",
-	},
-	{
-		config: "tests/run-with-sv.yaml",
-		opts:   []string{"--latest-task-definition", "--skip-task-definition", "--revision=42"},
-		td:     "test:42",
-	},
-	{
-		config: "tests/run-with-sv.yaml",
-		opts:   nil,
-		td:     "family katsubushi will be registered",
-	},
-	{
-		config: "tests/run-with-sv.yaml",
-		opts:   []string{"--task-def=tests/run-test-td.json"},
-		td:     "family test will be registered",
-	},
-	{
-		config:   "tests/run-without-sv.yaml",
-		opts:     []string{"--skip-task-definition"},
-		raiseErr: true, // without service, --skip-task-definition is not allowed
-	},
-	{
-		config: "tests/run-without-sv.yaml",
-		opts:   []string{"--skip-task-definition", "--revision=42"},
-		td:     "katsubushi:42",
-	},
-	{
-		config: "tests/run-without-sv.yaml",
-		opts:   []string{"--latest-task-definition"},
-		td:     "katsubushi:45",
-	},
-	{
-		config:   "tests/run-without-sv.yaml",
-		opts:     []string{"--latest-task-definition", "--skip-task-definition"},
-		raiseErr: true, // without service, --skip-task-definition is not allowed
-	},
-	{
-		config: "tests/run-without-sv.yaml",
-		opts:   []string{"--latest-task-definition", "--revision=42"},
-		td:     "katsubushi:42",
-	},
-	{
-		config: "tests/run-without-sv.yaml",
-		opts:   nil,
-		td:     "family katsubushi will be registered",
-	},
-	{
-		config: "tests/run-without-sv.yaml",
-		opts:   []string{"--task-def=tests/run-test-td.json"},
-		td:     "family test will be registered",
+	"tests/run-without-sv.yaml": {
+		{
+			opts:     []string{"--skip-task-definition"},
+			raiseErr: true, // without service, --skip-task-definition is not allowed
+		},
+		{
+			opts: []string{"--skip-task-definition", "--revision=42"},
+			td:   "katsubushi:42",
+		},
+		{
+			opts: []string{"--latest-task-definition"},
+			td:   "katsubushi:45",
+		},
+		{
+			opts:     []string{"--latest-task-definition", "--skip-task-definition"},
+			raiseErr: true, // without service, --skip-task-definition is not allowed
+		},
+		{
+			opts: []string{"--latest-task-definition", "--revision=42"},
+			td:   "katsubushi:42",
+		},
+		{
+			opts: nil,
+			td:   "family katsubushi will be registered",
+		},
+		{
+			opts: []string{"--task-def=tests/run-test-td.json"},
+			td:   "family test will be registered",
+		},
 	},
 }
 
@@ -93,29 +84,31 @@ func TestTaskDefinitionArnForRun(t *testing.T) {
 	// mock aws sdk
 	ecspresso.SetAWSV2ConfigLoadOptionsFunc([]func(*config.LoadOptions) error{
 		config.WithRegion("ap-northeast-1"),
-		config.WithAPIOptions([]func(*middleware.Stack) error{SDKTestingMiddleware()}),
+		config.WithAPIOptions([]func(*middleware.Stack) error{SDKTestingMiddleware("test")}),
 	})
 	defer ecspresso.ResetAWSV2ConfigLoadOptionsFunc()
-
-	for _, s := range testTaskDefinitionArnForRunSuite {
-		app, err := ecspresso.New(ctx, &ecspresso.Option{ConfigFilePath: s.config})
+	for config, suites := range testTaskDefinitionArnForRunSuite {
+		app, err := ecspresso.New(ctx, &ecspresso.Option{ConfigFilePath: config})
 		if err != nil {
 			t.Error(err)
 			continue
 		}
-		args := []string{"run", "--dry-run"}
-		args = append(args, s.opts...)
-		_, cliopts, _, err := ecspresso.ParseCLIv2(args)
-		if err != nil {
-			t.Error(err)
-		}
-		opts := *cliopts.Run
-		tdArn, err := app.TaskDefinitionArnForRun(ctx, opts)
-		if err != nil {
-			t.Errorf("%s %s unexpected error: %s", s.config, args, err)
-		}
-		if ecspresso.ArnToName(tdArn) != s.td {
-			t.Errorf("%s %s expected %s, got %s", s.config, args, s.td, tdArn)
+		for _, s := range suites {
+			args := []string{"run", "--dry-run"}
+			args = append(args, s.opts...)
+			_, cliopts, _, err := ecspresso.ParseCLIv2(args)
+			if err != nil {
+				t.Error(err)
+			}
+			opts := *cliopts.Run
+			tdArn, err := app.TaskDefinitionArnForRun(ctx, opts)
+			if s.raiseErr && err == nil {
+				t.Errorf("%s %s expected error, but got nil", config, args)
+			} else if err != nil {
+				t.Errorf("%s %s unexpected error: %s", config, args, err)
+			} else if td := ecspresso.ArnToName(tdArn); td != s.td {
+				t.Errorf("%s %s expected %s, got %s", config, args, s.td, td)
+			}
 		}
 	}
 }

--- a/run_test.go
+++ b/run_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/kayac/ecspresso/v2"
 )
 
+var v2_1_OrLater = false // TODO: set true if v2.1
+
 type taskDefinitionArnForRunSuite struct {
 	opts     []string
 	td       string
@@ -35,10 +37,12 @@ var testTaskDefinitionArnForRunSuite = map[string][]taskDefinitionArnForRunSuite
 		},
 		{
 			opts:     []string{"--latest-task-definition", "--skip-task-definition", "--revision=41"},
+			td:       "katsubushi:41",
 			raiseErr: true, // latest-task-definition and revision are exclusive
 		},
 		{
 			opts:     []string{"--latest-task-definition", "--revision=41"},
+			td:       "katsubushi:41",
 			raiseErr: true, // latest-task-definition and revision are exclusive
 		},
 		{
@@ -52,8 +56,8 @@ var testTaskDefinitionArnForRunSuite = map[string][]taskDefinitionArnForRunSuite
 	},
 	"tests/run-without-sv.yaml": {
 		{
-			opts:     []string{"--skip-task-definition"},
-			raiseErr: true, // without service, --skip-task-definition is not allowed
+			opts: []string{"--skip-task-definition"},
+			td:   "katsubushi:45",
 		},
 		{
 			opts: []string{"--skip-task-definition", "--revision=42"},
@@ -69,6 +73,7 @@ var testTaskDefinitionArnForRunSuite = map[string][]taskDefinitionArnForRunSuite
 		},
 		{
 			opts:     []string{"--latest-task-definition", "--revision=42"},
+			td:       "katsubushi:42",
 			raiseErr: true, // latest-task-definition and revision are exclusive
 		},
 		{
@@ -108,7 +113,7 @@ func TestTaskDefinitionArnForRun(t *testing.T) {
 			}
 			opts := *cliopts.Run
 			tdArn, err := app.TaskDefinitionArnForRun(ctx, opts)
-			if s.raiseErr {
+			if v2_1_OrLater && s.raiseErr {
 				if err == nil {
 					t.Errorf("%s %s expected error, but got nil", config, args)
 				}

--- a/run_test.go
+++ b/run_test.go
@@ -38,6 +38,10 @@ var testTaskDefinitionArnForRunSuite = map[string][]taskDefinitionArnForRunSuite
 			raiseErr: true, // latest-task-definition and revision are exclusive
 		},
 		{
+			opts:     []string{"--latest-task-definition", "--revision=41"},
+			raiseErr: true, // latest-task-definition and revision are exclusive
+		},
+		{
 			opts: nil,
 			td:   "family katsubushi will be registered",
 		},

--- a/run_test.go
+++ b/run_test.go
@@ -1,0 +1,57 @@
+package ecspresso_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/smithy-go/middleware"
+	"github.com/kayac/ecspresso/v2"
+)
+
+var testTaskDefinitionArnForRunSuite = []struct {
+	opts []string
+	td   string
+}{
+	{
+		opts: []string{"--skip-task-definition"},
+		td:   "test:39",
+	},
+	{
+		opts: []string{"--skip-task-definition", "--revision=42"},
+		td:   "test:42",
+	},
+}
+
+func TestTaskDefinitionArnForRun(t *testing.T) {
+	ctx := context.TODO()
+
+	// mock aws sdk
+	ecspresso.SetAWSV2ConfigLoadOptionsFunc([]func(*config.LoadOptions) error{
+		config.WithRegion("ap-northeast-1"),
+		config.WithAPIOptions([]func(*middleware.Stack) error{SDKTestingMiddleware()}),
+	})
+	defer ecspresso.ResetAWSV2ConfigLoadOptionsFunc()
+
+	app, err := ecspresso.New(ctx, &ecspresso.Option{ConfigFilePath: "tests/run-with-sv.yaml"})
+	if err != nil {
+		t.Error(err)
+	}
+
+	for _, s := range testTaskDefinitionArnForRunSuite {
+		args := []string{"run", "--dry-run"}
+		args = append(args, s.opts...)
+		_, cliopts, _, err := ecspresso.ParseCLIv2(args)
+		if err != nil {
+			t.Error(err)
+		}
+		opts := *cliopts.Run
+		tdArn, err := app.TaskDefinitionArnForRun(ctx, opts)
+		if err != nil {
+			t.Errorf("%s unexpected error: %s", args, err)
+		}
+		if ecspresso.ArnToName(tdArn) != s.td {
+			t.Errorf("%s expected %s, got %s", args, s.td, tdArn)
+		}
+	}
+}

--- a/run_test.go
+++ b/run_test.go
@@ -30,12 +30,12 @@ var testTaskDefinitionArnForRunSuite = map[string][]taskDefinitionArnForRunSuite
 			td:   "katsubushi:45",
 		},
 		{
-			opts:     []string{"--latest-task-definition", "--skip-task-definition"},
-			raiseErr: true,
+			opts: []string{"--latest-task-definition", "--skip-task-definition"},
+			td:   "katsubushi:45",
 		},
 		{
-			opts:     []string{"--latest-task-definition", "--skip-task-definition", "--revision=42"},
-			raiseErr: true,
+			opts:     []string{"--latest-task-definition", "--skip-task-definition", "--revision=41"},
+			raiseErr: true, // latest-task-definition and revision are exclusive
 		},
 		{
 			opts: nil,
@@ -60,12 +60,12 @@ var testTaskDefinitionArnForRunSuite = map[string][]taskDefinitionArnForRunSuite
 			td:   "katsubushi:45",
 		},
 		{
-			opts:     []string{"--latest-task-definition", "--skip-task-definition"},
-			raiseErr: true, // without service, --skip-task-definition is not allowed
+			opts: []string{"--latest-task-definition", "--skip-task-definition"},
+			td:   "katsubushi:45",
 		},
 		{
-			opts: []string{"--latest-task-definition", "--revision=42"},
-			td:   "katsubushi:42",
+			opts:     []string{"--latest-task-definition", "--revision=42"},
+			raiseErr: true, // latest-task-definition and revision are exclusive
 		},
 		{
 			opts: nil,

--- a/tests/run-test-td.json
+++ b/tests/run-test-td.json
@@ -1,0 +1,95 @@
+{
+  "taskDefinition": {
+    "networkMode": "awsvpc",
+    "family": "test",
+    "placementConstraints": [],
+    "requiresCompatibilities": [
+      "FARGATE"
+    ],
+    "volumes": [],
+    "taskRoleArn": "arn:aws:iam::999999999999:role/ecsTaskRole",
+    "executionRoleArn": "arn:aws:iam::999999999999:role/ecsTaskRole",
+    "ephemeralStorage": {
+      "sizeInGiB": 25
+    },
+    "containerDefinitions": [
+      {
+        "environment": [
+          {
+            "name": "worker_id",
+            "value": "3"
+          }
+        ],
+        "name": "katsubushi",
+        "mountPoints": [],
+        "portMappings": [
+          {
+            "protocol": "tcp",
+            "containerPort": 11212,
+            "hostPort": 11212
+          }
+        ],
+        "logConfiguration": {
+          "logDriver": "awslogs",
+          "options": {
+            "awslogs-group": "fargate",
+            "awslogs-region": "us-east-1",
+            "awslogs-stream-prefix": "katsubushi"
+          }
+        },
+        "image": "katsubushi/katsubushi:{{ env `TAG` `latest` }}",
+        "dockerLabels": {
+          "name": "katsubushi"
+        },
+        "cpu": 256,
+        "ulimits": [
+          {
+            "softLimit": 100000,
+            "name": "nofile",
+            "hardLimit": 100000
+          }
+        ],
+        "memory": 16,
+        "essential": true,
+        "volumesFrom": []
+      }
+    ],
+    "cpu": "1024",
+    "memory": "2048",
+    "proxyConfiguration": {
+      "type": "APPMESH",
+      "containerName": "envoy",
+      "properties": [
+        {
+          "name": "IgnoredUID",
+          "value": "1337"
+        },
+        {
+          "name": "IgnoredGID",
+          "value": ""
+        },
+        {
+          "name": "AppPorts",
+          "value": "26571"
+        },
+        {
+          "name": "ProxyIngressPort",
+          "value": "15000"
+        },
+        {
+          "name": "ProxyEgressPort",
+          "value": "15001"
+        },
+        {
+          "name": "EgressIgnoredIPs",
+          "value": "169.254.170.2,169.254.169.254"
+        },
+        {
+          "name": "EgressIgnoredPorts",
+          "value": ""
+        }
+      ]
+    },
+    "tags": []
+  }
+}

--- a/tests/run-with-sv.yaml
+++ b/tests/run-with-sv.yaml
@@ -1,0 +1,6 @@
+region: ap-northeast-1
+timeout: 300s
+service: test
+cluster: default2
+service_definition: sv.json
+task_definition: td.json

--- a/tests/run-without-sv.yaml
+++ b/tests/run-without-sv.yaml
@@ -1,0 +1,5 @@
+region: ap-northeast-1
+timeout: 300s
+cluster: default2
+service_definition: sv.json
+task_definition: td.json


### PR DESCRIPTION
Flags of `ecspresso run` is confusing. I fix the specification with testing.

When the configuration has an ECS Service,
- `--skip-task-definition` refers to the ECS service's task definition.
- `--skip-task-definition` and `--revision` specified, prefer  `revision` value.
- Both `--latest-task-definition` and `--skip-task-definition` specified,  simply use the latest.
- `--latest-task-definition` and `--revision`, prefer `revision`. (show warnings).

When the configuration doesn't have an ECS Service,
- `--skip-task-definition` uses a latest task definition.
- `--latest-task-definition` and `--revision`, prefer `revision`. (show warnings).

See also `run_test.go`.

After v2.1, `--latest-task-definition` and `--revision` will raise an error.




