### PR TITLE
add delete --terminate flag.

### DIFF
--- a/cli_test.go
+++ b/cli_test.go
@@ -283,16 +283,27 @@ var cliTests = []struct {
 		args: []string{"delete"},
 		sub:  "delete",
 		subOption: &ecspresso.DeleteOption{
-			DryRun: ptr(false),
-			Force:  ptr(false),
+			DryRun:    ptr(false),
+			Force:     ptr(false),
+			Terminate: ptr(false),
 		},
 	},
 	{
 		args: []string{"delete", "--force"},
 		sub:  "delete",
 		subOption: &ecspresso.DeleteOption{
-			DryRun: ptr(false),
-			Force:  ptr(true),
+			DryRun:    ptr(false),
+			Force:     ptr(true),
+			Terminate: ptr(false),
+		},
+	},
+	{
+		args: []string{"delete", "--terminate"},
+		sub:  "delete",
+		subOption: &ecspresso.DeleteOption{
+			DryRun:    ptr(false),
+			Force:     ptr(false),
+			Terminate: ptr(true),
 		},
 	},
 	{

--- a/delete.go
+++ b/delete.go
@@ -9,8 +9,9 @@ import (
 )
 
 type DeleteOption struct {
-	DryRun *bool `help:"dry-run" default:"false"`
-	Force  *bool `help:"delete without confirmation" default:"false"`
+	DryRun    *bool `help:"dry-run" default:"false"`
+	Force     *bool `help:"delete without confirmation" default:"false"`
+	Terminate *bool `help:"delete with terminate tasks" default:"false"`
 }
 
 func (opt DeleteOption) DryRunString() string {
@@ -42,10 +43,10 @@ func (d *App) Delete(ctx context.Context, opt DeleteOption) error {
 			return fmt.Errorf("confirmation failed")
 		}
 	}
-
 	dsi := &ecs.DeleteServiceInput{
 		Cluster: &d.config.Cluster,
 		Service: sv.ServiceName,
+		Force:   opt.Terminate, // == aws ecs delete-service --force
 	}
 	if _, err := d.ecs.DeleteService(ctx, dsi); err != nil {
 		return fmt.Errorf("failed to delete service: %w", err)


### PR DESCRIPTION
This option is equivalent to `aws ecs delete-service --force`.

By historical reason, `ecspresso delete --force` means "without confirmation". But `aws ecs delete-service --force` means "delete the service and related tasks".

A `--terminate` flag provides behavior the same as `aws ecs delete-service --force`.
