### PR TITLE
Add `--assume-role-arn` option to the top level of the CLI

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -7,11 +7,12 @@ import (
 )
 
 type CLIOptions struct {
-	Envfile []string          `help:"environment files"`
-	Debug   bool              `help:"enable debug log"`
-	ExtStr  map[string]string `help:"external string values for Jsonnet"`
-	ExtCode map[string]string `help:"external code values for Jsonnet"`
-	Config  string            `help:"config file" default:"ecspresso.yml"`
+	Envfile       []string          `help:"environment files"`
+	Debug         bool              `help:"enable debug log"`
+	ExtStr        map[string]string `help:"external string values for Jsonnet"`
+	ExtCode       map[string]string `help:"external code values for Jsonnet"`
+	Config        string            `help:"config file" default:"ecspresso.yml"`
+	AssumeRoleARN string            `help:"the ARN of the role to assume" default:""`
 
 	Option *Option
 
@@ -117,7 +118,7 @@ func dispatchCLI(ctx context.Context, sub string, usage func(), opts *CLIOptions
 	case "revisions":
 		return app.Revesions(ctx, *opts.Revisions)
 	case "init":
-		return app.Init(ctx, *opts.Init)
+		return app.Init(ctx, *opts.Init, opts.AssumeRoleARN)
 	case "diff":
 		return app.Diff(ctx, *opts.Diff)
 	case "appspec":

--- a/cli_test.go
+++ b/cli_test.go
@@ -25,6 +25,7 @@ var cliTests = []struct {
 			"--ext-str", "s2=v2",
 			"--ext-code", "c1=123",
 			"--ext-code", "c2=1+2",
+			"--assume-role-arn", "arn:aws:iam::123456789012:role/exampleRole",
 		},
 		sub: "status",
 		option: &ecspresso.Option{
@@ -33,6 +34,7 @@ var cliTests = []struct {
 			ExtStr:         map[string]string{"s1": "v1", "s2": "v2"},
 			ExtCode:        map[string]string{"c1": "123", "c2": "1+2"},
 			InitOption:     nil,
+			AssumeRoleARN:  "arn:aws:iam::123456789012:role/exampleRole",
 		},
 		subOption: &ecspresso.StatusOption{
 			Events: ptr(10),
@@ -57,6 +59,7 @@ var cliTests = []struct {
 			ExtStr:         map[string]string{},
 			ExtCode:        map[string]string{},
 			InitOption:     nil,
+			AssumeRoleARN:  "",
 		},
 		subOption: &ecspresso.StatusOption{
 			Events: ptr(100),

--- a/cliv2.go
+++ b/cliv2.go
@@ -35,6 +35,7 @@ func ParseCLIv2(args []string) (string, *CLIOptions, func(), error) {
 		Debug:          opts.Debug,
 		ExtStr:         opts.ExtStr,
 		ExtCode:        opts.ExtCode,
+		AssumeRoleARN:  opts.AssumeRoleARN,
 	}
 	if opts.Option.ExtStr == nil {
 		opts.Option.ExtStr = map[string]string{}

--- a/config_test.go
+++ b/config_test.go
@@ -65,7 +65,7 @@ func TestLoadConfigWithPluginDuplicate(t *testing.T) {
 	os.Setenv("JSON", `{"foo":"bar"}`)
 	ctx := context.Background()
 	loader := ecspresso.NewConfigLoader(nil, nil)
-	_, err := loader.Load(ctx, "tests/config_duplicate_plugins.yaml", "")
+	_, err := loader.Load(ctx, "tests/config_duplicate_plugins.yaml", "", "")
 	if err == nil {
 		t.Log("expected an error to occur, but it didn't.")
 		t.FailNow()
@@ -216,7 +216,7 @@ func TestConfigWithRequiredVersionUnsatisfied(t *testing.T) {
 		t.Run(c.CurrentVersion+":"+c.RequiredVersion, func(t *testing.T) {
 			conf := ecspresso.NewDefaultConfig()
 			conf.RequiredVersion = c.RequiredVersion
-			if err := conf.Restrict(ctx); err != nil {
+			if err := conf.Restrict(ctx, ""); err != nil {
 				t.Error(err)
 				return
 			}
@@ -249,7 +249,7 @@ func TestConfigWithInvalidRequiredVersion(t *testing.T) {
 		t.Run(c.CurrentVersion+":"+c.RequiredVersion, func(t *testing.T) {
 			conf := ecspresso.NewDefaultConfig()
 			conf.RequiredVersion = c.RequiredVersion
-			err := conf.Restrict(ctx)
+			err := conf.Restrict(ctx, "")
 			if err == nil {
 				t.Error("expected any error, but no error")
 				return
@@ -268,7 +268,7 @@ func TestLoadConfigWithoutTimeout(t *testing.T) {
 
 	ctx := context.Background()
 	loader := ecspresso.NewConfigLoader(nil, nil)
-	conf, err := loader.Load(ctx, "tests/notimeout.yml", "")
+	conf, err := loader.Load(ctx, "tests/notimeout.yml", "", "")
 	if err != nil {
 		t.Log("unexpected an error", err)
 		t.FailNow()
@@ -290,7 +290,7 @@ func TestLoadConfigForCodeDeploy(t *testing.T) {
 	loader := ecspresso.NewConfigLoader(nil, nil)
 	for _, ext := range []string{"yml", "json", "jsonnet"} {
 		name := "tests/config_codedeploy." + ext
-		conf, err := loader.Load(ctx, name, "")
+		conf, err := loader.Load(ctx, name, "", "")
 		if err != nil {
 			t.Error(err)
 		}

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -122,12 +122,12 @@ func New(ctx context.Context, opt *Option) (*App, error) {
 		err  error
 	)
 	if opt.InitOption != nil {
-		conf, err = opt.InitOption.NewConfig(ctx)
+		conf, err = opt.InitOption.NewConfig(ctx, opt.AssumeRoleARN)
 		if err != nil {
 			return nil, fmt.Errorf("failed to initialize config: %w", err)
 		}
 	} else {
-		conf, err = loader.Load(ctx, opt.ConfigFilePath, Version)
+		conf, err = loader.Load(ctx, opt.ConfigFilePath, Version, opt.AssumeRoleARN)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load config file %s: %w", opt.ConfigFilePath, err)
 		}
@@ -181,6 +181,7 @@ type Option struct {
 	Debug          bool
 	ExtStr         map[string]string
 	ExtCode        map[string]string
+	AssumeRoleARN  string
 }
 
 func (opt *Option) resolveConfigFilePath() (path string) {

--- a/init.go
+++ b/init.go
@@ -28,7 +28,7 @@ type InitOption struct {
 	Jsonnet               *bool `help:"output files as jsonnet format" default:"false"`
 }
 
-func (opt *InitOption) NewConfig(ctx context.Context) (*Config, error) {
+func (opt *InitOption) NewConfig(ctx context.Context, assumeRoleARN string) (*Config, error) {
 	conf := NewDefaultConfig()
 	conf.path = *opt.ConfigFilePath
 	conf.Region = *opt.Region
@@ -36,7 +36,7 @@ func (opt *InitOption) NewConfig(ctx context.Context) (*Config, error) {
 	conf.Service = *opt.Service
 	conf.TaskDefinitionPath = *opt.TaskDefinitionPath
 	conf.ServiceDefinitionPath = *opt.ServiceDefinitionPath
-	if err := conf.Restrict(ctx); err != nil {
+	if err := conf.Restrict(ctx, assumeRoleARN); err != nil {
 		return nil, err
 	}
 	return conf, nil
@@ -49,7 +49,7 @@ var (
 	yamlExt    = ".yaml"
 )
 
-func (d *App) Init(ctx context.Context, opt InitOption) error {
+func (d *App) Init(ctx context.Context, opt InitOption, assumeRoleARN string) error {
 	conf := d.config
 	d.LogJSON(opt)
 	if *opt.Jsonnet {
@@ -64,7 +64,7 @@ func (d *App) Init(ctx context.Context, opt InitOption) error {
 			opt.ConfigFilePath = &p
 		}
 	}
-	if err := conf.Restrict(ctx); err != nil {
+	if err := conf.Restrict(ctx, assumeRoleARN); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This option receives an ARN of the role to assume and it makes the user able to do the operations across the accounts according to the given role by assuming.

e.g.

```
$ ecspresso --help
Usage: ecspresso <command>

Flags:
  -h, --help                      Show context-sensitive help.
      --envfile=ENVFILE,...       environment files
      --debug                     enable debug log
      --ext-str=KEY=VALUE;...     external string values for Jsonnet
      --ext-code=KEY=VALUE;...    external code values for Jsonnet
      --config="ecspresso.yml"    config file
      --assume-role-arn=""        the ARN of the role to assume
      --option=OPTION

Commands:

...

$ ecspresso status --assume-role-arn=arn:aws:iam::123456789012:role/ecsOperatableRole
```

The motivation for this patch is we would like to manage the sort of deployment hub system on an AWS account in order to consolidate the deployment logs due to the audit reason and that hub system has to manipulate the ECS environments which are in the various different AWS accounts.