### PR TITLE
fix: verify SecretsManager JSON Key

### DIFF
--- a/verify.go
+++ b/verify.go
@@ -71,6 +71,9 @@ func (v *verifier) existsSecretValue(ctx context.Context, from string) error {
 		if err != nil {
 			return fmt.Errorf("failed to get secret value from %s secret id %s: %w", from, secretArn, err)
 		}
+		if len(part) < 8 {
+			return nil
+		}
 		key := part[7]
 		if key == "" {
 			return nil


### PR DESCRIPTION
Fixed `ecspresso verify` command to verify secretsManager JSON Key

fix #532 
