### PR TITLE
Install Ecspresso into toolchain cache directory

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,7 +48,3 @@ runs:
         echo "Adding ${RUNNER_TOOL_CACHE}/ecspresso to path..."
         echo "${RUNNER_TOOL_CACHE}/ecspresso" >> $GITHUB_PATH
         
-
-
-
-

--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ runs:
           unzip ${FILENAME}.zip
           sudo install ${FILENAME} ${RUNNER_TOOL_CACHE}/ecspresso/ecspresso
         fi
-        chmod +x ${RUNNER_TOOL_CACHE}/ecspresso/ecspresso
+        # chmod +x ${RUNNER_TOOL_CACHE}/ecspresso/ecspresso
         
         echo "Adding ${RUNNER_TOOL_CACHE}/ecspresso to path..."
         echo "${RUNNER_TOOL_CACHE}/ecspresso" >> $GITHUB_PATH

--- a/action.yml
+++ b/action.yml
@@ -31,14 +31,24 @@ runs:
         else
           DOWNLOAD_URL=https://github.com/kayac/ecspresso/releases/download/${VERSION}/ecspresso_${VERSION:1}_linux_amd64.tar.gz
         fi
+        mkdir -p ${RUNNER_TOOL_CACHE}/ecspresso
         cd /tmp
         curl -sfLO ${DOWNLOAD_URL}
         if [[ "${DOWNLOAD_URL}" =~ \.tar\.gz$ ]]; then
           FILENAME=$(basename $DOWNLOAD_URL .tar.gz)
           tar xzvf ${FILENAME}.tar.gz
-          sudo install ecspresso /usr/local/bin/ecspresso
+          sudo install ecspresso ${RUNNER_TOOL_CACHE}/ecspresso/ecspresso
         elif [[ "${DOWNLOAD_URL}" =~ \.zip$ ]]; then
           FILENAME=$(basename $DOWNLOAD_URL .zip)
           unzip ${FILENAME}.zip
-          sudo install ${FILENAME} /usr/local/bin/ecspresso
+          sudo install ${FILENAME} ${RUNNER_TOOL_CACHE}/ecspresso/ecspresso
         fi
+        chmod +x ${RUNNER_TOOL_CACHE}/ecspresso/ecspresso
+        
+        echo "Adding ${RUNNER_TOOL_CACHE}/ecspresso to path..."
+        echo "${RUNNER_TOOL_CACHE}/ecspresso" >> $GITHUB_PATH
+        
+
+
+
+

--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,6 @@ runs:
           unzip ${FILENAME}.zip
           sudo install ${FILENAME} ${RUNNER_TOOL_CACHE}/ecspresso/ecspresso
         fi
-        # chmod +x ${RUNNER_TOOL_CACHE}/ecspresso/ecspresso
         
         echo "Adding ${RUNNER_TOOL_CACHE}/ecspresso to path..."
         echo "${RUNNER_TOOL_CACHE}/ecspresso" >> $GITHUB_PATH


### PR DESCRIPTION
## What
* Install Ecspresso into toolchain cache directory

## Why
* Use toolchain cache directory as the directory for installation 

https://docs.github.com/en/enterprise-server@3.7/admin/github-actions/managing-access-to-actions-from-githubcom/setting-up-the-tool-cache-on-self-hosted-runners-without-internet-access