### PR TITLE
Fix/verify errors on create log group

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -19,6 +19,7 @@ var (
 	NewLogger                 = newLogger
 	NewLogFilter              = newLogFilter
 	NewConfigLoader           = newConfigLoader
+	NewVerifier               = newVerifier
 	ArnToName                 = arnToName
 	InitVerifyState           = initVerifyState
 	VerifyResource            = verifyResource

--- a/tests/ci/ecs-task-def.json
+++ b/tests/ci/ecs-task-def.json
@@ -8,6 +8,7 @@
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
+          "awslogs-create-group": "true",
           "awslogs-group": "ecspresso-test",
           "awslogs-region": "ap-northeast-1",
           "awslogs-stream-prefix": "nginx"

--- a/verify.go
+++ b/verify.go
@@ -139,6 +139,7 @@ func (v *verifier) existsEnvironmentFile(ctx context.Context, envFile types.Envi
 
 func (d *App) newAssumedVerifier(ctx context.Context, cfg aws.Config, executionRole *string, opt *VerifyOption) (*verifier, error) {
 	if executionRole == nil {
+		d.Log("[INFO] executionRoleArn is not set. Continue to verify with current session.")
 		return newVerifier(&cfg, &cfg, opt), nil
 	}
 	svc := sts.NewFromConfig(d.config.awsv2Config)
@@ -150,6 +151,7 @@ func (d *App) newAssumedVerifier(ctx context.Context, cfg aws.Config, executionR
 		d.Log("[INFO] failed to assume role to taskExecutionRole. Continue to verify with current session. %s", err.Error())
 		return newVerifier(&cfg, &cfg, opt), nil
 	}
+	d.Log("[INFO] success to assume role: %s", aws.ToString(executionRole))
 	ec := aws.Config{}
 	ec.Region = d.config.Region
 	ec.Credentials = credentials.NewStaticCredentialsProvider(
@@ -568,8 +570,10 @@ func (d *App) verifyLogConfiguration(ctx context.Context, c *types.ContainerDefi
 			if errors.As(err, &ex) {
 				// ignore error if log group already exists
 				d.Log("[DEBUG] log group %s already exists, ignored", group)
-			} else {
+			} else if d.verifier.IsAssumed() {
 				return fmt.Errorf("failed to create log group %s: %w", group, err)
+			} else {
+				d.Log("[WARNING] failed to create log group %s: %s", group, err)
 			}
 		} else {
 			d.Log("[INFO] created log group %s", group)

--- a/verify_test.go
+++ b/verify_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/fatih/color"
 	"github.com/kayac/ecspresso/v2"
@@ -243,6 +244,27 @@ func TestVerifySkipResource(t *testing.T) {
 					t.Error("unexpected output [SKIP] for skip resource")
 				}
 			}
+		}
+	}
+}
+
+func TestVerifierIsAssumed(t *testing.T) {
+	cfg1 := aws.Config{}
+	cfg2 := aws.Config{}
+	var testCases = []struct {
+		exec      *aws.Config
+		app       *aws.Config
+		isAssumed bool
+	}{
+		{&cfg1, &cfg2, true},
+		{&cfg1, &cfg1, false},
+		{&cfg2, &cfg2, false},
+		{&cfg2, &cfg1, true},
+	}
+	for i, c := range testCases {
+		v := ecspresso.NewVerifier(c.exec, c.app, &ecspresso.VerifyOption{})
+		if v.IsAssumed() != c.isAssumed {
+			t.Errorf("unexpected IsAssumed %d expected:%v got:%v", i, c.isAssumed, v.IsAssumed())
 		}
 	}
 }


### PR DESCRIPTION
v2.2.0 supports `awslogs-create-group:true`, but errored to verify in these conditions.

- not assumed to task execution role.
- failed to create the log group.

When verifying with a not assumed role, the role may not have permission to create log groups.

So this PR changes the behavior in this case to show warnings instead of errors.

refs https://github.com/kayac/ecspresso/pull/541