### PR TITLE
update to ecsta v0.3.2

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -30,8 +30,7 @@ func (d *App) NewEcsta(ctx context.Context) (*ecsta.Ecsta, error) {
 }
 
 func (d *App) Exec(ctx context.Context, opt ExecOption) error {
-	ctx, cancel := d.Start(ctx)
-	defer cancel()
+	// Do not call d.Start() because timeout disabled for exec.
 
 	ecstaApp, err := d.NewEcsta(ctx)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/aws/smithy-go v1.13.5
 	github.com/fatih/color v1.13.0
 	github.com/fujiwara/cfn-lookup v1.0.0
-	github.com/fujiwara/ecsta v0.3.1
+	github.com/fujiwara/ecsta v0.3.2
 	github.com/fujiwara/logutils v1.1.2
 	github.com/fujiwara/tfstate-lookup v1.0.0
 	github.com/goccy/go-yaml v1.9.5

--- a/go.sum
+++ b/go.sum
@@ -246,8 +246,8 @@ github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYF
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fujiwara/cfn-lookup v1.0.0 h1:oDhBXaEvT27B0dFB4z3zbjuTzA3E6m8t8Sge9mffAzU=
 github.com/fujiwara/cfn-lookup v1.0.0/go.mod h1:HI8F4hlW+nN9KRTWNzdwvnOUQFrN8jX9puyfhtAVgwU=
-github.com/fujiwara/ecsta v0.3.1 h1:aCm2ytd15MMFZEg5Uccr4YCZVUmHxPYqJ+AMwtPFA1o=
-github.com/fujiwara/ecsta v0.3.1/go.mod h1:nKX8kr9NQm1uhzp/dDPtJmmrt5CTjGqlhATIVAgFdHw=
+github.com/fujiwara/ecsta v0.3.2 h1:PPB0H6dJtWU7cVZF541dcCXveYmM+nhMHt46xSoNO6A=
+github.com/fujiwara/ecsta v0.3.2/go.mod h1:1p4HeI+G4f8PKkReHijdRt3leebkxPkSuj2SjN6CSTM=
 github.com/fujiwara/logutils v1.1.2 h1:nYVRyTj+5SyCvpZUrYIZU4kubqNycGTxFXMKJBKe0Sg=
 github.com/fujiwara/logutils v1.1.2/go.mod h1:pdb/Uk70rjQWEmFm/OvYH7OG8meZt1fEIqC0qZbvro4=
 github.com/fujiwara/tfstate-lookup v1.0.0 h1:Ii2F3Y1KASnLcMf+rod7HVn1VuiY6mTKoHgKPNnK31A=


### PR DESCRIPTION
kill session-manager-plugin when the task is stopping. 
see also
- https://github.com/fujiwara/ecsta/pull/17
- https://github.com/fujiwara/ecsta/pull/18
