### PR TITLE
Fix DesiredCount ignoring

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -87,7 +87,7 @@ func diffServices(local, remote *Service, remoteArn string, localPath string, un
 	}
 	if local.DesiredCount == nil {
 		// ignore DesiredCount when it in local is not defined.
-		remote.DesiredCount = nil
+		remoteSvForDiff.UpdateServiceInput.DesiredCount = nil
 	}
 	remoteSvBytes, err := MarshalJSONForAPI(remoteSvForDiff)
 	if err != nil {


### PR DESCRIPTION
https://github.com/kayac/ecspresso/commit/f39a452b06abffdc7f5716b9728a86b9844fd44e#diff-25c73b8098e407eee76a3695ae93ed896bd46fbfca9b544434d86efd745e0a7e
The code `remote.DesiredCount = nil` has been as is though `sortServiceDefinitionForDiff` took the place of `remote` here, so the code doesn't work.