### PR TITLE
add init --task-definition flag.

### DIFF
--- a/cli_test.go
+++ b/cli_test.go
@@ -640,6 +640,21 @@ var cliTests = []struct {
 		},
 	},
 	{
+		args: []string{"init", "--task-definition=app:123", "--config", "myconfig.yml"},
+		sub:  "init",
+		subOption: &ecspresso.InitOption{
+			Region:                os.Getenv("AWS_REGION"),
+			Cluster:               "default",
+			ConfigFilePath:        "myconfig.yml",
+			Service:               "",
+			TaskDefinition:        "app:123",
+			TaskDefinitionPath:    "ecs-task-def.json",
+			ServiceDefinitionPath: "ecs-service-def.json",
+			ForceOverwrite:        false,
+			Jsonnet:               false,
+		},
+	},
+	{
 		args: []string{"diff"},
 		sub:  "diff",
 		subOption: &ecspresso.DiffOption{

--- a/init.go
+++ b/init.go
@@ -52,14 +52,8 @@ var (
 
 func (d *App) Init(ctx context.Context, opt InitOption) error {
 	conf := d.config
-	var tdOnly bool
-	if opt.Service != "" {
-		tdOnly = false
-	} else if opt.TaskDefinition != "" {
-		tdOnly = true
-	} else {
-		return fmt.Errorf("--service or --task-definition is required")
-	}
+	// when --task-definition is not empty, --service is empty because these flags are exclusive.
+	tdOnly := opt.TaskDefinition != ""
 
 	d.LogJSON(opt)
 	if opt.Jsonnet {

--- a/init.go
+++ b/init.go
@@ -20,7 +20,8 @@ var CreateFileMode = os.FileMode(0644)
 type InitOption struct {
 	Region                string `help:"AWS region" env:"AWS_REGION" default:""`
 	Cluster               string `help:"ECS cluster name" default:"default"`
-	Service               string `help:"ECS service name" required:""`
+	Service               string `help:"ECS service name" required:"" xor:"FROM"`
+	TaskDefinition        string `help:"ECS task definition name:revision" required:"" xor:"FROM"`
 	TaskDefinitionPath    string `help:"path to output task definition file" default:"ecs-task-def.json"`
 	ServiceDefinitionPath string `help:"path to output service definition file" default:"ecs-service-def.json"`
 	ConfigFilePath        string
@@ -51,6 +52,15 @@ var (
 
 func (d *App) Init(ctx context.Context, opt InitOption) error {
 	conf := d.config
+	var tdOnly bool
+	if opt.Service != "" {
+		tdOnly = false
+	} else if opt.TaskDefinition != "" {
+		tdOnly = true
+	} else {
+		return fmt.Errorf("--service or --task-definition is required")
+	}
+
 	d.LogJSON(opt)
 	if opt.Jsonnet {
 		if ext := filepath.Ext(conf.ServiceDefinitionPath); ext == jsonExt {
@@ -66,72 +76,34 @@ func (d *App) Init(ctx context.Context, opt InitOption) error {
 	if err := conf.Restrict(ctx); err != nil {
 		return err
 	}
-
-	out, err := d.ecs.DescribeServices(ctx, d.DescribeServicesInput())
-	if err != nil {
-		return fmt.Errorf("failed to describe service: %w", err)
+	var err error
+	var sv *Service
+	var tdArn string
+	if tdOnly {
+		tdArn = opt.TaskDefinition
+	} else {
+		sv, tdArn, err = d.initServiceDefinition(ctx, opt)
+		if err != nil {
+			return err
+		}
 	}
-	if len(out.Services) == 0 {
-		return ErrNotFound("service is not found")
-	}
-
-	sv, err := d.newServiceFromTypes(ctx, out.Services[0])
-	if err != nil {
-		return fmt.Errorf("failed to describe service: %w", err)
-	}
-	td, err := d.DescribeTaskDefinition(ctx, *sv.TaskDefinition)
+	td, err := d.initTaskDefinition(ctx, opt, tdArn)
 	if err != nil {
 		return err
 	}
-
-	if long, _ := isLongArnFormat(*sv.ServiceArn); long {
-		// Long arn format must be used for tagging operations
-		lt, err := d.ecs.ListTagsForResource(ctx, &ecs.ListTagsForResourceInput{
-			ResourceArn: sv.ServiceArn,
-		})
-		if err != nil {
-			return fmt.Errorf("failed to list tags for service: %w", err)
-		}
-		sv.Tags = lt.Tags
+	if err := d.initConfigurationFile(ctx, opt, sv, td); err != nil {
+		return err
 	}
+	return nil
+}
 
-	// service-def
-	treatmentServiceDefinition(sv)
-	if b, err := MarshalJSONForAPI(sv); err != nil {
-		return fmt.Errorf("unable to marshal service definition to JSON: %w", err)
-	} else {
-		if opt.Jsonnet {
-			out, err := formatter.Format(conf.ServiceDefinitionPath, string(b), formatter.DefaultOptions())
-			if err != nil {
-				return fmt.Errorf("unable to format service definition as Jsonnet: %w", err)
-			}
-			b = []byte(out)
-		}
-		d.Log("save service definition to %s", conf.ServiceDefinitionPath)
-		if err := d.saveFile(conf.ServiceDefinitionPath, b, CreateFileMode, opt.ForceOverwrite); err != nil {
-			return err
-		}
-	}
-
-	// task-def
-	if b, err := MarshalJSONForAPI(td); err != nil {
-		return fmt.Errorf("unable to marshal task definition to JSON: %w", err)
-	} else {
-		if opt.Jsonnet {
-			out, err := formatter.Format(conf.TaskDefinitionPath, string(b), formatter.DefaultOptions())
-			if err != nil {
-				return fmt.Errorf("unable to format task definition as Jsonnet: %w", err)
-			}
-			b = []byte(out)
-		}
-		d.Log("save task definition to %s", conf.TaskDefinitionPath)
-		if err := d.saveFile(conf.TaskDefinitionPath, b, CreateFileMode, opt.ForceOverwrite); err != nil {
-			return err
-		}
-	}
-
-	// config
-	if sv.isCodeDeploy() {
+func (d *App) initConfigurationFile(ctx context.Context, opt InitOption, sv *Service, td *TaskDefinitionInput) error {
+	conf := d.config
+	if sv == nil {
+		// tdOnly
+		conf.Service = ""
+		conf.ServiceDefinitionPath = ""
+	} else if sv.isCodeDeploy() {
 		info, err := d.findDeploymentInfo(ctx)
 		if err != nil {
 			Log("[WARNING] failed to find CodeDeploy deployment info: %s", err)
@@ -168,6 +140,75 @@ func (d *App) Init(ctx context.Context, opt InitOption) error {
 		}
 	}
 	return nil
+}
+
+func (d *App) initServiceDefinition(ctx context.Context, opt InitOption) (*Service, string, error) {
+	conf := d.config
+	out, err := d.ecs.DescribeServices(ctx, d.DescribeServicesInput())
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to describe service: %w", err)
+	}
+	if len(out.Services) == 0 {
+		return nil, "", ErrNotFound("service is not found")
+	}
+
+	sv, err := d.newServiceFromTypes(ctx, out.Services[0])
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to describe service: %w", err)
+	}
+
+	if long, _ := isLongArnFormat(*sv.ServiceArn); long {
+		// Long arn format must be used for tagging operations
+		lt, err := d.ecs.ListTagsForResource(ctx, &ecs.ListTagsForResourceInput{
+			ResourceArn: sv.ServiceArn,
+		})
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to list tags for service: %w", err)
+		}
+		sv.Tags = lt.Tags
+	}
+	tdArn := *sv.TaskDefinition
+	treatmentServiceDefinition(sv)
+	if b, err := MarshalJSONForAPI(sv); err != nil {
+		return nil, "", fmt.Errorf("unable to marshal service definition to JSON: %w", err)
+	} else {
+		if opt.Jsonnet {
+			out, err := formatter.Format(conf.ServiceDefinitionPath, string(b), formatter.DefaultOptions())
+			if err != nil {
+				return nil, "", fmt.Errorf("unable to format service definition as Jsonnet: %w", err)
+			}
+			b = []byte(out)
+		}
+		d.Log("save service definition to %s", conf.ServiceDefinitionPath)
+		if err := d.saveFile(conf.ServiceDefinitionPath, b, CreateFileMode, opt.ForceOverwrite); err != nil {
+			return nil, "", err
+		}
+	}
+	return sv, tdArn, nil
+}
+
+func (d *App) initTaskDefinition(ctx context.Context, opt InitOption, tdArn string) (*TaskDefinitionInput, error) {
+	conf := d.config
+	td, err := d.DescribeTaskDefinition(ctx, tdArn)
+	if err != nil {
+		return nil, err
+	}
+	if b, err := MarshalJSONForAPI(td); err != nil {
+		return nil, fmt.Errorf("unable to marshal task definition to JSON: %w", err)
+	} else {
+		if opt.Jsonnet {
+			out, err := formatter.Format(conf.TaskDefinitionPath, string(b), formatter.DefaultOptions())
+			if err != nil {
+				return nil, fmt.Errorf("unable to format task definition as Jsonnet: %w", err)
+			}
+			b = []byte(out)
+		}
+		d.Log("save task definition to %s", conf.TaskDefinitionPath)
+		if err := d.saveFile(conf.TaskDefinitionPath, b, CreateFileMode, opt.ForceOverwrite); err != nil {
+			return nil, err
+		}
+	}
+	return td, nil
 }
 
 func treatmentServiceDefinition(sv *Service) {


### PR DESCRIPTION
Enables to generate task definition and config file only, without service.