### PR TITLE
Remove runningCount and pendingCount from generated service definition.

### DIFF
--- a/ecspresso.go
+++ b/ecspresso.go
@@ -462,7 +462,7 @@ func (d *App) LoadTaskDefinition(path string) (*TaskDefinitionInput, error) {
 		src = c.TaskDefinition
 	}
 	var td TaskDefinitionInput
-	if err := d.UnmarshalJSONForStruct(src, &td, path); err != nil {
+	if err := UnmarshalJSONForStruct(src, &td, path); err != nil {
 		return nil, fmt.Errorf("failed to load task definition %s: %w", path, err)
 	}
 	if len(td.Tags) == 0 {

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/hashicorp/go-envparse v0.1.0
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hexops/gotextdiff v1.0.3
+	github.com/itchyny/gojq v0.12.11
 	github.com/kayac/go-config v0.6.0
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-isatty v0.0.17
@@ -92,7 +93,6 @@ require (
 	github.com/hashicorp/go-slug v0.10.0 // indirect
 	github.com/hashicorp/go-tfe v1.10.0 // indirect
 	github.com/hashicorp/jsonapi v0.0.0-20210826224640-ee7dae0fb22d // indirect
-	github.com/itchyny/gojq v0.12.11 // indirect
 	github.com/itchyny/timefmt-go v0.1.5 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect

--- a/init.go
+++ b/init.go
@@ -163,7 +163,8 @@ func (d *App) initServiceDefinition(ctx context.Context, opt InitOption) (*Servi
 	}
 	tdArn := *sv.TaskDefinition
 	treatmentServiceDefinition(sv)
-	if b, err := MarshalJSONForAPI(sv); err != nil {
+	// remove unnecessary fields
+	if b, err := MarshalJSONForAPI(sv, "del(.runningCount, .pendingCount)"); err != nil {
 		return nil, "", fmt.Errorf("unable to marshal service definition to JSON: %w", err)
 	} else {
 		if opt.Jsonnet {

--- a/json_test.go
+++ b/json_test.go
@@ -1,0 +1,91 @@
+package ecspresso_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/kayac/ecspresso/v2"
+)
+
+type testJSONStruct = struct {
+	FooBarBaz string
+	Options   map[string]string
+	Nested    struct {
+		FooBar string
+	}
+}
+
+var testJSONValue = testJSONStruct{
+	FooBarBaz: "foo",
+	Options: map[string]string{
+		"Foo": "xxx",
+	},
+	Nested: struct {
+		FooBar string
+	}{
+		FooBar: "foobar",
+	},
+}
+
+var testSuiteJSONForAPI = []struct {
+	name    string
+	json    string
+	queries []string
+}{
+	{
+		name: "no transform",
+		json: `{"fooBarBaz": "foo","nested":{"fooBar":"foobar"},"options":{"Foo":"xxx"}}`,
+	},
+	{
+		name:    "options only",
+		json:    `{"Foo":"xxx"}`,
+		queries: []string{".options"},
+	},
+	{
+		name:    "del options",
+		json:    `{"fooBarBaz": "foo","nested":{"fooBar":"foobar"}}`,
+		queries: []string{"del(.options)"},
+	},
+	{
+		name:    "multiple del queries",
+		json:    `{"fooBarBaz": "foo"}`,
+		queries: []string{"del(.options)", "del(.nested)"},
+	},
+}
+
+func TestMarshalJSONForAPI(t *testing.T) {
+	for _, s := range testSuiteJSONForAPI {
+		t.Run(s.name, func(t *testing.T) {
+			b, err := ecspresso.MarshalJSONForAPI(testJSONValue, s.queries...)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var expected bytes.Buffer
+			json.Indent(&expected, []byte(s.json), "", "  ")
+			expected.WriteByte('\n') // json.MarshalIndent does not append newline
+			if diff := cmp.Diff(expected.String(), string(b)); diff != "" {
+				t.Errorf("unexpected json: %s", diff)
+			}
+		})
+	}
+}
+
+func TestUnmarshalJSON(t *testing.T) {
+	for _, s := range testSuiteJSONForAPI {
+		if s.queries != nil {
+			continue
+		}
+		t.Run(s.name, func(t *testing.T) {
+			var v testJSONStruct
+			err := ecspresso.UnmarshalJSONForStruct([]byte(s.json), &v, "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(v, testJSONValue); diff != "" {
+				t.Errorf("unexpected json: %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
These elements exist in types.Task, but no need to a definition file.
