### PR TITLE
An output of task-definition of init command to stable.

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -277,7 +277,7 @@ func sortTaskDefinitionForDiff(td *TaskDefinitionInput) {
 	})
 	// containerDefinitions are sorted by name
 	sort.SliceStable(td.ContainerDefinitions, func(i, j int) bool {
-		return aws.ToString(td.ContainerDefinitions[i].Name) > aws.ToString(td.ContainerDefinitions[j].Name)
+		return aws.ToString(td.ContainerDefinitions[i].Name) < aws.ToString(td.ContainerDefinitions[j].Name)
 	})
 
 	if td.Cpu != nil {

--- a/diff.go
+++ b/diff.go
@@ -110,8 +110,8 @@ func diffServices(local, remote *Service, remoteArn string, localPath string, un
 }
 
 func diffTaskDefs(local, remote *TaskDefinitionInput, remoteArn string, localPath string, unified bool) (string, error) {
-	sortTaskDefinitionForDiff(local)
-	sortTaskDefinitionForDiff(remote)
+	sortTaskDefinition(local)
+	sortTaskDefinition(remote)
 
 	newTdBytes, err := MarshalJSONForAPI(local)
 	if err != nil {
@@ -235,7 +235,7 @@ func ServiceDefinitionForDiff(sv *Service) *ServiceForDiff {
 	}
 }
 
-func sortTaskDefinitionForDiff(td *TaskDefinitionInput) {
+func sortTaskDefinition(td *TaskDefinitionInput) {
 	for i, cd := range td.ContainerDefinitions {
 		sort.SliceStable(cd.Environment, func(i, j int) bool {
 			return aws.ToString(cd.Environment[i].Name) < aws.ToString(cd.Environment[j].Name)

--- a/diff_test.go
+++ b/diff_test.go
@@ -137,8 +137,8 @@ var testTaskDefinition2 = &ecspresso.TaskDefinitionInput{
 }
 
 func TestTaskDefinitionDiffer(t *testing.T) {
-	ecspresso.SortTaskDefinitionForDiff(testTaskDefinition1)
-	ecspresso.SortTaskDefinitionForDiff(testTaskDefinition2)
+	ecspresso.SortTaskDefinition(testTaskDefinition1)
+	ecspresso.SortTaskDefinition(testTaskDefinition2)
 	td1, _ := ecspresso.MarshalJSONForAPI(testTaskDefinition1)
 	td2, _ := ecspresso.MarshalJSONForAPI(testTaskDefinition2)
 	if diff := cmp.Diff(td1, td2); diff != "" {
@@ -228,7 +228,7 @@ var testServiceDefinitionHasDesiredCount = &ecspresso.Service{
 }
 
 func TestDiffServices(t *testing.T) {
-	t.Run("when local.DesiredCount is nil, ignore diff of DesiredCount", func (t *testing.T) {
+	t.Run("when local.DesiredCount is nil, ignore diff of DesiredCount", func(t *testing.T) {
 		diff, err := ecspresso.DiffServices(
 			testServiceDefinitionNoDesiredCount,
 			testServiceDefinitionHasDesiredCount,

--- a/export_test.go
+++ b/export_test.go
@@ -8,23 +8,23 @@ import (
 )
 
 var (
-	SortTaskDefinitionForDiff = sortTaskDefinitionForDiff
-	ToNumberCPU               = toNumberCPU
-	ToNumberMemory            = toNumberMemory
-	CalcDesiredCount          = calcDesiredCount
-	ParseTags                 = parseTags
-	ExtractRoleName           = extractRoleName
-	IsLongArnFormat           = isLongArnFormat
-	ECRImageURLRegex          = ecrImageURLRegex
-	NewLogger                 = newLogger
-	NewLogFilter              = newLogFilter
-	NewConfigLoader           = newConfigLoader
-	NewVerifier               = newVerifier
-	ArnToName                 = arnToName
-	InitVerifyState           = initVerifyState
-	VerifyResource            = verifyResource
-	Map2str                   = map2str
-	DiffServices              = diffServices
+	SortTaskDefinition = sortTaskDefinition
+	ToNumberCPU        = toNumberCPU
+	ToNumberMemory     = toNumberMemory
+	CalcDesiredCount   = calcDesiredCount
+	ParseTags          = parseTags
+	ExtractRoleName    = extractRoleName
+	IsLongArnFormat    = isLongArnFormat
+	ECRImageURLRegex   = ecrImageURLRegex
+	NewLogger          = newLogger
+	NewLogFilter       = newLogFilter
+	NewConfigLoader    = newConfigLoader
+	NewVerifier        = newVerifier
+	ArnToName          = arnToName
+	InitVerifyState    = initVerifyState
+	VerifyResource     = verifyResource
+	Map2str            = map2str
+	DiffServices       = diffServices
 )
 
 type ModifyAutoScalingParams = modifyAutoScalingParams

--- a/init.go
+++ b/init.go
@@ -190,7 +190,7 @@ func (d *App) initTaskDefinition(ctx context.Context, opt InitOption, tdArn stri
 		return nil, err
 	}
 	if opt.Sort {
-		sortTaskDefinitionForDiff(td)
+		sortTaskDefinition(td)
 	}
 	if b, err := MarshalJSONForAPI(td); err != nil {
 		return nil, fmt.Errorf("unable to marshal task definition to JSON: %w", err)

--- a/init.go
+++ b/init.go
@@ -24,6 +24,7 @@ type InitOption struct {
 	TaskDefinition        string `help:"ECS task definition name:revision" required:"" xor:"FROM"`
 	TaskDefinitionPath    string `help:"path to output task definition file" default:"ecs-task-def.json"`
 	ServiceDefinitionPath string `help:"path to output service definition file" default:"ecs-service-def.json"`
+	Sort                  bool   `help:"sort elements in task definition" default:"false" negatable:""`
 	ConfigFilePath        string
 	ForceOverwrite        bool `help:"overwrite existing files" default:"false"`
 	Jsonnet               bool `help:"output files as jsonnet format" default:"false"`
@@ -187,6 +188,9 @@ func (d *App) initTaskDefinition(ctx context.Context, opt InitOption, tdArn stri
 	td, err := d.DescribeTaskDefinition(ctx, tdArn)
 	if err != nil {
 		return nil, err
+	}
+	if opt.Sort {
+		sortTaskDefinitionForDiff(td)
 	}
 	if b, err := MarshalJSONForAPI(td); err != nil {
 		return nil, fmt.Errorf("unable to marshal task definition to JSON: %w", err)


### PR DESCRIPTION
For #599.

Add `--sort` option to `init` command.
Apply `sortTaskDefinition` func when `init --sort` is specified.

The `--sort` option is not by default. But this default value may be changed in the next minor version released.