### PR TITLE
omit 'timeout' element by init command.

### DIFF
--- a/init.go
+++ b/init.go
@@ -71,7 +71,7 @@ func (d *App) Init(ctx context.Context, opt InitOption) error {
 	if err := conf.Restrict(ctx); err != nil {
 		return err
 	}
-	conf.Timeout = nil // timeout is omitted by init command. timout should be set by user.
+	conf.Timeout = nil // timeout is omitted by init command. timeout should be set by user.
 
 	var err error
 	var sv *Service

--- a/init.go
+++ b/init.go
@@ -71,6 +71,8 @@ func (d *App) Init(ctx context.Context, opt InitOption) error {
 	if err := conf.Restrict(ctx); err != nil {
 		return err
 	}
+	conf.Timeout = nil // timeout is omitted by init command. timout should be set by user.
+
 	var err error
 	var sv *Service
 	var tdArn string


### PR DESCRIPTION
timeout should be set by the user.
Use default timeout whenever it is not set.

related #598 