### PR TITLE
add run --client-token

### DIFF
--- a/cli_test.go
+++ b/cli_test.go
@@ -430,6 +430,7 @@ var cliTests = []struct {
 			Tags:                 "",
 			WaitUntil:            "stopped",
 			Revision:             ptr(int64(0)),
+			ClientToken:          nil,
 		},
 	},
 	{
@@ -449,6 +450,7 @@ var cliTests = []struct {
 			Tags:                 "",
 			WaitUntil:            "stopped",
 			Revision:             ptr(int64(0)),
+			ClientToken:          nil,
 		},
 	},
 	{
@@ -458,6 +460,7 @@ var cliTests = []struct {
 			"--overrides-file", "overrides.json",
 			"--latest-task-definition", "--tags", "KeyFoo=ValueFoo,KeyBar=ValueBar",
 			"--wait-until", "running", "--revision", "1",
+			"--client-token", "3abb3a41-c4dc-4c16-a3be-aaab729008a0",
 		},
 		sub: "run",
 		subOption: &ecspresso.RunOption{
@@ -474,6 +477,7 @@ var cliTests = []struct {
 			Tags:                 "KeyFoo=ValueFoo,KeyBar=ValueBar",
 			WaitUntil:            "running",
 			Revision:             ptr(int64(1)),
+			ClientToken:          ptr("3abb3a41-c4dc-4c16-a3be-aaab729008a0"),
 		},
 	},
 	{

--- a/run.go
+++ b/run.go
@@ -13,19 +13,20 @@ import (
 )
 
 type RunOption struct {
-	DryRun               bool   `help:"dry run" default:"false"`
-	TaskDefinition       string `name:"task-def" help:"task definition file for run task" default:""`
-	Wait                 bool   `help:"wait for task to complete" default:"true" negatable:""`
-	TaskOverrideStr      string `name:"overrides" help:"task override JSON string" default:""`
-	TaskOverrideFile     string `name:"overrides-file" help:"task override JSON file path" default:""`
-	SkipTaskDefinition   bool   `help:"skip register a new task definition" default:"false"`
-	Count                int32  `help:"number of tasks to run (max 10)" default:"1"`
-	WatchContainer       string `help:"container name for watching exit code" default:""`
-	LatestTaskDefinition bool   `help:"use the latest task definition without registering a new task definition" default:"false"`
-	PropagateTags        string `help:"propagate the tags for the task (SERVICE or TASK_DEFINITION)" default:""`
-	Tags                 string `help:"tags for the task: format is KeyFoo=ValueFoo,KeyBar=ValueBar" default:""`
-	WaitUntil            string `help:"wait until invoked tasks status reached to (running or stopped)" default:"stopped" enum:"running,stopped"`
-	Revision             *int64 `help:"revision of the task definition to run when --skip-task-definition" default:"0"`
+	DryRun               bool    `help:"dry run" default:"false"`
+	TaskDefinition       string  `name:"task-def" help:"task definition file for run task" default:""`
+	Wait                 bool    `help:"wait for task to complete" default:"true" negatable:""`
+	TaskOverrideStr      string  `name:"overrides" help:"task override JSON string" default:""`
+	TaskOverrideFile     string  `name:"overrides-file" help:"task override JSON file path" default:""`
+	SkipTaskDefinition   bool    `help:"skip register a new task definition" default:"false"`
+	Count                int32   `help:"number of tasks to run (max 10)" default:"1"`
+	WatchContainer       string  `help:"container name for watching exit code" default:""`
+	LatestTaskDefinition bool    `help:"use the latest task definition without registering a new task definition" default:"false"`
+	PropagateTags        string  `help:"propagate the tags for the task (SERVICE or TASK_DEFINITION)" default:""`
+	Tags                 string  `help:"tags for the task: format is KeyFoo=ValueFoo,KeyBar=ValueBar" default:""`
+	WaitUntil            string  `help:"wait until invoked tasks status reached to (running or stopped)" default:"stopped" enum:"running,stopped"`
+	Revision             *int64  `help:"revision of the task definition to run when --skip-task-definition" default:"0"`
+	ClientToken          *string `help:"unique token that identifies a request, useful for idempotency"`
 }
 
 func (opt RunOption) waitUntilRunning() bool {
@@ -123,6 +124,7 @@ func (d *App) RunTask(ctx context.Context, tdArn string, ov *types.TaskOverride,
 		Tags:                     tags,
 		EnableECSManagedTags:     sv.EnableECSManagedTags,
 		EnableExecuteCommand:     sv.EnableExecuteCommand,
+		ClientToken:              opt.ClientToken,
 	}
 
 	switch opt.PropagateTags {

--- a/tests/ci/Makefile
+++ b/tests/ci/Makefile
@@ -3,6 +3,7 @@
 export CLUSTER := ecspresso-test
 export SERVICE := nginx-$(CIRCLE_BRANCH)
 export NOW := $(shell date +%Y%m%d%H%M%S)
+export CLIENT_TOKEN := $(shell uuidgen)
 ECSPRESSO := ecspresso --envfile envfile
 
 help:
@@ -53,7 +54,7 @@ run-task:
 		--dry-run
 	$(ECSPRESSO) --envfile envfile.override run \
 		--overrides '{"containerOverrides":[{"name":"nginx", "command":["nginx", "-V"]}]}' \
-		--debug
+		--debug --client-token $(CLIENT_TOKEN)
 	OPTION=-v $(ECSPRESSO) --envfile envfile.override run \
 		--overrides-file=overrides.json \
 		--dry-run


### PR DESCRIPTION
Support to `run --client-token`.

See also https://aws.amazon.com/en/about-aws/whats-new/2023/11/amazon-elastic-container-service-idempotency-launches/