### PR TITLE
diff command works whenever a remote service or a task definition are not found.

### DIFF
--- a/deploy.go
+++ b/deploy.go
@@ -133,7 +133,7 @@ func (d *App) Deploy(ctx context.Context, opt DeployOption) error {
 			return err
 		}
 		addedTags, updatedTags, deletedTags := CompareTags(sv.Tags, newSv.Tags)
-		ds, err := diffServices(newSv, sv, "", d.config.ServiceDefinitionPath, true)
+		ds, err := diffServices(newSv, sv, d.config.ServiceDefinitionPath, true)
 		if err != nil {
 			return fmt.Errorf("failed to diff of service definitions: %w", err)
 		}

--- a/diff_test.go
+++ b/diff_test.go
@@ -232,7 +232,7 @@ func TestDiffServices(t *testing.T) {
 		diff, err := ecspresso.DiffServices(
 			testServiceDefinitionNoDesiredCount,
 			testServiceDefinitionHasDesiredCount,
-			"arn", "file", true,
+			"file", true,
 		)
 		if err != nil {
 			t.Error(err)
@@ -245,7 +245,51 @@ func TestDiffServices(t *testing.T) {
 		diff, err := ecspresso.DiffServices(
 			testServiceDefinitionHasDesiredCount,
 			testServiceDefinitionNoDesiredCount,
-			"arn", "file", true,
+			"file", true,
+		)
+		if err != nil {
+			t.Error(err)
+		}
+		if diff == "" {
+			t.Errorf("unexpected diff: %s", diff)
+		}
+	})
+
+	t.Run("remote service is nil", func(t *testing.T) {
+		diff, err := ecspresso.DiffServices(
+			testServiceDefinitionNoDesiredCount,
+			nil,
+			"file", true,
+		)
+		if err != nil {
+			t.Error(err)
+		}
+		if diff == "" {
+			t.Errorf("unexpected diff: %s", diff)
+		}
+	})
+}
+
+func TestDiffTaskDefs(t *testing.T) {
+	t.Run("diff task defs same actually", func(t *testing.T) {
+		diff, err := ecspresso.DiffTaskDefs(
+			testTaskDefinition1,
+			testTaskDefinition2,
+			"file", "remote", true,
+		)
+		if err != nil {
+			t.Error(err)
+		}
+		if diff != "" {
+			t.Errorf("unexpected diff: %s", diff)
+		}
+	})
+
+	t.Run("diff task defs remote nil", func(t *testing.T) {
+		diff, err := ecspresso.DiffTaskDefs(
+			testTaskDefinition1,
+			nil,
+			"file", "", true,
 		)
 		if err != nil {
 			t.Error(err)

--- a/export_test.go
+++ b/export_test.go
@@ -25,6 +25,7 @@ var (
 	VerifyResource     = verifyResource
 	Map2str            = map2str
 	DiffServices       = diffServices
+	DiffTaskDefs       = diffTaskDefs
 )
 
 type ModifyAutoScalingParams = modifyAutoScalingParams

--- a/json.go
+++ b/json.go
@@ -27,6 +27,9 @@ func MustMarshalJSONStringForAPI(v interface{}) string {
 }
 
 func MarshalJSONForAPI(v interface{}, queries ...string) ([]byte, error) {
+	if v == nil {
+		return nil, nil
+	}
 	b, err := json.Marshal(v)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Now, the `diff` command fails when a remote service or task definition does not exist. But we want to run the `diff` command before a service is created.