### PR TITLE
Enables to override timeout in a configuration file by --timeout.

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -7,14 +7,7 @@ import (
 )
 
 type CLIOptions struct {
-	Envfile       []string          `help:"environment files"`
-	Debug         bool              `help:"enable debug log"`
-	ExtStr        map[string]string `help:"external string values for Jsonnet"`
-	ExtCode       map[string]string `help:"external code values for Jsonnet"`
-	Config        string            `help:"config file" default:"ecspresso.yml"`
-	AssumeRoleARN string            `help:"the ARN of the role to assume" default:""`
-
-	Option *Option
+	Option
 
 	Appspec    *AppSpecOption    `cmd:"" help:"output AppSpec YAML for CodeDeploy to STDOUT"`
 	Delete     *DeleteOption     `cmd:"" help:"delete service"`
@@ -87,7 +80,7 @@ func dispatchCLI(ctx context.Context, sub string, usage func(), opts *CLIOptions
 		return nil
 	}
 
-	app, err := New(ctx, opts.Option)
+	app, err := New(ctx, &opts.Option)
 	if err != nil {
 		return err
 	}

--- a/cli_test.go
+++ b/cli_test.go
@@ -31,6 +31,7 @@ var cliTests = []struct {
 		option: &ecspresso.Option{
 			ConfigFilePath: "config.yml",
 			Debug:          true,
+			Envfile:        []string{"tests/envfile"},
 			ExtStr:         map[string]string{"s1": "v1", "s2": "v2"},
 			ExtCode:        map[string]string{"c1": "123", "c2": "1+2"},
 			InitOption:     nil,
@@ -797,7 +798,7 @@ func TestParseCLIv2(t *testing.T) {
 				t.Errorf("unexpected subcommand: expected %s, got %s", tt.sub, sub)
 			}
 			if tt.option != nil {
-				if diff := cmp.Diff(tt.option, opt.Option); diff != "" {
+				if diff := cmp.Diff(*tt.option, opt.Option); diff != "" {
 					t.Errorf("unexpected option: diff %s", diff)
 				}
 			}

--- a/cliv2.go
+++ b/cliv2.go
@@ -30,13 +30,6 @@ func ParseCLIv2(args []string) (string, *CLIOptions, func(), error) {
 		}
 	}
 
-	opts.Option = &Option{
-		ConfigFilePath: opts.Config,
-		Debug:          opts.Debug,
-		ExtStr:         opts.ExtStr,
-		ExtCode:        opts.ExtCode,
-		AssumeRoleARN:  opts.AssumeRoleARN,
-	}
 	if opts.Option.ExtStr == nil {
 		opts.Option.ExtStr = map[string]string{}
 	}
@@ -45,7 +38,7 @@ func ParseCLIv2(args []string) (string, *CLIOptions, func(), error) {
 	}
 	switch sub {
 	case "init":
-		opts.Init.ConfigFilePath = opts.Config
+		opts.Init.ConfigFilePath = opts.ConfigFilePath
 		opts.Option.InitOption = opts.Init
 	}
 	return sub, &opts, func() { c.PrintUsage(true) }, nil

--- a/config.go
+++ b/config.go
@@ -112,6 +112,12 @@ func (l *configLoader) Load(ctx context.Context, path string, version string) (*
 	return conf, nil
 }
 
+func (c *Config) OverrideByOption(opt *Option) {
+	if opt.Timeout != nil {
+		c.Timeout = &Duration{*opt.Timeout}
+	}
+}
+
 // Restrict restricts a configuration.
 func (c *Config) Restrict(ctx context.Context) error {
 	if c.Cluster == "" {

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -128,6 +128,7 @@ func New(ctx context.Context, opt *Option) (*App, error) {
 			return nil, fmt.Errorf("failed to load config file %s: %w", opt.ConfigFilePath, err)
 		}
 	}
+	conf.OverrideByOption(opt)
 	conf.AssumeRole(opt.AssumeRoleARN)
 
 	logger := newLogger()
@@ -153,6 +154,7 @@ func New(ctx context.Context, opt *Option) (*App, error) {
 		logger: logger,
 	}
 	d.Log("[DEBUG] config file path: %s", opt.ConfigFilePath)
+	d.Log("[DEBUG] timeout: %s", d.config.Timeout)
 	return d, nil
 }
 
@@ -173,12 +175,15 @@ func (d *App) Start(ctx context.Context) (context.Context, context.CancelFunc) {
 }
 
 type Option struct {
-	InitOption     *InitOption
-	ConfigFilePath string
-	Debug          bool
-	ExtStr         map[string]string
-	ExtCode        map[string]string
-	AssumeRoleARN  string
+	InitOption *InitOption
+
+	Envfile        []string          `help:"environment files" env:"ECSPRESSO_ENVFILE"`
+	Debug          bool              `help:"enable debug log" env:"ECSPRESSO_DEBUG"`
+	ExtStr         map[string]string `help:"external string values for Jsonnet" env:"ECSPRESSO_EXT_STR"`
+	ExtCode        map[string]string `help:"external code values for Jsonnet" env:"ECSPRESSO_EXT_CODE"`
+	ConfigFilePath string            `name:"config" help:"config file" default:"ecspresso.yml" env:"ECSPRESSO_CONFIG"`
+	AssumeRoleARN  string            `help:"the ARN of the role to assume" default:"" env:"ECSPRESSO_ASSUME_ROLE_ARN"`
+	Timeout        *time.Duration    `help:"timeout. Override in a configuration file." env:"ECSPRESSO_TIMEOUT"`
 }
 
 func (opt *Option) resolveConfigFilePath() (path string) {


### PR DESCRIPTION
refs #598

A cli flag `--timeout` and environment variable `ECSPRESSO_TIMEOUT` can override `timeout` in a configuration file.

ECSPRESSO_ENVFILE, ECSPRESSO_DEBUG, etc are set CLI flags.