### PR TITLE
fix diff output compared with nil

### DIFF
--- a/diff_test.go
+++ b/diff_test.go
@@ -1,6 +1,7 @@
 package ecspresso_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -267,6 +268,15 @@ func TestDiffServices(t *testing.T) {
 		if diff == "" {
 			t.Errorf("unexpected diff: %s", diff)
 		}
+		minusDiffs := 0
+		for _, line := range strings.Split(diff, "\n") {
+			if strings.HasPrefix(line, "-") {
+				minusDiffs++
+			}
+		}
+		if minusDiffs != 1 {  // The first line is "---"
+			t.Errorf("unexpected diff. has many minus diffs: %s", diff)
+		}
 	})
 }
 
@@ -296,6 +306,15 @@ func TestDiffTaskDefs(t *testing.T) {
 		}
 		if diff == "" {
 			t.Errorf("unexpected diff: %s", diff)
+		}
+		minusDiffs := 0
+		for _, line := range strings.Split(diff, "\n") {
+			if strings.HasPrefix(line, "-") {
+				minusDiffs++
+			}
+		}
+		if minusDiffs != 1 { // The first line is "---"
+			t.Errorf("unexpected diff. has many minus diffs: %s", diff)
 		}
 	})
 }

--- a/json.go
+++ b/json.go
@@ -12,7 +12,7 @@ import (
 func (d *App) OutputJSONForAPI(w io.Writer, v interface{}) error {
 	b, err := MarshalJSONForAPI(v)
 	if err != nil {
-		fmt.Errorf("failed to marshal json: %w", err)
+		return fmt.Errorf("failed to marshal json: %w", err)
 	}
 	_, err = w.Write(b)
 	return err


### PR DESCRIPTION
refs #632 

When a remote resource is not found, show a diff compared with an empty string instead of `null`.