### PR TITLE
Refactoring options

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ $ asdf plugin add ecspresso
 # or
 $ asdf plugin add ecspresso https://github.com/kayac/asdf-ecspresso.git
 
-$ asdf install ecspresso 2.0.0
-$ asdf global ecspresso 2.0.0
+$ asdf install ecspresso 2.3.0
+$ asdf global ecspresso 2.3.0
 ```
 
 ### aqua (macOS and Linux)
@@ -49,13 +49,13 @@ https://circleci.com/orbs/registry/orb/fujiwara/ecspresso
 ```yaml
 version: 2.1
 orbs:
-  ecspresso: fujiwara/ecspresso@2.0.3
+  ecspresso: fujiwara/ecspresso@2.3.0
 jobs:
   install:
     steps:
       - checkout
       - ecspresso/install:
-          version: v2.0.0 # or latest
+          version: v2.3.0 # or latest
           # version-file: .ecspresso-version
       - run:
           command: |
@@ -86,7 +86,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: kayac/ecspresso@v2
         with:
-          version: v2.0.0 # or latest
+          version: v2.3.0 # or latest
           # version-file: .ecspresso-version
       - run: |
           ecspresso deploy --config ecspresso.yml
@@ -108,7 +108,7 @@ Pass the parameter "latest" to use the latest version of ecspresso.
 
 `version: latest` is not recommended because it may cause unexpected behavior when the new version of ecspresso is released.
 
-GitHub Action `kayac/ecspresso@v2` supports `version-file: path/to/file` installs ecspresso that version written in the file. This version number does not have `v` prefix, For example `2.0.0`.
+GitHub Action `kayac/ecspresso@v2` supports `version-file: path/to/file` installs ecspresso that version written in the file. This version number does not have `v` prefix, For example `2.3.0`.
 
 ## Usage
 
@@ -116,14 +116,16 @@ GitHub Action `kayac/ecspresso@v2` supports `version-file: path/to/file` install
 Usage: ecspresso <command>
 
 Flags:
-  -h, --help                      Show context-sensitive help.
-      --envfile=ENVFILE,...       environment files
-      --debug                     enable debug log
-      --ext-str=KEY=VALUE;...     external string values for Jsonnet
-      --ext-code=KEY=VALUE;...    external code values for Jsonnet
-      --config="ecspresso.yml"    config file
-      --assume-role-arn=""        the ARN of the role to assume
-      --option=OPTION
+  -h, --help                       Show context-sensitive help.
+      --init-option=INIT-OPTION
+      --envfile=ENVFILE,...        environment files ($ECSPRESSO_ENVFILE)
+      --debug                      enable debug log ($ECSPRESSO_DEBUG)
+      --ext-str=KEY=VALUE;...      external string values for Jsonnet ($ECSPRESSO_EXT_STR)
+      --ext-code=KEY=VALUE;...     external code values for Jsonnet ($ECSPRESSO_EXT_CODE)
+      --config="ecspresso.yml"     config file ($ECSPRESSO_CONFIG)
+      --assume-role-arn=""         the ARN of the role to assume ($ECSPRESSO_ASSUME_ROLE_ARN)
+      --timeout=TIMEOUT            timeout. Override in a configuration file ($ECSPRESSO_TIMEOUT).
+      --filter-command=STRING      filter command ($ECSPRESSO_FILTER_COMMAND)
 
 Commands:
   appspec

--- a/README.md
+++ b/README.md
@@ -116,16 +116,15 @@ GitHub Action `kayac/ecspresso@v2` supports `version-file: path/to/file` install
 Usage: ecspresso <command>
 
 Flags:
-  -h, --help                       Show context-sensitive help.
-      --init-option=INIT-OPTION
-      --envfile=ENVFILE,...        environment files ($ECSPRESSO_ENVFILE)
-      --debug                      enable debug log ($ECSPRESSO_DEBUG)
-      --ext-str=KEY=VALUE;...      external string values for Jsonnet ($ECSPRESSO_EXT_STR)
-      --ext-code=KEY=VALUE;...     external code values for Jsonnet ($ECSPRESSO_EXT_CODE)
-      --config="ecspresso.yml"     config file ($ECSPRESSO_CONFIG)
-      --assume-role-arn=""         the ARN of the role to assume ($ECSPRESSO_ASSUME_ROLE_ARN)
-      --timeout=TIMEOUT            timeout. Override in a configuration file ($ECSPRESSO_TIMEOUT).
-      --filter-command=STRING      filter command ($ECSPRESSO_FILTER_COMMAND)
+  -h, --help                      Show context-sensitive help.
+      --envfile=ENVFILE,...       environment files ($ECSPRESSO_ENVFILE)
+      --debug                     enable debug log ($ECSPRESSO_DEBUG)
+      --ext-str=KEY=VALUE;...     external string values for Jsonnet ($ECSPRESSO_EXT_STR)
+      --ext-code=KEY=VALUE;...    external code values for Jsonnet ($ECSPRESSO_EXT_CODE)
+      --config="ecspresso.yml"    config file ($ECSPRESSO_CONFIG)
+      --assume-role-arn=""        the ARN of the role to assume ($ECSPRESSO_ASSUME_ROLE_ARN)
+      --timeout=TIMEOUT           timeout. Override in a configuration file ($ECSPRESSO_TIMEOUT).
+      --filter-command=STRING     filter command ($ECSPRESSO_FILTER_COMMAND)
 
 Commands:
   appspec

--- a/cli.go
+++ b/cli.go
@@ -79,8 +79,10 @@ func dispatchCLI(ctx context.Context, sub string, usage func(), opts *CLIOptions
 		fmt.Println("ecspresso", Version)
 		return nil
 	}
-
-	app, err := New(ctx, &opts.Option)
+	if sub != "init" {
+		opts.Init = nil
+	}
+	app, err := New(ctx, &opts.Option, opts.Init)
 	if err != nil {
 		return err
 	}
@@ -111,7 +113,7 @@ func dispatchCLI(ctx context.Context, sub string, usage func(), opts *CLIOptions
 	case "revisions":
 		return app.Revesions(ctx, *opts.Revisions)
 	case "init":
-		return app.Init(ctx, *opts.Init)
+		return app.Init(ctx, *opts.Init, opts.ConfigFilePath)
 	case "diff":
 		return app.Diff(ctx, *opts.Diff)
 	case "appspec":

--- a/cli_test.go
+++ b/cli_test.go
@@ -34,7 +34,6 @@ var cliTests = []struct {
 			Envfile:        []string{"tests/envfile"},
 			ExtStr:         map[string]string{"s1": "v1", "s2": "v2"},
 			ExtCode:        map[string]string{"c1": "123", "c2": "1+2"},
-			InitOption:     nil,
 			AssumeRoleARN:  "arn:aws:iam::123456789012:role/exampleRole",
 		},
 		subOption: &ecspresso.StatusOption{
@@ -59,7 +58,6 @@ var cliTests = []struct {
 			Debug:          true,
 			ExtStr:         map[string]string{},
 			ExtCode:        map[string]string{},
-			InitOption:     nil,
 			AssumeRoleARN:  "",
 		},
 		subOption: &ecspresso.StatusOption{
@@ -587,7 +585,6 @@ var cliTests = []struct {
 		subOption: &ecspresso.InitOption{
 			Region:                os.Getenv("AWS_REGION"),
 			Cluster:               "default",
-			ConfigFilePath:        "myconfig.yml",
 			Service:               "myservice",
 			TaskDefinitionPath:    "ecs-task-def.json",
 			ServiceDefinitionPath: "ecs-service-def.json",
@@ -599,16 +596,6 @@ var cliTests = []struct {
 		args: []string{"init", "--service", "myservice", "--config", "myconfig.yml"},
 		sub:  "init",
 		option: &ecspresso.Option{
-			InitOption: &ecspresso.InitOption{
-				Region:                os.Getenv("AWS_REGION"),
-				Cluster:               "default",
-				ConfigFilePath:        "myconfig.yml",
-				Service:               "myservice",
-				TaskDefinitionPath:    "ecs-task-def.json",
-				ServiceDefinitionPath: "ecs-service-def.json",
-				ForceOverwrite:        false,
-				Jsonnet:               false,
-			},
 			ConfigFilePath: "myconfig.yml",
 			Debug:          false,
 			ExtStr:         map[string]string{},
@@ -617,7 +604,6 @@ var cliTests = []struct {
 		subOption: &ecspresso.InitOption{
 			Region:                os.Getenv("AWS_REGION"),
 			Cluster:               "default",
-			ConfigFilePath:        "myconfig.yml",
 			Service:               "myservice",
 			TaskDefinitionPath:    "ecs-task-def.json",
 			ServiceDefinitionPath: "ecs-service-def.json",
@@ -636,7 +622,6 @@ var cliTests = []struct {
 		subOption: &ecspresso.InitOption{
 			Region:                os.Getenv("AWS_REGION"),
 			Cluster:               "mycluster",
-			ConfigFilePath:        "myconfig.jsonnet",
 			Service:               "myservice",
 			TaskDefinitionPath:    "taskdef.jsonnet",
 			ServiceDefinitionPath: "servicedef.jsonnet",
@@ -650,7 +635,6 @@ var cliTests = []struct {
 		subOption: &ecspresso.InitOption{
 			Region:                os.Getenv("AWS_REGION"),
 			Cluster:               "default",
-			ConfigFilePath:        "myconfig.yml",
 			Service:               "",
 			TaskDefinition:        "app:123",
 			TaskDefinitionPath:    "ecs-task-def.json",

--- a/cli_test.go
+++ b/cli_test.go
@@ -12,7 +12,7 @@ import (
 var cliTests = []struct {
 	args      []string
 	sub       string
-	option    *ecspresso.Option
+	option    *ecspresso.CLIOptions
 	subOption any
 	fn        func(*testing.T, any)
 }{
@@ -28,7 +28,7 @@ var cliTests = []struct {
 			"--assume-role-arn", "arn:aws:iam::123456789012:role/exampleRole",
 		},
 		sub: "status",
-		option: &ecspresso.Option{
+		option: &ecspresso.CLIOptions{
 			ConfigFilePath: "config.yml",
 			Debug:          true,
 			Envfile:        []string{"tests/envfile"},
@@ -53,7 +53,7 @@ var cliTests = []struct {
 			"--events=100",
 		},
 		sub: "status",
-		option: &ecspresso.Option{
+		option: &ecspresso.CLIOptions{
 			ConfigFilePath: "config.yml",
 			Debug:          true,
 			ExtStr:         map[string]string{},
@@ -595,7 +595,7 @@ var cliTests = []struct {
 	{
 		args: []string{"init", "--service", "myservice", "--config", "myconfig.yml"},
 		sub:  "init",
-		option: &ecspresso.Option{
+		option: &ecspresso.CLIOptions{
 			ConfigFilePath: "myconfig.yml",
 			Debug:          false,
 			ExtStr:         map[string]string{},
@@ -782,7 +782,7 @@ func TestParseCLIv2(t *testing.T) {
 				t.Errorf("unexpected subcommand: expected %s, got %s", tt.sub, sub)
 			}
 			if tt.option != nil {
-				if diff := cmp.Diff(*tt.option, opt.Option); diff != "" {
+				if diff := cmp.Diff(tt.option, CLIOptionsGlobalOnly(opt)); diff != "" {
 					t.Errorf("unexpected option: diff %s", diff)
 				}
 			}
@@ -795,5 +795,18 @@ func TestParseCLIv2(t *testing.T) {
 				tt.fn(t, opt.ForSubCommand(sub))
 			}
 		})
+	}
+}
+
+func CLIOptionsGlobalOnly(opts *ecspresso.CLIOptions) *ecspresso.CLIOptions {
+	return &ecspresso.CLIOptions{
+		ConfigFilePath: opts.ConfigFilePath,
+		Debug:          opts.Debug,
+		ExtStr:         opts.ExtStr,
+		ExtCode:        opts.ExtCode,
+		Envfile:        opts.Envfile,
+		AssumeRoleARN:  opts.AssumeRoleARN,
+		Timeout:        opts.Timeout,
+		FilterCommand:  opts.FilterCommand,
 	}
 }

--- a/cliv2.go
+++ b/cliv2.go
@@ -36,10 +36,5 @@ func ParseCLIv2(args []string) (string, *CLIOptions, func(), error) {
 	if opts.Option.ExtCode == nil {
 		opts.Option.ExtCode = map[string]string{}
 	}
-	switch sub {
-	case "init":
-		opts.Init.ConfigFilePath = opts.ConfigFilePath
-		opts.Option.InitOption = opts.Init
-	}
 	return sub, &opts, func() { c.PrintUsage(true) }, nil
 }

--- a/cliv2.go
+++ b/cliv2.go
@@ -30,11 +30,11 @@ func ParseCLIv2(args []string) (string, *CLIOptions, func(), error) {
 		}
 	}
 
-	if opts.Option.ExtStr == nil {
-		opts.Option.ExtStr = map[string]string{}
+	if opts.ExtStr == nil {
+		opts.ExtStr = map[string]string{}
 	}
-	if opts.Option.ExtCode == nil {
-		opts.Option.ExtCode = map[string]string{}
+	if opts.ExtCode == nil {
+		opts.ExtCode = map[string]string{}
 	}
 	return sub, &opts, func() { c.PrintUsage(true) }, nil
 }

--- a/config.go
+++ b/config.go
@@ -112,7 +112,7 @@ func (l *configLoader) Load(ctx context.Context, path string, version string) (*
 	return conf, nil
 }
 
-func (c *Config) OverrideByOption(opt *Option) {
+func (c *Config) OverrideByCLIOptions(opt *CLIOptions) {
 	if opt.Timeout != nil {
 		c.Timeout = &Duration{*opt.Timeout}
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestLoadServiceDefinition(t *testing.T) {
 	ctx := context.Background()
-	app, err := ecspresso.New(ctx, &ecspresso.Option{ConfigFilePath: "tests/test.yaml"})
+	app, err := ecspresso.New(ctx, &ecspresso.CLIOptions{ConfigFilePath: "tests/test.yaml"})
 	if err != nil {
 		t.Error(err)
 	}
@@ -89,7 +89,7 @@ func testLoadConfigWithPlugin(t *testing.T, path string) {
 	t.Setenv("JSON", `{"foo":"bar"}`)
 	t.Setenv("AWS_REGION", "ap-northeast-1")
 	ctx := context.Background()
-	app, err := ecspresso.New(ctx, &ecspresso.Option{ConfigFilePath: path})
+	app, err := ecspresso.New(ctx, &ecspresso.CLIOptions{ConfigFilePath: path})
 	if err != nil {
 		t.Error(err)
 	}
@@ -311,7 +311,7 @@ var FilterCommandTests = []struct {
 func TestFilterCommandDeprecated(t *testing.T) {
 	ctx := context.Background()
 	for _, ts := range FilterCommandTests {
-		app, err := ecspresso.New(ctx, &ecspresso.Option{
+		app, err := ecspresso.New(ctx, &ecspresso.CLIOptions{
 			ConfigFilePath: "tests/filter_command.yml",
 			FilterCommand:  ts.Env,
 		})

--- a/ecspresso_test.go
+++ b/ecspresso_test.go
@@ -20,7 +20,7 @@ func TestLoadTaskDefinition(t *testing.T) {
 		"tests/td-plain-in-tags.json",
 		"tests/td.jsonnet",
 	} {
-		app, err := ecspresso.New(ctx, &ecspresso.Option{
+		app, err := ecspresso.New(ctx, &ecspresso.CLIOptions{
 			ConfigFilePath: "tests/td-config.yml",
 			ExtStr:         map[string]string{"WorkerID": "3"},
 			ExtCode:        map[string]string{"EphemeralStorage": "24 + 1"}, // == 25
@@ -48,7 +48,7 @@ func TestLoadTaskDefinition(t *testing.T) {
 func TestLoadTaskDefinitionTags(t *testing.T) {
 	ctx := context.Background()
 	for _, path := range []string{"tests/td.json", "tests/td-plain.json", "tests/td.jsonnet"} {
-		app, err := ecspresso.New(ctx, &ecspresso.Option{
+		app, err := ecspresso.New(ctx, &ecspresso.CLIOptions{
 			ConfigFilePath: "tests/td-config.yml",
 			ExtStr:         map[string]string{"WorkerID": "3"},
 			ExtCode:        map[string]string{"EphemeralStorage": "24 + 1"}, // == 25
@@ -66,7 +66,7 @@ func TestLoadTaskDefinitionTags(t *testing.T) {
 	}
 
 	for _, path := range []string{"tests/td-in-tags.json", "tests/td-plain-in-tags.json"} {
-		app, err := ecspresso.New(ctx, &ecspresso.Option{ConfigFilePath: "tests/td-config.yml"})
+		app, err := ecspresso.New(ctx, &ecspresso.CLIOptions{ConfigFilePath: "tests/td-config.yml"})
 		if err != nil {
 			t.Error(err)
 		}

--- a/envfile.go
+++ b/envfile.go
@@ -11,6 +11,7 @@ func ExportEnvFile(file string) error {
 	if file == "" {
 		return nil
 	}
+	Log("[DEBUG] loading envfile: %s", file)
 
 	f, err := os.Open(file)
 	if err != nil {

--- a/init.go
+++ b/init.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/Songmu/prompter"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/goccy/go-yaml"
@@ -128,7 +129,7 @@ func (d *App) initConfigurationFile(ctx context.Context, configFilePath string, 
 				return fmt.Errorf("unable to marshal config to YAML: %w", err)
 			}
 		}
-		// d.Log("save config to %s", opt.ConfigFilePath)
+		d.Log("save the config to %s", configFilePath)
 		if err := d.saveFile(configFilePath, b, CreateFileMode, opt.ForceOverwrite); err != nil {
 			return err
 		}
@@ -150,8 +151,8 @@ func (d *App) initServiceDefinition(ctx context.Context, opt InitOption) (*Servi
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to describe service: %w", err)
 	}
-
-	if long, _ := isLongArnFormat(*sv.ServiceArn); long {
+	svArn := aws.ToString(sv.ServiceArn)
+	if long, _ := isLongArnFormat(svArn); long {
 		// Long arn format must be used for tagging operations
 		lt, err := d.ecs.ListTagsForResource(ctx, &ecs.ListTagsForResourceInput{
 			ResourceArn: sv.ServiceArn,
@@ -174,7 +175,7 @@ func (d *App) initServiceDefinition(ctx context.Context, opt InitOption) (*Servi
 			}
 			b = []byte(out)
 		}
-		d.Log("save service definition to %s", conf.ServiceDefinitionPath)
+		d.Log("save the service definition %s to %s", svArn, conf.ServiceDefinitionPath)
 		if err := d.saveFile(conf.ServiceDefinitionPath, b, CreateFileMode, opt.ForceOverwrite); err != nil {
 			return nil, "", err
 		}
@@ -201,7 +202,7 @@ func (d *App) initTaskDefinition(ctx context.Context, opt InitOption, tdArn stri
 			}
 			b = []byte(out)
 		}
-		d.Log("save task definition to %s", conf.TaskDefinitionPath)
+		d.Log("save the task definition %s to %s", tdArn, conf.TaskDefinitionPath)
 		if err := d.saveFile(conf.TaskDefinitionPath, b, CreateFileMode, opt.ForceOverwrite); err != nil {
 			return nil, err
 		}

--- a/init.go
+++ b/init.go
@@ -68,15 +68,12 @@ func (d *App) Init(ctx context.Context, opt InitOption) error {
 			conf.path = strings.TrimSuffix(conf.path, ext) + jsonnetExt
 		}
 	}
-	if err := conf.Restrict(ctx); err != nil {
-		return err
-	}
-	var err error
 	var sv *Service
 	var tdArn string
 	if tdOnly {
 		tdArn = opt.TaskDefinition
 	} else {
+		var err error
 		sv, tdArn, err = d.initServiceDefinition(ctx, opt)
 		if err != nil {
 			return err

--- a/init.go
+++ b/init.go
@@ -51,7 +51,7 @@ var (
 	yamlExt    = ".yaml"
 )
 
-func (d *App) Init(ctx context.Context, opt InitOption, configFilePath string) error {
+func (d *App) Init(ctx context.Context, opt InitOption) error {
 	conf := d.config
 	// when --task-definition is not empty, --service is empty because these flags are exclusive.
 	tdOnly := opt.TaskDefinition != ""
@@ -64,8 +64,8 @@ func (d *App) Init(ctx context.Context, opt InitOption, configFilePath string) e
 		if ext := filepath.Ext(conf.TaskDefinitionPath); ext == jsonExt {
 			conf.TaskDefinitionPath = strings.TrimSuffix(conf.TaskDefinitionPath, ext) + jsonnetExt
 		}
-		if ext := filepath.Ext(configFilePath); ext == ymlExt || ext == yamlExt {
-			configFilePath = strings.TrimSuffix(configFilePath, ext) + jsonnetExt
+		if ext := filepath.Ext(conf.path); ext == ymlExt || ext == yamlExt {
+			conf.path = strings.TrimSuffix(conf.path, ext) + jsonnetExt
 		}
 	}
 	if err := conf.Restrict(ctx); err != nil {
@@ -86,7 +86,7 @@ func (d *App) Init(ctx context.Context, opt InitOption, configFilePath string) e
 	if err != nil {
 		return err
 	}
-	if err := d.initConfigurationFile(ctx, configFilePath, opt, sv, td); err != nil {
+	if err := d.initConfigurationFile(ctx, conf.path, opt, sv, td); err != nil {
 		return err
 	}
 	return nil

--- a/run_test.go
+++ b/run_test.go
@@ -99,7 +99,7 @@ func TestTaskDefinitionArnForRun(t *testing.T) {
 	})
 	defer ecspresso.ResetAWSV2ConfigLoadOptionsFunc()
 	for config, suites := range testTaskDefinitionArnForRunSuite {
-		app, err := ecspresso.New(ctx, &ecspresso.Option{ConfigFilePath: config})
+		app, err := ecspresso.New(ctx, &ecspresso.CLIOptions{ConfigFilePath: config})
 		if err != nil {
 			t.Error(err)
 			continue

--- a/tests/ci/ecs-task-def.json
+++ b/tests/ci/ecs-task-def.json
@@ -4,7 +4,7 @@
       "cpu": 0,
       "environment": [
         {
-          "name": "FOO",
+          "name": "FOO_ENV",
           "value": "{{ ssm `/ecspresso-test/foo` }}"
         },
         {
@@ -34,7 +34,7 @@
       ],
       "secrets": [
         {
-          "name": "FOO",
+          "name": "FOO_SECRETS",
           "valueFrom": "/ecspresso-test/foo"
         },
         {


### PR DESCRIPTION
- The `Option` struct is renamed to `CLIOptions`.
- `espresso.New()` accepts optional arguments to initialize the application.