### PR TITLE
verify multiple tag specifications for ManagedEBSVolume

### DIFF
--- a/run.go
+++ b/run.go
@@ -277,6 +277,10 @@ func (d *App) taskDefinitionArnForRun(ctx context.Context, opt RunOption) (strin
 		if err != nil {
 			return "", err
 		}
+		{
+			b, _ := MarshalJSONForAPI(in)
+			d.Log("[DEBUG] task definition: %s", string(b))
+		}
 		if opt.DryRun {
 			return fmt.Sprintf("family %s will be registered", *in.Family), nil
 		}


### PR DESCRIPTION
Only the first tag specification is used. This is undocumented behavior, but AWS support confirmed.