### PR TITLE
Fix ecspresso rollback issue

### DIFF
--- a/wait.go
+++ b/wait.go
@@ -111,6 +111,7 @@ func (d *App) WaitForCodeDeploy(ctx context.Context, sv *Service) error {
 				cdTypes.DeploymentStatusQueued,
 				cdTypes.DeploymentStatusInProgress,
 				cdTypes.DeploymentStatusReady,
+				cdTypes.DeploymentStatusSucceeded,
 			},
 		},
 	)


### PR DESCRIPTION
Thank you for developing this awesome tool.

I'm submitting this PR to address an issue sometimes encountered during blue/green deployments. 
When executing `ecspresso rollback` while a deployment is in progress on CodeDeploy, we occasionally face the following error:
> [ERROR] FAILED. No deployments found in progress on CodeDeploy

After executing `StopDeploy`, the deployment status occasionally turns to `Succeeded` , indicating that the deployment stop and rollback process was successfully completed, but `ListDeployments` is unable to retrieve this status, so this error occurs. 
Even when the status is `Succeeded`, I would expect that the process would proceed without errors and complete the deregistration of the task definition.

https://github.com/kayac/ecspresso/blob/v2/rollback.go#L153
https://github.com/kayac/ecspresso/blob/v2/wait.go#L104