### PR TITLE
Allow to specify os,arch of binary to install in CircleCI's orb

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,7 +649,7 @@ $ ecspresso diff
 -  "platformVersion": "1.3.0"
 +  "platformVersion": "LATEST"
  }
-
+ 
 --- arn:aws:ecs:ap-northeast-1:123456789012:task-definition/ecspresso-test:202
 +++ ecs-task-def.json
 @@ -1,6 +1,10 @@

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ https://circleci.com/orbs/registry/orb/fujiwara/ecspresso
 ```yaml
 version: 2.1
 orbs:
-  ecspresso: fujiwara/ecspresso@2.0.3
+  ecspresso: fujiwara/ecspresso@2.0.4
 jobs:
   install:
     steps:
@@ -57,6 +57,8 @@ jobs:
       - ecspresso/install:
           version: v2.3.0 # or latest
           # version-file: .ecspresso-version
+          os: linux # or windows or darwin
+          arch: amd64 # or arm64
       - run:
           command: |
             ecspresso version
@@ -647,7 +649,7 @@ $ ecspresso diff
 -  "platformVersion": "1.3.0"
 +  "platformVersion": "LATEST"
  }
- 
+
 --- arn:aws:ecs:ap-northeast-1:123456789012:task-definition/ecspresso-test:202
 +++ ecs-task-def.json
 @@ -1,6 +1,10 @@

--- a/orb.yml
+++ b/orb.yml
@@ -14,6 +14,14 @@ commands:
         description: "File containing the ecspresso version. Example: .ecspresso-version"
         type: string
         default: ""
+      os:
+        description: "OS of the binary. Example: linux, darwin, windows"
+        type: string
+        default: "linux"
+      arch:
+        description: "Architecture of the binary. Example: amd64, arm64"
+        type: string
+        default: "amd64"
     steps:
       - run:
           name: "Install ecspresso"
@@ -23,10 +31,12 @@ commands:
             if [ -n "<< parameters.version-file >>" ]; then
               VERSION="v$(cat << parameters.version-file >>)"
             fi
+            DOWNLOAD_OS="<< parameters.os >>"
+            DOWNLOAD_ARCH="<< parameters.arch >>"
             if [ "${VERSION}" = "latest" ]; then
-              DOWNLOAD_URL=$(curl -sS https://api.github.com/repos/kayac/ecspresso/releases | jq -r '[.[]|select(.tag_name > "v2.0")|select(.prerelease==false)][0].assets[].browser_download_url|select(match("linux.amd64."))')
+              DOWNLOAD_URL=$(curl -sS https://api.github.com/repos/kayac/ecspresso/releases | jq --arg arch ${DOWNLOAD_OS}.${DOWNLOAD_ARCH}. -r '[.[]|select(.tag_name > "v2.0")|select(.prerelease==false)][0].assets[].browser_download_url|select(match($arch))')
             else
-              DOWNLOAD_URL=https://github.com/kayac/ecspresso/releases/download/${VERSION}/ecspresso_${VERSION:1}_linux_amd64.tar.gz
+              DOWNLOAD_URL=https://github.com/kayac/ecspresso/releases/download/${VERSION}/ecspresso_${VERSION:1}_${DOWNLOAD_OS}_${DOWNLOAD_ARCH}.tar.gz
             fi
             cd /tmp
             curl -sfLO ${DOWNLOAD_URL}


### PR DESCRIPTION
CircleCi orb OS/architecture was fixed to `linux/amd64`.
It can now be specified in the configuration file.

Before change

![image](https://github.com/kayac/ecspresso/assets/203382/24195a3c-dcdf-4c71-b17b-ad985c8aadb3)


After change

![image](https://github.com/kayac/ecspresso/assets/203382/28e1ec4e-6863-4952-bb58-b74099f17a81)
