### PR TITLE
Set shorten waiter max delay.

### DIFF
--- a/ecspresso.go
+++ b/ecspresso.go
@@ -34,6 +34,7 @@ const dryRunStr = "DRY RUN"
 
 var Version string
 var delayForServiceChanged = 3 * time.Second
+var waiterMaxDelay = 15 * time.Second
 var spcIndent = "  "
 
 type TaskDefinition = types.TaskDefinition

--- a/run.go
+++ b/run.go
@@ -214,7 +214,9 @@ func (d *App) waitTask(ctx context.Context, task *types.Task, untilRunning bool)
 	id := arnToName(*task.TaskArn)
 	if untilRunning {
 		d.Log("Waiting for task ID %s until running", id)
-		waiter := ecs.NewTasksRunningWaiter(d.ecs)
+		waiter := ecs.NewTasksRunningWaiter(d.ecs, func(o *ecs.TasksRunningWaiterOptions) {
+			o.MaxDelay = waiterMaxDelay
+		})
 		if err := waiter.Wait(ctx, d.DescribeTasksInput(task), d.Timeout()); err != nil {
 			return err
 		}
@@ -223,7 +225,9 @@ func (d *App) waitTask(ctx context.Context, task *types.Task, untilRunning bool)
 	}
 
 	d.Log("Waiting for task ID %s until stopped", id)
-	waiter := ecs.NewTasksStoppedWaiter(d.ecs)
+	waiter := ecs.NewTasksStoppedWaiter(d.ecs, func(o *ecs.TasksStoppedWaiterOptions) {
+		o.MaxDelay = waiterMaxDelay
+	})
 	if err := waiter.Wait(ctx, d.DescribeTasksInput(task), d.Timeout()); err != nil {
 		return fmt.Errorf("failed to wait task: %w", err)
 	}

--- a/wait.go
+++ b/wait.go
@@ -73,8 +73,8 @@ func (d *App) WaitServiceStable(ctx context.Context, sv *Service) error {
 	defer cancel()
 
 	tick := time.NewTicker(10 * time.Second)
+	st := &showState{lastEventAt: time.Now()}
 	go func() {
-		st := &showState{lastEventAt: time.Now()}
 		for {
 			select {
 			case <-waitCtx.Done():
@@ -93,6 +93,13 @@ func (d *App) WaitServiceStable(ctx context.Context, sv *Service) error {
 	})
 	if err := waiter.Wait(ctx, d.DescribeServicesInput(), d.Timeout()); err != nil {
 		return fmt.Errorf("failed to wait for service stable: %w", err)
+	}
+	cancel() // stop the showServiceStatus
+
+	<-time.After(delayForServiceChanged)
+	// show the service status once more (correct all logs)
+	if err := d.showServiceStatus(ctx, st); err != nil {
+		d.Log("[WARNING] %s", err.Error())
 	}
 	return nil
 }

--- a/wait.go
+++ b/wait.go
@@ -88,7 +88,9 @@ func (d *App) WaitServiceStable(ctx context.Context, sv *Service) error {
 		}
 	}()
 
-	waiter := ecs.NewServicesStableWaiter(d.ecs)
+	waiter := ecs.NewServicesStableWaiter(d.ecs, func(o *ecs.ServicesStableWaiterOptions) {
+		o.MaxDelay = waiterMaxDelay
+	})
 	if err := waiter.Wait(ctx, d.DescribeServicesInput(), d.Timeout()); err != nil {
 		return fmt.Errorf("failed to wait for service stable: %w", err)
 	}
@@ -125,7 +127,9 @@ func (d *App) WaitForCodeDeploy(ctx context.Context, sv *Service) error {
 	d.Log("Waiting for a deployment successful ID: " + dpID)
 	go d.codeDeployProgressBar(ctx, dpID)
 
-	waiter := codedeploy.NewDeploymentSuccessfulWaiter(d.codedeploy)
+	waiter := codedeploy.NewDeploymentSuccessfulWaiter(d.codedeploy, func(o *codedeploy.DeploymentSuccessfulWaiterOptions) {
+		o.MaxDelay = waiterMaxDelay
+	})
 	return waiter.Wait(
 		ctx,
 		&codedeploy.GetDeploymentInput{DeploymentId: &dpID},


### PR DESCRIPTION
By SDK defaults, waiter.MaxDelay is 120s. This is too long.

Reduce this value, ecspresso run/deploy/wait will return immediately after completion.
This helps to reduce CI/CD wait time and costs.