### PR TITLE
fix: use GetParameters instead of GetParameter to simulate actual ECS' behavior

### DIFF
--- a/docs/iam-policy-example.json
+++ b/docs/iam-policy-example.json
@@ -18,7 +18,7 @@
 				"logs:GetLogEvents",
 				"secretsmanager:GetSecretValue",
 				"servicediscovery:GetNamespace",
-				"ssm:GetParameter",
+				"ssm:GetParameters",
 				"sts:AssumeRole"
 			],
 			"Resource": "*"

--- a/tests/terraform/iam.tf
+++ b/tests/terraform/iam.tf
@@ -73,7 +73,6 @@ resource "aws_iam_policy" "ecs-task-execution" {
           "logs:CreateLogGroup",
           "logs:CreateLogStream",
           "logs:PutLogEvents",
-          "ssm:GetParameter",
           "ssm:GetParameters",
           "secretsmanager:GetSecretValue",
         ]

--- a/verify.go
+++ b/verify.go
@@ -116,8 +116,8 @@ func (v *verifier) existsSecretValue(ctx context.Context, from string) error {
 	} else {
 		name = from
 	}
-	_, err := v.ssm.GetParameter(ctx, &ssm.GetParameterInput{
-		Name:           &name,
+	_, err := v.ssm.GetParameters(ctx, &ssm.GetParametersInput{
+		Names:          []string{name},
 		WithDecryption: aws.Bool(true),
 	})
 	if err != nil {


### PR DESCRIPTION
This PR may solve the problem reported in #677.

Now we get the chance to reduce the API calls but this PR replaces the `ssm:GetParameter` call with `ssm:GetParameters`.
