### PR TITLE
do rollbackTaskDefinition if a rollbacking deployment was completed.

### DIFF
--- a/rollback.go
+++ b/rollback.go
@@ -78,7 +78,7 @@ func (d *App) Rollback(ctx context.Context, opt RollbackOption) error {
 	if err := doWait(ctx, sv); err != nil {
 		if errors.As(err, &errNotFound) {
 			d.Log("[INFO] %s", err)
-			return nil
+			return d.rollbackTaskDefinition(ctx, rollbackedTdArn, opt)
 		}
 		return err
 	}


### PR DESCRIPTION
After StopDelpoyment, CodeDeploy creates a new rollback deployment. The deployment will complated soon, so ecspresso may not find the deployment in progress.
Even in this case, deregistering task definition should be called.

https://github.com/kayac/ecspresso/pull/663#issuecomment-2019608123