### PR TITLE
fix: add missing space between words in run command log messages

### DIFF
--- a/run.go
+++ b/run.go
@@ -252,7 +252,7 @@ func (d *App) taskDefinitionArnForRun(ctx context.Context, opt RunOption) (strin
 		if err != nil {
 			return "", err
 		}
-		d.Log("Revision is not specified. Use latest task definition family" + family)
+		d.Log("Revision is not specified. Use latest task definition family " + family)
 		latestTdArn, err := d.findLatestTaskDefinitionArn(ctx, family)
 		if err != nil {
 			return "", err
@@ -266,7 +266,7 @@ func (d *App) taskDefinitionArnForRun(ctx context.Context, opt RunOption) (strin
 		if rev != "" {
 			return fmt.Sprintf("%s:%s", family, rev), nil
 		}
-		d.Log("Revision is not specified. Use latest task definition family" + family)
+		d.Log("Revision is not specified. Use latest task definition family " + family)
 		latestTdArn, err := d.findLatestTaskDefinitionArn(ctx, family)
 		if err != nil {
 			return "", err


### PR DESCRIPTION
This patch add a missing space between words in log message for `run` command to improve log message more readable.


Before:
```
2024/05/23 09:49:14 bastion/bastion Revision is not specified. Use latest task definition familybastion
```

After:
```
2024/05/23 11:13:18 bastion/bastion Revision is not specified. Use latest task definition family bastion
```