### PR TITLE
--rm-dist has been deprecated in favor of --clean

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -45,7 +45,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v5
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ env.DO_RELEASE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v5
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,10 @@ test:
 	go test -race ./...
 
 packages:
-	goreleaser build --skip-validate --rm-dist
+	goreleaser build --skip-validate --clean
 
 packages-snapshot:
-	goreleaser build --skip-validate --rm-dist --snapshot
+	goreleaser build --skip-validate --clean --snapshot
 
 clean:
 	rm -f cmd/ecspresso/ecspresso


### PR DESCRIPTION
see https://goreleaser.com/deprecations/?h=rm#-rm-dist
it was removed 2024-05-26 (v2.0).