### PR TITLE
Add pidMode mapping to tdToTaskDefinitionInput function

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -183,6 +183,7 @@ func tdToTaskDefinitionInput(td *TaskDefinition, tdTags []types.Tag) *TaskDefini
 		Memory:                  td.Memory,
 		NetworkMode:             td.NetworkMode,
 		PlacementConstraints:    td.PlacementConstraints,
+		PidMode:                 td.PidMode,
 		RequiresCompatibilities: td.RequiresCompatibilities,
 		RuntimePlatform:         td.RuntimePlatform,
 		TaskRoleArn:             td.TaskRoleArn,


### PR DESCRIPTION
When converting remoteTaskDef to TaskDefinitionInput, pidMode is not mapped, causing persistent diffs due to missing information.