### PR TITLE
add disables colorized output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Flags:
       --assume-role-arn=""        the ARN of the role to assume ($ECSPRESSO_ASSUME_ROLE_ARN)
       --timeout=TIMEOUT           timeout. Override in a configuration file ($ECSPRESSO_TIMEOUT).
       --filter-command=STRING     filter command ($ECSPRESSO_FILTER_COMMAND)
+      --no-color                  disables colorized output
 
 Commands:
   appspec

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Flags:
       --assume-role-arn=""        the ARN of the role to assume ($ECSPRESSO_ASSUME_ROLE_ARN)
       --timeout=TIMEOUT           timeout. Override in a configuration file ($ECSPRESSO_TIMEOUT).
       --filter-command=STRING     filter command ($ECSPRESSO_FILTER_COMMAND)
-      --no-color                  disables colorized output
+      --[no-]color                enable colorized output ($ECSPRESSO_COLOR)
 
 Commands:
   appspec

--- a/cli.go
+++ b/cli.go
@@ -16,7 +16,7 @@ type CLIOptions struct {
 	AssumeRoleARN  string            `help:"the ARN of the role to assume" default:"" env:"ECSPRESSO_ASSUME_ROLE_ARN"`
 	Timeout        *time.Duration    `help:"timeout. Override in a configuration file." env:"ECSPRESSO_TIMEOUT"`
 	FilterCommand  string            `help:"filter command" env:"ECSPRESSO_FILTER_COMMAND"`
-	NoColor        bool              `help:"disables colorized output" default:"false"`
+	Color          bool              `help:"enable colorized output" env:"ECSPRESSO_COLOR" default:"true" negatable:""`
 
 	Appspec    *AppSpecOption    `cmd:"" help:"output AppSpec YAML for CodeDeploy to STDOUT"`
 	Delete     *DeleteOption     `cmd:"" help:"delete service"`

--- a/cli.go
+++ b/cli.go
@@ -16,6 +16,7 @@ type CLIOptions struct {
 	AssumeRoleARN  string            `help:"the ARN of the role to assume" default:"" env:"ECSPRESSO_ASSUME_ROLE_ARN"`
 	Timeout        *time.Duration    `help:"timeout. Override in a configuration file." env:"ECSPRESSO_TIMEOUT"`
 	FilterCommand  string            `help:"filter command" env:"ECSPRESSO_FILTER_COMMAND"`
+	NoColor        bool              `help:"disables colorized output" default:"false"`
 
 	Appspec    *AppSpecOption    `cmd:"" help:"output AppSpec YAML for CodeDeploy to STDOUT"`
 	Delete     *DeleteOption     `cmd:"" help:"delete service"`

--- a/cliv2.go
+++ b/cliv2.go
@@ -37,8 +37,6 @@ func ParseCLIv2(args []string) (string, *CLIOptions, func(), error) {
 	if opts.ExtCode == nil {
 		opts.ExtCode = map[string]string{}
 	}
-	if opts.NoColor {
-		color.NoColor = true
-	}
+	color.NoColor = !opts.Color
 	return sub, &opts, func() { c.PrintUsage(true) }, nil
 }

--- a/cliv2.go
+++ b/cliv2.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/alecthomas/kong"
+	"github.com/fatih/color"
 )
 
 func ParseCLIv2(args []string) (string, *CLIOptions, func(), error) {
@@ -35,6 +36,9 @@ func ParseCLIv2(args []string) (string, *CLIOptions, func(), error) {
 	}
 	if opts.ExtCode == nil {
 		opts.ExtCode = map[string]string{}
+	}
+	if opts.NoColor {
+		color.NoColor = true
 	}
 	return sub, &opts, func() { c.PrintUsage(true) }, nil
 }


### PR DESCRIPTION
I want to easily disable terminal formatting sequences when automatically commenting on a PR with the results of ecspresso diff, using tools like [suzuki-shunsuke/github-comment](https://github.com/suzuki-shunsuke/github-comment)."

### colorized
<img width="527" alt="colorized" src="https://github.com/user-attachments/assets/2ff72b6a-659b-4272-967b-db69eac160a8">

### no color
<img width="546" alt="noncolor" src="https://github.com/user-attachments/assets/d035ef82-cc69-4b39-a5f7-72bd21f6bb17">
