### PR TITLE
run --revision and --latest-task-definition are exclusive

### DIFF
--- a/run.go
+++ b/run.go
@@ -238,9 +238,7 @@ func (d *App) taskDefinitionArnForRun(ctx context.Context, opt RunOption) (strin
 	switch {
 	case *opt.Revision > 0:
 		if opt.LatestTaskDefinition {
-			err := ErrConflictOptions("revision and latest-task-definition are exclusive")
-			// TODO: v2.1 raise error
-			d.Log("[WARNING] %s", err)
+			return "", ErrConflictOptions("revision and latest-task-definition are exclusive")
 		}
 		family, _, err := d.resolveTaskdefinition(ctx)
 		if err != nil {

--- a/run_test.go
+++ b/run_test.go
@@ -9,8 +9,6 @@ import (
 	"github.com/kayac/ecspresso/v2"
 )
 
-var v2_1_OrLater = false // TODO: set true if v2.1
-
 type taskDefinitionArnForRunSuite struct {
 	opts     []string
 	td       string
@@ -113,7 +111,7 @@ func TestTaskDefinitionArnForRun(t *testing.T) {
 			}
 			opts := *cliopts.Run
 			tdArn, err := app.TaskDefinitionArnForRun(ctx, opts)
-			if v2_1_OrLater && s.raiseErr {
+			if s.raiseErr {
 				if err == nil {
 					t.Errorf("%s %s expected error, but got nil", config, args)
 				}


### PR DESCRIPTION
- refs https://github.com/kayac/ecspresso/pull/505
  > After v2.1, --latest-task-definition and --revision will raise an error. 