### PR TITLE
Add diff --external. Runs external diff command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -705,6 +705,19 @@ $ ecspresso diff
          "options": {
 ```
 
+v2.4 or later, `ecspresso diff --external` can invoke an external command. You can use the "diff" command you like.
+
+For example, use [difftastic](https://github.com/Wilfred/difftastic) (`difft`) command.
+
+```console
+$ ecspresso diff --external "difft --color=always"
+
+$ ECSPRESSO_DIFF_COMMAND="difft --color=always" ecspresso diff
+```
+
+The command should exit with status 0. If it exits with a non-zero status when two files differ (for example, `diff(1)`), you need to write a wrapper command.
+
+
 #### verify
 
 Verify resources related with service/task definitions.

--- a/cli_test.go
+++ b/cli_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/kayac/ecspresso/v2"
 )
 
@@ -841,7 +842,7 @@ func TestParseCLIv2(t *testing.T) {
 				}
 			}
 			if tt.subOption != nil {
-				if diff := cmp.Diff(opt.ForSubCommand(sub), tt.subOption); diff != "" {
+				if diff := cmp.Diff(opt.ForSubCommand(sub), tt.subOption, cmpopts.IgnoreUnexported(ecspresso.DiffOption{})); diff != "" {
 					t.Errorf("unexpected subOption: diff %s", diff)
 				}
 			}

--- a/deploy.go
+++ b/deploy.go
@@ -112,11 +112,11 @@ func (d *App) Deploy(ctx context.Context, opt DeployOption) error {
 			return err
 		}
 		addedTags, updatedTags, deletedTags := CompareTags(sv.Tags, newSv.Tags)
-		ds, err := diffServices(newSv, sv, d.config.ServiceDefinitionPath, true)
+		differ, err := diffServices(ctx, newSv, sv, d.config.ServiceDefinitionPath, &DiffOption{Unified: true})
 		if err != nil {
 			return fmt.Errorf("failed to diff of service definitions: %w", err)
 		}
-		if ds != "" {
+		if differ {
 			if err = d.UpdateServiceAttributes(ctx, newSv, tdArn, opt); err != nil {
 				return err
 			}

--- a/deploy.go
+++ b/deploy.go
@@ -112,7 +112,7 @@ func (d *App) Deploy(ctx context.Context, opt DeployOption) error {
 			return err
 		}
 		addedTags, updatedTags, deletedTags := CompareTags(sv.Tags, newSv.Tags)
-		differ, err := diffServices(ctx, newSv, sv, d.config.ServiceDefinitionPath, &DiffOption{Unified: true})
+		differ, err := diffServices(ctx, newSv, sv, d.config.ServiceDefinitionPath, &DiffOption{Unified: true, w: os.Stdout})
 		if err != nil {
 			return fmt.Errorf("failed to diff of service definitions: %w", err)
 		}

--- a/diff.go
+++ b/diff.go
@@ -6,6 +6,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -18,15 +22,22 @@ import (
 	"github.com/hexops/gotextdiff/myers"
 	"github.com/hexops/gotextdiff/span"
 	"github.com/kylelemons/godebug/diff"
+	"github.com/mattn/go-shellwords"
 )
 
 type DiffOption struct {
-	Unified bool `help:"unified diff format" default:"true" negatable:""`
+	Unified  bool   `help:"unified diff format" default:"true" negatable:""`
+	External string `help:"external command to format diff" env:"ECSPRESSO_DIFF_COMMAND"`
+
+	w io.Writer `kong:"-"`
 }
 
 func (d *App) Diff(ctx context.Context, opt DiffOption) error {
 	ctx, cancel := d.Start(ctx)
 	defer cancel()
+	if opt.w == nil {
+		opt.w = os.Stdout
+	}
 
 	var remoteTaskDefArn string
 	// diff for services only when service defined
@@ -44,10 +55,8 @@ func (d *App) Diff(ctx context.Context, opt DiffOption) error {
 				return fmt.Errorf("failed to describe service: %w", err)
 			}
 		}
-		if ds, err := diffServices(newSv, remoteSv, d.config.ServiceDefinitionPath, opt.Unified); err != nil {
+		if _, err := diffServices(ctx, newSv, remoteSv, d.config.ServiceDefinitionPath, &opt); err != nil {
 			return err
-		} else if ds != "" {
-			fmt.Print(coloredDiff(ds))
 		}
 		if remoteSv != nil {
 			remoteTaskDefArn = *remoteSv.TaskDefinition
@@ -79,10 +88,8 @@ func (d *App) Diff(ctx context.Context, opt DiffOption) error {
 		}
 	}
 
-	if ds, err := diffTaskDefs(newTd, remoteTd, d.config.TaskDefinitionPath, remoteTaskDefArn, opt.Unified); err != nil {
+	if _, err := diffTaskDefs(ctx, newTd, remoteTd, d.config.TaskDefinitionPath, remoteTaskDefArn, &opt); err != nil {
 		return err
-	} else if ds != "" {
-		fmt.Print(coloredDiff(ds))
 	}
 
 	return nil
@@ -93,7 +100,7 @@ type ServiceForDiff struct {
 	Tags []types.Tag
 }
 
-func diffServices(local, remote *Service, localPath string, unified bool) (string, error) {
+func diffServices(ctx context.Context, local, remote *Service, localPath string, opt *DiffOption) (bool, error) {
 	var remoteArn string
 	if remote != nil {
 		remoteArn = aws.ToString(remote.ServiceArn)
@@ -104,7 +111,7 @@ func diffServices(local, remote *Service, localPath string, unified bool) (strin
 
 	newSvBytes, err := MarshalJSONForAPI(localSvForDiff)
 	if err != nil {
-		return "", fmt.Errorf("failed to marshal new service definition: %w", err)
+		return false, fmt.Errorf("failed to marshal new service definition: %w", err)
 	}
 	if local.DesiredCount == nil && remoteSvForDiff != nil {
 		// ignore DesiredCount when it in local is not defined.
@@ -112,54 +119,114 @@ func diffServices(local, remote *Service, localPath string, unified bool) (strin
 	}
 	remoteSvBytes, err := MarshalJSONForAPI(remoteSvForDiff)
 	if err != nil {
-		return "", fmt.Errorf("failed to marshal remote service definition: %w", err)
+		return false, fmt.Errorf("failed to marshal remote service definition: %w", err)
 	}
 
 	remoteSv := toDiffString(remoteSvBytes)
 	newSv := toDiffString(newSvBytes)
+	if remoteSv == newSv {
+		return false, nil
+	}
 
-	if unified {
+	switch {
+	case opt.External != "":
+		return true, diffExternal(ctx, opt.External, "service", remoteSv, newSv, opt)
+	case opt.Unified:
 		edits := myers.ComputeEdits(span.URIFromPath(remoteArn), remoteSv, newSv)
-		return fmt.Sprint(gotextdiff.ToUnified(remoteArn, localPath, remoteSv, edits)), nil
+		ds := fmt.Sprint(gotextdiff.ToUnified(remoteArn, localPath, remoteSv, edits))
+		fmt.Fprint(opt.w, coloredDiff(ds))
+		return true, nil
+	default:
+		ds := diff.Diff(remoteSv, newSv)
+		fmt.Fprint(opt.w, coloredDiff(fmt.Sprintf("--- %s\n+++ %s\n%s", remoteArn, localPath, ds)))
+		return true, nil
 	}
-
-	ds := diff.Diff(remoteSv, newSv)
-	if ds == "" {
-		return ds, nil
-	}
-	return fmt.Sprintf("--- %s\n+++ %s\n%s", remoteArn, localPath, ds), nil
 }
 
-func diffTaskDefs(local, remote *TaskDefinitionInput, localPath, remoteArn string, unified bool) (string, error) {
+func diffTaskDefs(ctx context.Context, local, remote *TaskDefinitionInput, localPath, remoteArn string, opt *DiffOption) (bool, error) {
 	sortTaskDefinition(local)
 	sortTaskDefinition(remote)
 
 	newTdBytes, err := MarshalJSONForAPI(local)
 	if err != nil {
-		return "", fmt.Errorf("failed to marshal new task definition: %w", err)
+		return false, fmt.Errorf("failed to marshal new task definition: %w", err)
 	}
 
 	remoteTdBytes, err := MarshalJSONForAPI(remote)
 	if err != nil {
-		return "", fmt.Errorf("failed to marshal remote task definition: %w", err)
+		return false, fmt.Errorf("failed to marshal remote task definition: %w", err)
 	}
 
 	remoteTd := toDiffString(remoteTdBytes)
 	newTd := toDiffString(newTdBytes)
+	if remoteTd == newTd {
+		return false, nil
+	}
 
-	if unified {
+	switch {
+	case opt.External != "":
+		return true, diffExternal(ctx, opt.External, "taskdef", remoteTd, newTd, opt)
+	case opt.Unified:
 		edits := myers.ComputeEdits(span.URIFromPath(remoteArn), remoteTd, newTd)
-		return fmt.Sprint(gotextdiff.ToUnified(remoteArn, localPath, remoteTd, edits)), nil
+		ds := fmt.Sprint(gotextdiff.ToUnified(remoteArn, localPath, remoteTd, edits))
+		fmt.Fprint(opt.w, coloredDiff(ds))
+		return true, nil
+	default:
+		ds := diff.Diff(remoteTd, newTd)
+		fmt.Fprint(opt.w, coloredDiff(fmt.Sprintf("--- %s\n+++ %s\n%s", remoteArn, localPath, ds)))
+		return true, nil
 	}
+}
 
-	ds := diff.Diff(remoteTd, newTd)
-	if ds == "" {
-		return ds, nil
+func diffExternal(ctx context.Context, diffCmd string, target, remote, local string, opt *DiffOption) error {
+	args, err := shellwords.Parse(diffCmd)
+	if err != nil {
+		return fmt.Errorf("failed to parse diff command: %w", err)
 	}
-	return fmt.Sprintf("--- %s\n+++ %s\n%s", remoteArn, localPath, ds), nil
+	tmpDir, err := os.MkdirTemp("", "ecspresso-diff-")
+	if err != nil {
+		return fmt.Errorf("failed to create temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	pwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to getwd: %w", err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		return fmt.Errorf("failed to chdir: %w", err)
+	}
+	defer os.Chdir(pwd)
+
+	for _, name := range []string{"remote", "local"} {
+		if err := os.Mkdir(name, 0755); err != nil {
+			return fmt.Errorf("failed to create temp dir: %w", err)
+		}
+	}
+	remoteFile := filepath.Join("remote", target+".json")
+	localFile := filepath.Join("local", target+".json")
+	if err := os.WriteFile(remoteFile, []byte(remote), 0644); err != nil {
+		return fmt.Errorf("failed to write remote file: %w", err)
+	}
+	if err := os.WriteFile(localFile, []byte(local), 0644); err != nil {
+		return fmt.Errorf("failed to write local file: %w", err)
+	}
+	args = append(args, remoteFile, localFile)
+
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	cmd.Stdout = opt.w
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to run diff command: %w", err)
+	}
+	return nil
 }
 
 func coloredDiff(src string) string {
+	if color.NoColor {
+		// disable color
+		return src
+	}
 	var b strings.Builder
 	for _, line := range strings.Split(src, "\n") {
 		if strings.HasPrefix(line, "-") {

--- a/export_test.go
+++ b/export_test.go
@@ -2,6 +2,7 @@ package ecspresso
 
 import (
 	"context"
+	"io"
 	"log"
 
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -48,4 +49,8 @@ func ResetAWSV2ConfigLoadOptionsFunc() {
 
 func (d *App) TaskDefinitionArnForRun(ctx context.Context, opt RunOption) (string, error) {
 	return d.taskDefinitionArnForRun(ctx, opt)
+}
+
+func (opt *DiffOption) SetWriter(w io.Writer) {
+	opt.w = w
 }

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/kayac/go-config v0.7.0
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-isatty v0.0.20
+	github.com/mattn/go-shellwords v1.0.12
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/opencontainers/image-spec v1.1.0
 	github.com/samber/lo v1.46.0

--- a/go.sum
+++ b/go.sum
@@ -275,6 +275,8 @@ github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh
 github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
 github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/mattn/go-shellwords v1.0.12 h1:M2zGm7EW6UQJvDeQxo4T51eKPurbeFbe8WtebGE2xrk=
+github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/mattn/goveralls v0.0.9/go.mod h1:FRbM1PS8oVsOe9JtdzAAXM+DsvDMMHcM1C7drGJD8HY=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2EmQ4l5rM/4FEfDWcRD+abF5XlKShorW5LRoQ=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=


### PR DESCRIPTION
Add `--external` option to `diff` command.

`ecspresso diff` invokes the external command with two arguments, "remote" and "local" resource files that are rendered.

The command should exit with status 0. You need to write a wrapper command if it exits with a non-zero status when two files differ (for example, `diff (1)`).


```console
$ ecspresso diff --external="difft --color=always"

$ ECSPRESSO_DIFF="difft --color=always"
```

