### PR TITLE
Add ignore.tags into a configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,9 @@ cluster: default
 service: myservice
 task_definition: taskdef.json
 timeout: 5m # default 10m
+ignore:
+  tags:
+    - ecspresso:ignore # ignore tags of service and task definition
 ```
 
 `ecspresso deploy` works as below.

--- a/cli.go
+++ b/cli.go
@@ -143,7 +143,7 @@ func dispatchCLI(ctx context.Context, sub string, usage func(), opts *CLIOptions
 	case "deregister":
 		return app.Deregister(ctx, *opts.Deregister)
 	case "revisions":
-		return app.Revesions(ctx, *opts.Revisions)
+		return app.Revisions(ctx, *opts.Revisions)
 	case "init":
 		return app.Init(ctx, *opts.Init)
 	case "diff":

--- a/config.go
+++ b/config.go
@@ -237,6 +237,11 @@ type ConfigIgnore struct {
 	Tags []string `yaml:"tags,omitempty" json:"tags,omitempty"`
 }
 
+type hasTags interface {
+	GetTags() []types.Tag
+	SetTags([]types.Tag)
+}
+
 func (i *ConfigIgnore) filterTags(tags []types.Tag) []types.Tag {
 	if i == nil || len(i.Tags) == 0 {
 		return tags
@@ -246,12 +251,7 @@ func (i *ConfigIgnore) filterTags(tags []types.Tag) []types.Tag {
 	})
 }
 
-func (i *ConfigIgnore) ApplyService(sv *Service) error {
-	sv.Tags = i.filterTags(sv.Tags)
-	return nil
-}
-
-func (i *ConfigIgnore) ApplyTaskDefinitionInput(in *TaskDefinitionInput) error {
-	in.Tags = i.filterTags(in.Tags)
+func (i *ConfigIgnore) Apply(v hasTags) error {
+	v.SetTags(i.filterTags(v.GetTags()))
 	return nil
 }

--- a/config_test.go
+++ b/config_test.go
@@ -82,7 +82,9 @@ func TestLoadConfigWithPluginDuplicate(t *testing.T) {
 
 func TestLoadConfigWithPlugin(t *testing.T) {
 	for _, ext := range []string{".yml", ".yaml", ".json", ".jsonnet"} {
-		testLoadConfigWithPlugin(t, "tests/ecspresso"+ext)
+		t.Run("tests/ecspresso"+ext, func(t *testing.T) {
+			testLoadConfigWithPlugin(t, "tests/ecspresso"+ext)
+		})
 	}
 }
 
@@ -107,7 +109,7 @@ func testLoadConfigWithPlugin(t *testing.T, path string) {
 	if err != nil {
 		t.Error(err)
 	}
-	t.Log(svd)
+	t.Log(str(svd))
 	sgID := svd.NetworkConfiguration.AwsvpcConfiguration.SecurityGroups[0]
 	subnetID := svd.NetworkConfiguration.AwsvpcConfiguration.Subnets[0]
 	if sgID != "sg-12345678" {
@@ -124,17 +126,17 @@ func testLoadConfigWithPlugin(t *testing.T, path string) {
 		t.Errorf("unexpected deploymentCircuitBreaker.rollback got:%v", cb.Rollback)
 	}
 	if len(svd.Tags) != 1 {
-		t.Errorf("unexpected tags got:%v", svd.Tags)
+		t.Errorf("unexpected tags got:%s", str(svd.Tags))
 	}
 	if tag := svd.Tags[0]; *tag.Key != "Name" || *tag.Value != "test" {
-		t.Errorf("unexpected tag got:%v", t)
+		t.Errorf("unexpected tag got:%s", str(tag))
 	}
 
 	td, err := app.LoadTaskDefinition(conf.TaskDefinitionPath)
 	if err != nil {
 		t.Error(err)
 	}
-	t.Log(td)
+	t.Log(str(td))
 	image := *td.ContainerDefinitions[0].Image
 	if image != "123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/app:testing" {
 		t.Errorf("unexpected image got:%s", image)
@@ -144,10 +146,10 @@ func testLoadConfigWithPlugin(t *testing.T, path string) {
 		t.Errorf("unexpected JSON got:%s", *env.Value)
 	}
 	if len(td.Tags) != 1 {
-		t.Errorf("unexpected tags got:%v", td.Tags)
+		t.Errorf("unexpected tags got:%s", str(td.Tags))
 	}
 	if tag := td.Tags[0]; *tag.Key != "Name" || *tag.Value != "test" {
-		t.Errorf("unexpected tag got:%v", t)
+		t.Errorf("unexpected tag got:%s", str(tag))
 	}
 }
 
@@ -376,6 +378,17 @@ var ConfigIgnoreTests = []struct {
 		expectedTags: []types.Tag{
 			{Key: ptr("foo"), Value: ptr("x")},
 			{Key: ptr("bar"), Value: ptr("y")},
+		},
+	},
+	{
+		name:   "ignore case sensitive",
+		ignore: &ecspresso.ConfigIgnore{Tags: []string{"Foo"}},
+		resourceTags: []types.Tag{
+			{Key: ptr("foo"), Value: ptr("x")},
+			{Key: ptr("Foo"), Value: ptr("y")},
+		},
+		expectedTags: []types.Tag{
+			{Key: ptr("foo"), Value: ptr("x")},
 		},
 	},
 }

--- a/diff.go
+++ b/diff.go
@@ -79,7 +79,7 @@ func (d *App) Diff(ctx context.Context, opt DiffOption) error {
 		}
 		remoteTaskDefArn = arn
 	}
-	var remoteTd *ecs.RegisterTaskDefinitionInput
+	var remoteTd *TaskDefinitionInput
 	if remoteTaskDefArn != "" {
 		d.Log("[DEBUG] diff task definition compare with %s", remoteTaskDefArn)
 		remoteTd, err = d.DescribeTaskDefinition(ctx, remoteTaskDefArn)

--- a/ecspresso_test.go
+++ b/ecspresso_test.go
@@ -2,6 +2,7 @@ package ecspresso_test
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/kayac/ecspresso/v2"
@@ -9,6 +10,14 @@ import (
 
 func ptr[T any](v T) *T {
 	return &v
+}
+
+func str[T any](v T) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
 }
 
 func TestLoadTaskDefinition(t *testing.T) {

--- a/export_test.go
+++ b/export_test.go
@@ -6,6 +6,7 @@ import (
 	"log"
 
 	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
 )
 
 var (
@@ -53,4 +54,8 @@ func (d *App) TaskDefinitionArnForRun(ctx context.Context, opt RunOption) (strin
 
 func (opt *DiffOption) SetWriter(w io.Writer) {
 	opt.w = w
+}
+
+func (i *ConfigIgnore) FilterTags(tags []types.Tag) []types.Tag {
+	return i.filterTags(tags)
 }

--- a/json_test.go
+++ b/json_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/kayac/ecspresso/v2"
 )
 
-type testJSONStruct = struct {
+type testJSONStruct struct {
 	FooBarBaz string
 	Options   map[string]string
 	Nested    struct {

--- a/revisions.go
+++ b/revisions.go
@@ -69,7 +69,7 @@ func (revs revisions) OutputTable(w io.Writer) error {
 	return nil
 }
 
-func (d *App) Revesions(ctx context.Context, opt RevisionsOption) error {
+func (d *App) Revisions(ctx context.Context, opt RevisionsOption) error {
 	ctx, cancel := d.Start(ctx)
 	defer cancel()
 

--- a/tests/ci/ecs-service-def.jsonnet
+++ b/tests/ci/ecs-service-def.jsonnet
@@ -65,6 +65,10 @@ local isCodeDeploy = env('DEPLOYMENT_CONTROLLER', 'ECS') == 'CODE_DEPLOY';
       key: 'cluster',
       value: 'ecspresso-test',
     },
+    {
+      key: 'cost-category',
+      value: 'ecspresso-test',
+    },
   ],
   volumeConfigurations: if isCodeDeploy then null else [
     {

--- a/tests/ci/ecs-task-def.jsonnet
+++ b/tests/ci/ecs-task-def.jsonnet
@@ -130,6 +130,10 @@ local isCodeDeploy = env('DEPLOYMENT_CONTROLLER', 'ECS') == 'CODE_DEPLOY';
       key: 'TaskType',
       value: 'ecspresso-test',
     },
+    {
+      key: 'cost-category',
+      value: 'ecspresso-test',
+    },
   ],
   taskRoleArn: 'arn:aws:iam::{{must_env `AWS_ACCOUNT_ID`}}:role/ecsTaskRole',
   volumes: if isCodeDeploy then null else [

--- a/tests/ci/ecspresso.yml
+++ b/tests/ci/ecspresso.yml
@@ -4,6 +4,9 @@ service: "{{ must_env `SERVICE` }}"
 service_definition: ecs-service-def.jsonnet
 task_definition: ecs-task-def.jsonnet
 timeout: 20m0s
+ignore:
+  tags:
+    - cost-category
 plugins:
   - name: tfstate
     config:

--- a/tests/config_abs.yaml
+++ b/tests/config_abs.yaml
@@ -8,3 +8,6 @@ plugins:
   - name: tfstate
     config:
       path: '{{ must_env "PWD" }}/tests/terraform.tfstate'
+ignore:
+  tags:
+    - ecspresso:ignore

--- a/tests/config_multiple_plugins.yaml
+++ b/tests/config_multiple_plugins.yaml
@@ -12,3 +12,6 @@ plugins:
   - name: tfstate
     config:
       path: '{{ must_env "PWD" }}/tests/terraform.tfstate'
+ignore:
+  tags:
+    - ecspresso:ignore

--- a/tests/ecs-service-def.json
+++ b/tests/ecs-service-def.json
@@ -25,5 +25,15 @@
       ],
       "assignPublicIp": "ENABLED"
     }
-  }
+  },
+  "tags": [
+    {
+      "key": "Name",
+      "value": "test"
+    },
+    {
+      "key": "ecspresso:ignore",
+      "value": "true"
+    }
+  ]
 }

--- a/tests/ecs-task-def-multiple-plugins.json
+++ b/tests/ecs-task-def-multiple-plugins.json
@@ -28,5 +28,15 @@
   "family": "app",
   "requiresCompatibilities": [
     "EC2"
+  ],
+  "tags": [
+    {
+      "key": "Name",
+      "value": "test"
+    },
+    {
+      "key": "ecspresso:ignore",
+      "value": "true"
+    }
   ]
 }

--- a/tests/ecs-task-def.json
+++ b/tests/ecs-task-def.json
@@ -24,5 +24,15 @@
   "family": "app",
   "requiresCompatibilities": [
     "EC2"
+  ],
+  "tags": [
+    {
+      "key": "Name",
+      "value": "test"
+    },
+    {
+      "key": "ecspresso:ignore",
+      "value": "true"
+    }
   ]
 }

--- a/tests/ecspresso.json
+++ b/tests/ecspresso.json
@@ -5,6 +5,11 @@
   "service_definition": "ecs-service-def.json",
   "task_definition": "ecs-task-def.json",
   "timeout": "10m0s",
+  "ignore": {
+    "tags": [
+      "ecspresso:ignore"
+    ]
+  },
   "plugins": [
     {
       "name": "tfstate",

--- a/tests/ecspresso.jsonnet
+++ b/tests/ecspresso.jsonnet
@@ -6,6 +6,11 @@ local must_env = std.native('must_env');
   service_definition: 'ecs-service-def.json',
   task_definition: 'ecs-task-def.json',
   timeout: '10m0s',
+  ignore: {
+    tags: [
+      'ecspresso:ignore',
+    ],
+  },
   plugins: [
     {
       name: 'tfstate',

--- a/tests/ecspresso.yml
+++ b/tests/ecspresso.yml
@@ -8,3 +8,6 @@ plugins:
   - name: tfstate
     config:
       path: terraform.tfstate
+ignore:
+  tags:
+    - ecspresso:ignore

--- a/verify.go
+++ b/verify.go
@@ -535,7 +535,7 @@ func (d *App) verifyImage(ctx context.Context, image string) error {
 	return d.verifyRegistryImage(ctx, image, "", "")
 }
 
-func (d *App) verifyContainer(ctx context.Context, c *types.ContainerDefinition, td *ecs.RegisterTaskDefinitionInput) error {
+func (d *App) verifyContainer(ctx context.Context, c *types.ContainerDefinition, td *TaskDefinitionInput) error {
 	image := aws.ToString(c.Image)
 	name := fmt.Sprintf("Image[%s]", image)
 	err := verifyResource(ctx, name, func(ctx context.Context) error {


### PR DESCRIPTION
refs #726 

This PR adds `ignore.tags` into a configuration.

For example, set "ecspresso:ignore" to `ignore.tags` as below,

```yaml
ignore:
  tags:
    - ecspresso:ignore # ignore tags of service and task definition
```

ecspresso ignores the tag that the key equals "ecspresso:ignore" of ECS services and task definitions.

Even if the tag exists in definition files or resources in ECS, ecspresso does not edit the tags.

This is useful for managing some tags with other tools.
