### PR TITLE
fix null pointer exception

### DIFF
--- a/run.go
+++ b/run.go
@@ -68,7 +68,7 @@ func (d *App) Run(ctx context.Context, opt RunOption) error {
 		return err
 	}
 	if tdForRun.Arn == "" && tdForRun.TaskDefinitionInput != nil {
-		d.Log("Task definition family %s will be registered", *tdForRun.TaskDefinitionInput.Family)
+		d.Log("Task definition family %s will be registered", aws.ToString(tdForRun.TaskDefinitionInput.Family))
 	} else {
 		d.Log("Task definition ARN: %s", tdForRun.Arn)
 		var err error

--- a/run_test.go
+++ b/run_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/smithy-go/middleware"
 	"github.com/kayac/ecspresso/v2"
@@ -131,7 +132,7 @@ func TestTaskDefinitionArnForRun(t *testing.T) {
 					t.Errorf("%s %s expected %s, got %s", config, args, s.arn, name)
 				}
 			} else {
-				family := *td.TaskDefinitionInput.Family
+				family := aws.ToString(td.TaskDefinitionInput.Family)
 				if family != s.family {
 					t.Errorf("%s %s expected %s, got %s", config, args, s.family, family)
 				}

--- a/tests/td-in-tags.json
+++ b/tests/td-in-tags.json
@@ -55,7 +55,6 @@
         "volumesFrom": []
       }
     ],
-    "revision": 1,
     "cpu": "1024",
     "memory": "2048",
     "proxyConfiguration": {

--- a/tests/td-plain-in-tags.json
+++ b/tests/td-plain-in-tags.json
@@ -54,7 +54,6 @@
       "volumesFrom": []
     }
   ],
-  "revision": 1,
   "cpu": "1024",
   "memory": "2048",
   "proxyConfiguration": {

--- a/tests/td-plain.json
+++ b/tests/td-plain.json
@@ -54,7 +54,6 @@
       "volumesFrom": []
     }
   ],
-  "revision": 1,
   "cpu": "1024",
   "memory": "2048",
   "proxyConfiguration": {


### PR DESCRIPTION
Fix: If `family` is not defined in a task definition, `ecspresso run` raised a panic.