### PR TITLE
Update aws-sdk-go-v2/service/ecs to v1.51.0 and go mod tidy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.37.3
 	github.com/aws/aws-sdk-go-v2/service/codedeploy v1.27.3
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.31.0
-	github.com/aws/aws-sdk-go-v2/service/ecs v1.50.0
+	github.com/aws/aws-sdk-go-v2/service/ecs v1.51.0
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.34.0
 	github.com/aws/aws-sdk-go-v2/service/iam v1.34.3
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.58.3
@@ -20,6 +20,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.31.3
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.52.3
 	github.com/aws/aws-sdk-go-v2/service/sts v1.30.3
+	github.com/aws/aws-sdk-go-v2/service/vpclattice v1.12.7
 	github.com/aws/smithy-go v1.22.1
 	github.com/fatih/color v1.16.0
 	github.com/fujiwara/cfn-lookup v1.1.0
@@ -82,7 +83,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sns v1.26.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.22.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.26.4 // indirect
-	github.com/aws/aws-sdk-go-v2/service/vpclattice v1.12.7 // indirect
 	github.com/creack/pty v1.1.20 // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,8 @@ github.com/aws/aws-sdk-go-v2/service/codedeploy v1.27.3 h1:MSA1lrc/3I1rDQtLKmCe0
 github.com/aws/aws-sdk-go-v2/service/codedeploy v1.27.3/go.mod h1:Zqk3aokH+BfnsAfJl10gz9zWU3TC28e5rR5N/U7yYDk=
 github.com/aws/aws-sdk-go-v2/service/ecr v1.31.0 h1:vi/MwojjLGATEEUFn2GEdLiom7CFlB+qCIx4tDWqKfQ=
 github.com/aws/aws-sdk-go-v2/service/ecr v1.31.0/go.mod h1:RhaP7Wil0+uuuhiE4FzOOEFZwkmFAk1ZflXzK+O3ptU=
-github.com/aws/aws-sdk-go-v2/service/ecs v1.50.0 h1:NW+6/MPclDxOWcuZZxIJSMt6cVPWVojmJ4R3HsICCsI=
-github.com/aws/aws-sdk-go-v2/service/ecs v1.50.0/go.mod h1:dPTOvmjJQ1T7Q+2+Xs2KSPrMvx+p0rpyV+HsQVnUK4o=
+github.com/aws/aws-sdk-go-v2/service/ecs v1.51.0 h1:epdVcxw2YDc4sx0b8aH89zMrxENOnDPktkEAmBCrTkc=
+github.com/aws/aws-sdk-go-v2/service/ecs v1.51.0/go.mod h1:dPTOvmjJQ1T7Q+2+Xs2KSPrMvx+p0rpyV+HsQVnUK4o=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.34.0 h1:8rDRtPOu3ax8jEctw7G926JQlnFdhZZA4KJzQ+4ks3Q=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.34.0/go.mod h1:L5bVuO4PeXuDuMYZfL3IW69E6mz6PDCYpp6IKDlcLMA=
 github.com/aws/aws-sdk-go-v2/service/iam v1.34.3 h1:p4L/tixJ3JUIxCteMGT6oMlqCbEv/EzSZoVwdiib8sU=


### PR DESCRIPTION
Update the SDK to latest in order to use `versionConsistency` in TaskDefinition.

It was introduced in v1.51.0.

https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ecs@v1.51.0/types#VersionConsistency


cf. `versionConsistency` was just released in 2024-11-19. Details:
https://aws.amazon.com/jp/about-aws/whats-new/2024/11/amazon-ecs-configure-software-version-consistency/