### PR TITLE
remove healthCheckGracePeriodSeconds validation

### DIFF
--- a/verify.go
+++ b/verify.go
@@ -353,9 +353,6 @@ func (d *App) verifyServiceDefinition(ctx context.Context) error {
 			return err
 		}
 	}
-	if len(sv.LoadBalancers) == 0 && sv.HealthCheckGracePeriodSeconds != nil {
-		return errors.New("service has no load balancers, but healthCheckGracePeriodSeconds is defined")
-	}
 
 	for i, vc := range sv.VolumeConfigurations {
 		name := fmt.Sprintf("VolumeConfigurations[%d]", i)


### PR DESCRIPTION
# Problem
When running ECS services without load balancers, `ecspresso verify` fails if `healthCheckGracePeriodSeconds` is defined in the service definition. However, AWS ECS automatically adds this field (with value `0`) to all services, making this validation unnecessary.

# Current Behavior
```jsonnet
// Service definition without healthCheckGracePeriodSeconds
{
  "availabilityZoneRebalancing": "ENABLED",
  "desiredCount": 1,
  "launchType": "FARGATE",
  "networkConfiguration": {
    "awsvpcConfiguration": {
      "assignPublicIp": "ENABLED",
      "securityGroups": [
        "sg-xxxxxxxx"
      ],
      "subnets": [
        "subnet-aaaaaa",
        "subnet-cccccc"
      ]
    }
  },
  "platformVersion": "LATEST",
  "healthCheckGracePeriodSeconds": 1,
  "propagateTags": "NONE"
}
```

```
$ ecspresso diff
-  "healthCheckGracePeriodSeconds": 0,
```

```
$ aws ecs describe-services --cluster test --services test | grep health
            "healthCheckGracePeriodSeconds": 0,
```

When adding the field to match AWS's behavior:

```jsonnet
{
  "healthCheckGracePeriodSeconds": 0,
  "desiredCount": 1,
  // ... rest of service definition
}
```

`ecspresso verify` fails:

```
$ ecspresso verify
2025/02/17 03:50:37 test Starting verify
  TaskDefinition
    ExecutionRole[arn:aws:iam::012345678912:role/ecsTaskExecutionRole]
    --> [OK]
    ContainerDefinition[test]
      Image[redis]
      --> [OK]
      LogConfiguration[awslogs]
      --> [OK]
    --> [OK]
  --> [OK]
  ServiceDefinition
  --> [NG] service has no load balancers, but healthCheckGracePeriodSeconds is defined
```

# Solution
Remove the validation check for healthCheckGracePeriodSeconds because:

1. ECS adds this field by default with value 0
2. Having this field is valid for services without load balancers
3. The current validation causes unnecessary friction