### PR TITLE
fix: add support for AWS China ECR URLs

### DIFF
--- a/verify.go
+++ b/verify.go
@@ -466,7 +466,7 @@ func (d *App) verifyTaskDefinition(ctx context.Context) error {
 
 var (
 	// e.g. {aws_account_id}.dkr.ecr.{region}.amazonaws.com/amazonlinux:latest
-	ecrImageURLRegex = regexp.MustCompile(`^([0-9]+)\.dkr\.ecr\.([0-9a-zA-Z-]+)\.amazonaws\.com/.*`)
+	ecrImageURLRegex = regexp.MustCompile(`^([0-9]+)\.dkr\.ecr\.([0-9a-zA-Z-]+)\.amazonaws\.com(?:\.cn)?\/.*`)
 )
 
 func (d *App) verifyECRImage(ctx context.Context, image, region string) error {


### PR DESCRIPTION
**Context**

The current regex in [verify.go#L469](https://github.com/kayac/ecspresso/blob/6db523858ff437cb833d75e7b14d1ba2c3f78de8/verify.go#L469) does not support AWS China ECR URLs, which use .cn in the domain (e.g., amazonaws.com.cn). This affects the `ecspresso verify` command, preventing it from correctly validating ECR image URLs in China regions.

**Change**

- Updated the regex to make .cn optional using a non-capturing group.
- Ensures correct parsing of both global AWS ECR and China AWS ECR URLs.

**Impact**

- Adds China regions support to `ecspresso verify` without breaking existing functionality.

Please review! 🚀