### PR TITLE
Pin external actions to mitigate supply chain attacks

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -15,7 +15,7 @@ jobs:
     name: test action
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: kayac/ecspresso@v0
         with:
           version: v1.5.0
@@ -70,7 +70,7 @@ jobs:
     name: test action
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: kayac/ecspresso@v2-action-testing
         with:
           version: latest

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5
         with:
           go-version: "1.24"
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           ref: v2
           fetch-depth: 0 # it is required for the changelog to work correctly.
@@ -42,7 +42,7 @@ jobs:
           fi
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@90a3faa9d0182683851fbfa97ca1a2cb983bfca3 # v6
         with:
           version: latest
           args: release --clean

--- a/.github/workflows/tagpr-release.yml
+++ b/.github/workflows/tagpr-release.yml
@@ -19,26 +19,26 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           ref: ${{ inputs.tag || github.ref }}
       - name: Get current branch
         run: |
           git checkout v2
           git symbolic-ref --short HEAD
-      - uses: Songmu/tagpr@v1
+      - uses: Songmu/tagpr@e89d37247ca73d3e5620bf074a53fbd5b39e66b0 # v1
         id: tagpr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ github.event_name != 'workflow_dispatch' }} # skip on workflow_dispatch
       # after tagpr adds a release tag, or workflow_dispatch, release it
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5
         with:
           go-version: "1.23"
         if: ${{ steps.tagpr.outputs.tag != '' || github.event_name == 'workflow_dispatch' }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@90a3faa9d0182683851fbfa97ca1a2cb983bfca3 # v6
         with:
           version: '~> v2'
           args: release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5
         with:
           go-version: ${{ matrix.go }}
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Build & Test
         run: |


### PR DESCRIPTION
Related Refs:
 - https://github.com/advisories/GHSA-mrrh-fwg8-r2c3
 - https://www.wiz.io/blog/new-github-action-supply-chain-attack-reviewdog-action-setup

The recent CVE appears to have been a supply chain attack via reviewdog. Given the current global trend of increasing supply chain attacks, we will take this opportunity to implement countermeasures. Specifically, we will pin the following external actions in GitHub Actions:

```
Replaced uses:
  - actions/checkout@v4 -> 11bd71901bbe5b1630ceea73d27597364c9af683
  - actions/setup-go@v5 -> f111f3307d8850f501ac008e886eec1fd1932a34
  - goreleaser/goreleaser-action@v6 -> 90a3faa9d0182683851fbfa97ca1a2cb983bfca3
  - Songmu/tagpr@v1 -> e89d37247ca73d3e5620bf074a53fbd5b39e66b0

Replaced files:
  - .github/workflows/action.yml
  - .github/workflows/nightly.yml
  - .github/workflows/tagpr-release.yml
  - .github/workflows/test.yml
```
