### PR TITLE
Add deployment_config_name to config of CodeDeploy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ Important notes:
 codedeploy:
   application_name: myapp
   deployment_group_name: mydeployment
+  deployment_config_name: myDeploymentConfig # optional, override DeploymentGroup setting
 ```
 
 `ecspresso deploy` creates a new deployment for CodeDeploy, and it continues on CodeDeploy.

--- a/config.go
+++ b/config.go
@@ -73,8 +73,9 @@ type Config struct {
 }
 
 type ConfigCodeDeploy struct {
-	ApplicationName     string `yaml:"application_name,omitempty" json:"application_name,omitempty"`
-	DeploymentGroupName string `yaml:"deployment_group_name,omitempty" json:"deployment_group_name,omitempty"`
+	ApplicationName      string `yaml:"application_name,omitempty" json:"application_name,omitempty"`
+	DeploymentGroupName  string `yaml:"deployment_group_name,omitempty" json:"deployment_group_name,omitempty"`
+	DeploymentConfigName string `yaml:"deployment_config_name,omitempty" json:"deployment_config_name,omitempty"`
 }
 
 // Load loads configuration file from file path.

--- a/config_test.go
+++ b/config_test.go
@@ -308,10 +308,13 @@ func TestLoadConfigForCodeDeploy(t *testing.T) {
 			t.Error(err)
 		}
 		if conf.CodeDeploy.ApplicationName != "myapp" {
-			t.Errorf("expected application name, but %v", conf.CodeDeploy.ApplicationName)
+			t.Errorf("expected application name=myapp, but %v", conf.CodeDeploy.ApplicationName)
 		}
 		if conf.CodeDeploy.DeploymentGroupName != "mydeployment" {
-			t.Errorf("expected deployment group name, but %v", conf.CodeDeploy.DeploymentGroupName)
+			t.Errorf("expected deployment group name=mydeployment, but %v", conf.CodeDeploy.DeploymentGroupName)
+		}
+		if conf.CodeDeploy.DeploymentConfigName != "myConfigName" {
+			t.Errorf("expected deployment config name=myConfigName, but %v", conf.CodeDeploy.DeploymentConfigName)
 		}
 	}
 }

--- a/deploy.go
+++ b/deploy.go
@@ -306,7 +306,7 @@ func (d *App) findDeploymentInfo(ctx context.Context) (*cdTypes.DeploymentInfo, 
 			for _, ecsService := range dg.EcsServices {
 				if *ecsService.ClusterName == d.config.Cluster && *ecsService.ServiceName == d.config.Service {
 					var configName *string
-					if d.config.CodeDeploy.DeploymentConfigName != "" {
+					if d.config.CodeDeploy != nil && d.config.CodeDeploy.DeploymentConfigName != "" {
 						configName = aws.String(d.config.CodeDeploy.DeploymentConfigName)
 					} else {
 						configName = dg.DeploymentConfigName

--- a/deploy.go
+++ b/deploy.go
@@ -305,10 +305,16 @@ func (d *App) findDeploymentInfo(ctx context.Context) (*cdTypes.DeploymentInfo, 
 			d.LogJSON(dg)
 			for _, ecsService := range dg.EcsServices {
 				if *ecsService.ClusterName == d.config.Cluster && *ecsService.ServiceName == d.config.Service {
+					var configName *string
+					if d.config.CodeDeploy.DeploymentConfigName != "" {
+						configName = aws.String(d.config.CodeDeploy.DeploymentConfigName)
+					} else {
+						configName = dg.DeploymentConfigName
+					}
 					return &cdTypes.DeploymentInfo{
 						ApplicationName:      app.ApplicationName,
 						DeploymentGroupName:  dg.DeploymentGroupName,
-						DeploymentConfigName: dg.DeploymentConfigName,
+						DeploymentConfigName: configName,
 					}, nil
 				}
 			}

--- a/tests/config_codedeploy.json
+++ b/tests/config_codedeploy.json
@@ -5,6 +5,7 @@
   "task_definition": "ecs-task-def.json",
   "codedeploy": {
     "application_name": "myapp",
-    "deployment_group_name": "mydeployment"
+    "deployment_group_name": "mydeployment",
+    "deployment_config_name": "myConfigName"
   }
 }

--- a/tests/config_codedeploy.jsonnet
+++ b/tests/config_codedeploy.jsonnet
@@ -6,5 +6,6 @@
   codedeploy: {
     application_name: 'myapp',
     deployment_group_name: 'mydeployment',
+    deployment_config_name: 'myConfigName',
   },
 }

--- a/tests/config_codedeploy.yml
+++ b/tests/config_codedeploy.yml
@@ -5,3 +5,4 @@ task_definition: ecs-task-def.json
 codedeploy:
   application_name: myapp
   deployment_group_name: mydeployment
+  deployment_config_name: myConfigName


### PR DESCRIPTION
refs
- #827 

---

This pull request introduces support for specifying a custom `DeploymentConfigName` in the CodeDeploy configuration. The changes include updates to the configuration structure, documentation, testing, and deployment logic to accommodate this new optional field.

### Enhancements to CodeDeploy Configuration:

* **`README.md`**: Updated documentation to include the new `deployment_config_name` field, specifying that it is optional and can override the DeploymentGroup setting.
* **`config.go`**: Added `DeploymentConfigName` as a new field in the `ConfigCodeDeploy` struct to allow users to specify a custom deployment configuration.

### Testing Improvements:

* **`config_test.go`**: Enhanced the `TestLoadConfigForCodeDeploy` test to validate the new `DeploymentConfigName` field, ensuring it is correctly loaded and verified.

### Deployment Logic Updates:

* **`deploy.go`**: Modified the `findDeploymentInfo` function to prioritize the user-specified `DeploymentConfigName` if provided; otherwise, it falls back to the default value from the DeploymentGroup.