### PR TITLE
Add JSON format support for logs and outputs

### DIFF
--- a/appspec.go
+++ b/appspec.go
@@ -52,6 +52,6 @@ func (d *App) AppSpec(ctx context.Context, opt AppSpecOption) error {
 		spec.Hooks = d.config.AppSpec.Hooks
 	}
 
-	fmt.Print(spec.String())
-	return nil
+	_, err = WriteOutput(spec)
+	return err
 }

--- a/appspec/spec.go
+++ b/appspec/spec.go
@@ -1,6 +1,7 @@
 package appspec
 
 import (
+	"encoding/json"
 	"errors"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -27,6 +28,11 @@ func New() *AppSpec {
 
 func (a *AppSpec) String() string {
 	b, _ := yaml.Marshal(a)
+	return string(b)
+}
+
+func (a *AppSpec) JSON() string {
+	b, _ := json.Marshal(a)
 	return string(b)
 }
 

--- a/cli.go
+++ b/cli.go
@@ -3,6 +3,7 @@ package ecspresso
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"time"
 )
@@ -17,6 +18,7 @@ type CLIOptions struct {
 	Timeout        *time.Duration    `help:"timeout. Override in a configuration file." env:"ECSPRESSO_TIMEOUT"`
 	FilterCommand  string            `help:"filter command" env:"ECSPRESSO_FILTER_COMMAND"`
 	Color          bool              `help:"enable colorized output" env:"ECSPRESSO_COLOR" default:"true" negatable:""`
+	LogFormat      string            `help:"log format" env:"ECSPRESSO_LOG_FORMAT" default:"text" enum:"text,json"`
 
 	Appspec    *AppSpecOption    `cmd:"" help:"output AppSpec YAML for CodeDeploy to STDOUT"`
 	Delete     *DeleteOption     `cmd:"" help:"delete service"`
@@ -171,6 +173,14 @@ func CLI(ctx context.Context, parse CLIParseFunc) (int, error) {
 	if err != nil {
 		return 1, err
 	}
+	// set log format and level
+	setLogFormat(opts.LogFormat)
+	if opts.Debug {
+		logLevel.Set(slog.LevelDebug)
+	} else {
+		logLevel.Set(slog.LevelInfo)
+	}
+
 	if err := dispatchCLI(ctx, sub, usage, opts); err != nil {
 		return 1, err
 	}

--- a/cli.go
+++ b/cli.go
@@ -105,8 +105,8 @@ func (opts *CLIOptions) ForSubCommand(sub string) interface{} {
 func dispatchCLI(ctx context.Context, sub string, usage func(), opts *CLIOptions) error {
 	switch sub {
 	case "version", "":
-		fmt.Println("ecspresso", Version)
-		return nil
+		_, err := WriteOutput("ecspresso " + Version)
+		return err
 	}
 	var appOpts []AppOption
 	if sub == "init" {

--- a/cli_test.go
+++ b/cli_test.go
@@ -611,7 +611,7 @@ var cliTests = []struct {
 		sub:  "revisions",
 		subOption: &ecspresso.RevisionsOption{
 			Revision: "",
-			Output:   "",
+			Output:   "table",
 		},
 	},
 	{

--- a/cli_test.go
+++ b/cli_test.go
@@ -611,7 +611,7 @@ var cliTests = []struct {
 		sub:  "revisions",
 		subOption: &ecspresso.RevisionsOption{
 			Revision: "",
-			Output:   "table",
+			Output:   "",
 		},
 	},
 	{

--- a/create.go
+++ b/create.go
@@ -30,9 +30,9 @@ func (d *App) createService(ctx context.Context, opt DeployOption) error {
 
 	if opt.DryRun {
 		d.LogInfo("task definition:")
-		d.OutputJSONForAPI(os.Stderr, td)
+		OutputJSONForAPI(os.Stdout, td)
 		d.LogInfo("service definition:")
-		d.OutputJSONForAPI(os.Stderr, svd)
+		OutputJSONForAPI(os.Stdout, svd)
 		d.LogInfo("DRY RUN OK")
 		return nil
 	}

--- a/deploy.go
+++ b/deploy.go
@@ -565,7 +565,7 @@ func (d *App) taskDefinitionArnForDeploy(ctx context.Context, sv *Service, opt D
 
 	if opt.DryRun {
 		d.LogInfo("task definition:")
-		d.OutputJSONForAPI(os.Stderr, td)
+		OutputJSONForAPI(os.Stdout, td)
 		return "", nil
 	}
 

--- a/diff.go
+++ b/diff.go
@@ -36,7 +36,7 @@ func (d *App) Diff(ctx context.Context, opt DiffOption) error {
 	ctx, cancel := d.Start(ctx)
 	defer cancel()
 	if opt.w == nil {
-		opt.w = defaultWriteTo
+		opt.w = os.Stdout
 	}
 
 	var remoteTaskDefArn string

--- a/diff.go
+++ b/diff.go
@@ -36,7 +36,7 @@ func (d *App) Diff(ctx context.Context, opt DiffOption) error {
 	ctx, cancel := d.Start(ctx)
 	defer cancel()
 	if opt.w == nil {
-		opt.w = os.Stdout
+		opt.w = defaultWriteTo
 	}
 
 	var remoteTaskDefArn string

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -176,12 +176,6 @@ func New(ctx context.Context, opt *CLIOptions, newAppOptions ...AppOption) (*App
 		fn(&appOpts)
 	}
 
-	// set log level
-	if opt.Debug {
-		logLevel.Set(slog.LevelDebug)
-	} else {
-		logLevel.Set(slog.LevelInfo)
-	}
 	LogInfo("ecspresso version: %s", Version)
 
 	// load config file

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -37,7 +37,6 @@ var Version string
 var delayForServiceChanged = 3 * time.Second
 var waiterMaxDelay = 15 * time.Second
 var spcIndent = "  "
-var defaultWriteTo = os.Stdout
 
 type TaskDefinition types.TaskDefinition
 

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -37,6 +37,7 @@ var Version string
 var delayForServiceChanged = 3 * time.Second
 var waiterMaxDelay = 15 * time.Second
 var spcIndent = "  "
+var defaultWriteTo = os.Stdout
 
 type TaskDefinition types.TaskDefinition
 
@@ -206,7 +207,11 @@ func New(ctx context.Context, opt *CLIOptions, newAppOptions ...AppOption) (*App
 		loader:      appOpts.loader,
 		config:      appOpts.config,
 	}
-	d.logger = appOpts.logger.With("", d.Name())
+	if logFormat == logFormatJSON {
+		d.logger = appOpts.logger.With("cluster", d.Cluster, "service", d.Service)
+	} else {
+		d.logger = appOpts.logger.With("", d.Name())
+	}
 
 	d.LogDebug("config file path: %s", opt.ConfigFilePath)
 	d.LogDebug("timeout: %s", d.config.Timeout)
@@ -280,43 +285,85 @@ func (d *App) DescribeService(ctx context.Context) (*Service, error) {
 	return sv, nil
 }
 
+type DescribeServiceStatusOutput struct {
+	Service        string
+	Cluster        string
+	TaskDefinition string
+	Deployments    []types.Deployment
+	TaskSets       []types.TaskSet
+	AutoScaling    struct {
+		ScalableTargets []aasTypes.ScalableTarget
+		ScalingPolicies []aasTypes.ScalingPolicy
+	}
+	Events []types.ServiceEvent
+}
+
+func (s *DescribeServiceStatusOutput) String() string {
+	buf := &strings.Builder{}
+	fmt.Fprintln(buf, "Service:", s.Service)
+	fmt.Fprintln(buf, "Cluster:", arnToName(s.Cluster))
+	fmt.Fprintln(buf, "TaskDefinition:", arnToName(s.TaskDefinition))
+	if len(s.Deployments) > 0 {
+		fmt.Fprintln(buf, "Deployments:")
+		for _, dep := range s.Deployments {
+			fmt.Fprintln(buf, spcIndent+formatDeployment(dep))
+		}
+	}
+	if len(s.TaskSets) > 0 {
+		fmt.Fprintln(buf, "TaskSets:")
+		for _, ts := range s.TaskSets {
+			fmt.Fprintln(buf, spcIndent+formatTaskSet(ts))
+		}
+	}
+
+	fmt.Fprintln(buf, "AutoScaling:")
+	for _, target := range s.AutoScaling.ScalableTargets {
+		fmt.Fprintln(buf, formatScalableTarget(target))
+	}
+	for _, policy := range s.AutoScaling.ScalingPolicies {
+		fmt.Fprintln(buf, formatScalingPolicy(policy))
+	}
+
+	fmt.Fprintln(buf, "Events:")
+	for _, e := range s.Events {
+		fmt.Fprintln(buf, serviceEvent(e).String())
+	}
+	return buf.String()
+}
+
 func (d *App) DescribeServiceStatus(ctx context.Context, events int) (*Service, error) {
 	s, err := d.DescribeService(ctx)
 	if err != nil {
 		return nil, err
 	}
-	fmt.Println("Service:", *s.ServiceName)
-	fmt.Println("Cluster:", arnToName(*s.ClusterArn))
-	fmt.Println("TaskDefinition:", arnToName(*s.TaskDefinition))
-	if len(s.Deployments) > 0 {
-		fmt.Println("Deployments:")
-		for _, dep := range s.Deployments {
-			fmt.Println(spcIndent + formatDeployment(dep))
-		}
-	}
-	if len(s.TaskSets) > 0 {
-		fmt.Println("TaskSets:")
-		for _, ts := range s.TaskSets {
-			fmt.Println(spcIndent + formatTaskSet(ts))
-		}
+	out := &DescribeServiceStatusOutput{
+		Service:        *s.ServiceName,
+		Cluster:        *s.ClusterArn,
+		TaskDefinition: *s.TaskDefinition,
+		Deployments:    s.Deployments,
+		TaskSets:       s.TaskSets,
 	}
 
-	if err := d.describeAutoScaling(ctx, s); err != nil {
-		return nil, fmt.Errorf("failed to describe autoscaling: %w", err)
-	}
-
-	fmt.Println("Events:")
 	sort.SliceStable(s.Events, func(i, j int) bool {
 		return s.Events[i].CreatedAt.Before(*s.Events[j].CreatedAt)
 	})
 	head := lo.Max([]int{len(s.Events) - events, 0})
 	for i := head; i < len(s.Events); i++ {
-		fmt.Println(formatEvent(s.Events[i]))
+		out.Events = append(out.Events, s.Events[i])
+	}
+
+	out.AutoScaling.ScalableTargets, out.AutoScaling.ScalingPolicies, err = d.describeAutoScaling(ctx, s)
+	if err != nil {
+		return nil, fmt.Errorf("failed to describe autoscaling: %w", err)
+	}
+
+	if _, err := WriteOutput(out); err != nil {
+		return nil, fmt.Errorf("failed to write output: %w", err)
 	}
 	return s, nil
 }
 
-func (d *App) describeAutoScaling(ctx context.Context, s *Service) error {
+func (d *App) describeAutoScaling(ctx context.Context, s *Service) ([]aasTypes.ScalableTarget, []aasTypes.ScalingPolicy, error) {
 	resourceId := fmt.Sprintf("service/%s/%s", arnToName(*s.ClusterArn), *s.ServiceName)
 	tout, err := d.autoScaling.DescribeScalableTargets(
 		ctx,
@@ -330,17 +377,12 @@ func (d *App) describeAutoScaling(ctx context.Context, s *Service) error {
 		var oe *smithy.OperationError
 		if errors.As(err, &oe) {
 			d.LogWarn("failed to describe scalable targets: %s", oe)
-			return nil
+			return nil, nil, nil
 		}
-		return fmt.Errorf("failed to describe scalable targets: %w", err)
+		return nil, nil, fmt.Errorf("failed to describe scalable targets: %w", err)
 	}
 	if len(tout.ScalableTargets) == 0 {
-		return nil
-	}
-
-	fmt.Println("AutoScaling:")
-	for _, target := range tout.ScalableTargets {
-		fmt.Println(formatScalableTarget(target))
+		return tout.ScalableTargets, nil, nil
 	}
 
 	pout, err := d.autoScaling.DescribeScalingPolicies(
@@ -355,14 +397,12 @@ func (d *App) describeAutoScaling(ctx context.Context, s *Service) error {
 		var oe *smithy.OperationError
 		if errors.As(err, &oe) {
 			d.LogWarn("failed to describe scaling policies: %s", oe)
-			return nil
+			return tout.ScalableTargets, nil, nil
 		}
-		return fmt.Errorf("failed to describe scaling policies: %w", err)
+		return tout.ScalableTargets, nil, fmt.Errorf("failed to describe scaling policies: %w", err)
 	}
-	for _, policy := range pout.ScalingPolicies {
-		fmt.Println(formatScalingPolicy(policy))
-	}
-	return nil
+
+	return tout.ScalableTargets, pout.ScalingPolicies, nil
 }
 
 func (d *App) DescribeTaskStatus(ctx context.Context, task *types.Task, watchContainer *types.ContainerDefinition) error {
@@ -430,7 +470,7 @@ func (d *App) GetLogEvents(ctx context.Context, logGroup string, logStream strin
 		return nextToken, nil
 	}
 	for _, event := range out.Events {
-		fmt.Println(formatLogEvent(event))
+		WriteOutput(logEvent(event))
 	}
 	return out.NextForwardToken, nil
 }

--- a/export_test.go
+++ b/export_test.go
@@ -21,6 +21,7 @@ var (
 	NewLogger          = newLogger
 	NewConfigLoader    = newConfigLoader
 	LogLevel           = logLevel
+	SetLogFormat       = setLogFormat
 	NewVerifier        = newVerifier
 	ArnToName          = arnToName
 	InitVerifyState    = initVerifyState

--- a/format.go
+++ b/format.go
@@ -3,6 +3,7 @@ package ecspresso
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -14,6 +15,12 @@ import (
 )
 
 var EventTimeFormat = sloghandler.TimeFormat
+
+type genericLogEvent struct {
+	Time  time.Time `json:"time"`
+	Level string    `json:"level"`
+	Msg   string    `json:"msg"`
+}
 
 func formatDeployment(dp types.Deployment) string {
 	return fmt.Sprintf(
@@ -44,6 +51,16 @@ func (e serviceEvent) String() string {
 	)
 }
 
+func (e serviceEvent) JSON() string {
+	t := e.CreatedAt.In(time.Local)
+	b, _ := json.Marshal(genericLogEvent{
+		Time:  t,
+		Level: slog.LevelInfo.String(),
+		Msg:   *e.Message,
+	})
+	return string(b)
+}
+
 type logEvent logsTypes.OutputLogEvent
 
 func (e logEvent) String() string {
@@ -55,13 +72,11 @@ func (e logEvent) String() string {
 }
 
 func (e logEvent) JSON() string {
-	t := time.Unix((*e.Timestamp / int64(1000)), 0)
-	b, _ := json.Marshal(struct {
-		Time    time.Time
-		Message string
-	}{
-		Time:    t,
-		Message: *e.Message,
+	t := time.Unix((*e.Timestamp / int64(1000)), 0).In(time.Local)
+	b, _ := json.Marshal(genericLogEvent{
+		Time:  t,
+		Level: slog.LevelInfo.String(),
+		Msg:   *e.Message,
 	})
 	return string(b)
 }

--- a/format.go
+++ b/format.go
@@ -1,6 +1,7 @@
 package ecspresso
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -34,19 +35,35 @@ func formatTaskSet(ts types.TaskSet) string {
 	)
 }
 
-func formatEvent(e types.ServiceEvent) string {
+type serviceEvent types.ServiceEvent
+
+func (e serviceEvent) String() string {
 	return fmt.Sprintf("%s %s",
 		e.CreatedAt.In(time.Local).Format(EventTimeFormat),
 		*e.Message,
 	)
 }
 
-func formatLogEvent(e logsTypes.OutputLogEvent) string {
+type logEvent logsTypes.OutputLogEvent
+
+func (e logEvent) String() string {
 	t := time.Unix((*e.Timestamp / int64(1000)), 0)
 	return fmt.Sprintf("%s %s",
 		t.In(time.Local).Format(EventTimeFormat),
 		*e.Message,
 	)
+}
+
+func (e logEvent) JSON() string {
+	t := time.Unix((*e.Timestamp / int64(1000)), 0)
+	b, _ := json.Marshal(struct {
+		Time    time.Time
+		Message string
+	}{
+		Time:    t,
+		Message: *e.Message,
+	})
+	return string(b)
 }
 
 func formatScalableTarget(t aasTypes.ScalableTarget) string {

--- a/json.go
+++ b/json.go
@@ -9,13 +9,12 @@ import (
 	"github.com/itchyny/gojq"
 )
 
-func (d *App) OutputJSONForAPI(w io.Writer, v interface{}) error {
+func OutputJSONForAPI(w io.Writer, v interface{}) (int, error) {
 	b, err := MarshalJSONForAPI(v)
 	if err != nil {
-		return fmt.Errorf("failed to marshal json: %w", err)
+		return 0, fmt.Errorf("failed to marshal json: %w", err)
 	}
-	_, err = w.Write(b)
-	return err
+	return w.Write(b)
 }
 
 func MustMarshalJSONStringForAPI(v interface{}) string {

--- a/logger.go
+++ b/logger.go
@@ -12,6 +12,7 @@ import (
 
 var (
 	logLevel           = new(slog.LevelVar)
+	logFormat          string
 	commonLogger       = newLogger(os.Stderr)
 	slogHandlerOptions = &sloghandler.HandlerOptions{
 		Color: true,
@@ -21,8 +22,28 @@ var (
 	}
 )
 
+const (
+	logFormatText = "text"
+	logFormatJSON = "json"
+)
+
+func setLogFormat(format string) {
+	changed := format != logFormat
+	logFormat = format
+	if changed {
+		commonLogger = newLogger(os.Stderr)
+	}
+}
+
 func newLogger(w io.Writer) *slog.Logger {
-	return slog.New(sloghandler.NewLogHandler(w, slogHandlerOptions))
+	switch logFormat {
+	case logFormatJSON:
+		return slog.New(slog.NewJSONHandler(w, &slogHandlerOptions.HandlerOptions))
+	case logFormatText, "":
+		return slog.New(sloghandler.NewLogHandler(w, slogHandlerOptions))
+	default:
+		panic("unknown log format " + logFormat)
+	}
 }
 
 func LogDebug(f string, v ...interface{}) {

--- a/logger_test.go
+++ b/logger_test.go
@@ -11,32 +11,38 @@ import (
 var logLevels = []slog.Level{slog.LevelDebug, slog.LevelInfo, slog.LevelWarn, slog.LevelError}
 
 func TestCommonLogger(t *testing.T) {
-	for _, level := range logLevels {
-		b := new(bytes.Buffer)
-		logger := ecspresso.NewLogger(b)
-		ecspresso.LogLevel.Set(level)
-		ecspresso.SetLogger(logger)
+	for _, format := range []string{"text", "json"} {
+		for _, level := range logLevels {
+			b := new(bytes.Buffer)
+			ecspresso.SetLogFormat(format)
+			logger := ecspresso.NewLogger(b)
+			ecspresso.LogLevel.Set(level)
+			ecspresso.SetLogger(logger)
 
-		ecspresso.LogDebug("test %s", level)
-		ecspresso.LogInfo("test %s", level)
-		ecspresso.LogWarn("test %s", level)
-		ecspresso.LogError("test %s", level)
-		t.Log(b.String())
+			ecspresso.LogDebug("test %s", level)
+			ecspresso.LogInfo("test %s", level)
+			ecspresso.LogWarn("test %s", level)
+			ecspresso.LogError("test %s", level)
+			t.Log(b.String())
+		}
 	}
 }
 
 func TestLogger(t *testing.T) {
 	app := &ecspresso.App{}
-	for _, level := range logLevels {
-		b := new(bytes.Buffer)
-		logger := ecspresso.NewLogger(b)
-		ecspresso.LogLevel.Set(level)
-		app.SetLogger(logger)
+	for _, format := range []string{"text", "json"} {
+		for _, level := range logLevels {
+			b := new(bytes.Buffer)
+			ecspresso.SetLogFormat(format)
+			logger := ecspresso.NewLogger(b)
+			ecspresso.LogLevel.Set(level)
+			app.SetLogger(logger)
 
-		app.LogDebug("test %s", "test")
-		app.LogInfo("test %s", "test")
-		app.LogWarn("test %s", "test")
-		app.LogError("test %s", "test")
-		t.Log(b.String())
+			app.LogDebug("test %s", "test")
+			app.LogInfo("test %s", "test")
+			app.LogWarn("test %s", "test")
+			app.LogError("test %s", "test")
+			t.Log(b.String())
+		}
 	}
 }

--- a/output.go
+++ b/output.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 )
 
@@ -16,7 +17,7 @@ type stringer interface {
 }
 
 func WriteOutput(v any) (int, error) {
-	w := defaultWriteTo
+	w := os.Stdout
 	switch logFormat {
 	case logFormatJSON:
 		switch v := v.(type) {

--- a/output.go
+++ b/output.go
@@ -38,7 +38,7 @@ func WriteOutput(v any) (int, error) {
 		if s, ok := v.(stringer); ok {
 			return io.WriteString(w, s.String()+"\n")
 		} else {
-			io.WriteString(w, fmt.Sprintf("%s\n", v))
+			return io.WriteString(w, fmt.Sprintf("%s\n", v))
 		}
 	}
 	return 0, fmt.Errorf("unknown log format %s", logFormat)

--- a/output.go
+++ b/output.go
@@ -1,0 +1,45 @@
+package ecspresso
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+type jsonStringer interface {
+	JSON() string
+}
+
+type stringer interface {
+	String() string
+}
+
+func WriteOutput(v any) (int, error) {
+	w := defaultWriteTo
+	switch logFormat {
+	case logFormatJSON:
+		switch v := v.(type) {
+		case jsonStringer:
+			s := v.JSON()
+			if strings.HasSuffix(s, "\n") {
+				return io.WriteString(w, s)
+			} else {
+				return io.WriteString(w, s+"\n")
+			}
+		case string:
+			b, _ := json.Marshal(v)
+			b = append(b, '\n')
+			return w.Write(b)
+		default:
+			return OutputJSONForAPI(w, v)
+		}
+	case logFormatText, "":
+		if s, ok := v.(stringer); ok {
+			return io.WriteString(w, s.String()+"\n")
+		} else {
+			io.WriteString(w, fmt.Sprintf("%s\n", v))
+		}
+	}
+	return 0, fmt.Errorf("unknown log format %s", logFormat)
+}

--- a/register.go
+++ b/register.go
@@ -28,7 +28,7 @@ func (d *App) Register(ctx context.Context, opt RegisterOption) error {
 	}
 	if opt.DryRun {
 		d.LogInfo("task definition:")
-		if err := d.OutputJSONForAPI(os.Stdout, td); err != nil {
+		if _, err := OutputJSONForAPI(os.Stdout, td); err != nil {
 			return err
 		}
 		d.LogInfo("DRY RUN OK")
@@ -41,7 +41,8 @@ func (d *App) Register(ctx context.Context, opt RegisterOption) error {
 	}
 
 	if opt.Output {
-		return d.OutputJSONForAPI(os.Stdout, newTd)
+		_, err := OutputJSONForAPI(os.Stdout, newTd)
+		return err
 	}
 	return nil
 }

--- a/revisions.go
+++ b/revisions.go
@@ -16,7 +16,7 @@ import (
 
 type RevisionsOption struct {
 	Revision string `help:"revision number or 'current' or 'latest'" default:""`
-	Output   string `help:"output format (json, table, tsv)" default:"table" enum:"json,table,tsv"`
+	Output   string `help:"output format (json, table, tsv)" default:"" enum:"json,table,tsv,"`
 }
 
 type revision struct {
@@ -111,10 +111,14 @@ func (d *App) Revisions(ctx context.Context, opt RevisionsOption) error {
 			break
 		}
 	}
-	switch opt.Output {
+	outputFormat := opt.Output
+	if outputFormat == "" && logFormat == logFormatJSON {
+		outputFormat = logFormatJSON
+	}
+	switch outputFormat {
 	case "json":
 		revs.OutputJSON(os.Stdout)
-	case "table":
+	case "table", "":
 		revs.OutputTable(os.Stdout)
 	case "tsv":
 		revs.OutputTSV(os.Stdout)

--- a/verify.go
+++ b/verify.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/url"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -261,7 +263,7 @@ func verifyResource(ctx context.Context, name string, verifyFunc func(context.Co
 	defer func() { verifyState.level-- }()
 	indent := strings.Repeat("  ", verifyState.level)
 	print := func(f string, args ...interface{}) {
-		defaultWriteTo.WriteString(fmt.Sprintf(indent+f+"\n", args...))
+		io.WriteString(os.Stdout, fmt.Sprintf(indent+f+"\n", args...))
 	}
 	print("%s", name)
 	var cached string

--- a/verify.go
+++ b/verify.go
@@ -261,7 +261,7 @@ func verifyResource(ctx context.Context, name string, verifyFunc func(context.Co
 	defer func() { verifyState.level-- }()
 	indent := strings.Repeat("  ", verifyState.level)
 	print := func(f string, args ...interface{}) {
-		fmt.Printf(indent+f+"\n", args...)
+		defaultWriteTo.WriteString(fmt.Sprintf(indent+f+"\n", args...))
 	}
 	print("%s", name)
 	var cached string

--- a/wait.go
+++ b/wait.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"sort"
 	"time"
 
@@ -307,10 +308,10 @@ func (d *App) codeDeployProgressBar(ctx context.Context, dpID string) error {
 		// disable progress bar in JSON format
 		opts = append(opts, progressbar.OptionSetWriter(io.Discard))
 	} else {
-		opts = append(opts, progressbar.OptionSetWriter(defaultWriteTo))
+		opts = append(opts, progressbar.OptionSetWriter(os.Stdout))
 		defer func() {
 			// append new line after progress bar
-			defaultWriteTo.Write([]byte("\n"))
+			os.Stdout.Write([]byte("\n"))
 		}()
 	}
 	bar := progressbar.NewOptions(100, opts...)

--- a/wait.go
+++ b/wait.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"io"
 	"sort"
 	"time"
 
@@ -273,7 +274,7 @@ func (d *App) showServiceStatus(ctx context.Context, st *showState) error {
 	})
 	for _, event := range sv.Events {
 		if (*event.CreatedAt).After(st.lastEventAt) {
-			fmt.Println(formatEvent(event))
+			WriteOutput(serviceEvent(event))
 			st.lastEventAt = *event.CreatedAt
 		}
 	}
@@ -298,10 +299,21 @@ func (d *App) showServiceStatus(ctx context.Context, st *showState) error {
 }
 
 func (d *App) codeDeployProgressBar(ctx context.Context, dpID string) error {
-	bar := progressbar.NewOptions(100,
+	opts := []progressbar.Option{
 		progressbar.OptionSetDescription("Traffic shifted"),
 		progressbar.OptionSetWidth(20),
-	)
+	}
+	if logFormat == logFormatJSON {
+		// disable progress bar in JSON format
+		opts = append(opts, progressbar.OptionSetWriter(io.Discard))
+	} else {
+		opts = append(opts, progressbar.OptionSetWriter(defaultWriteTo))
+		defer func() {
+			// append new line after progress bar
+			defaultWriteTo.Write([]byte("\n"))
+		}()
+	}
+	bar := progressbar.NewOptions(100, opts...)
 	t := time.NewTicker(10 * time.Second)
 	lcEvents := map[string]cdTypes.LifecycleEventStatus{}
 	for {
@@ -339,8 +351,7 @@ func (d *App) codeDeployProgressBar(ctx context.Context, dpID string) error {
 			}
 		}
 	}
-	bar.Set(100)
-	fmt.Println()
+	bar.Finish()
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- Add `--log-format` option (text/json) to CLI, toggleable via `ECSPRESSO_LOG_FORMAT` env var
- Implement structured JSON output for all text outputs when JSON format is selected
- Refactor logging system to support multiple output formats

## Details

This PR adds the ability to output logs and command results in JSON format, making ecspresso more friendly for programmatic consumption and automated tools. The implementation:

1. Adds a new `--log-format` CLI option with `text` (default) and `json` formats
2. Creates a unified output system via the `WriteOutput` function that formats data according to the selected format
3. Implements `stringer` and `jsonStringer` interfaces for various output types
4. Improves logger initialization by moving configuration to a central location
5. Handles progress bars appropriately in JSON mode by hiding them
6. Updates all direct stdout output to use the new output system

## Example Usage

Default text output

```console
ecspresso status
```

JSON output

```console
ecspresso --log-format=json status
```

or

```console
ECSPRESSO_LOG_FORMAT=json ecspresso status
```
