### PR TITLE
replace time.Sleep with sleepContext for handling context cancellation

### DIFF
--- a/create.go
+++ b/create.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
@@ -88,7 +87,7 @@ func (d *App) createService(ctx context.Context, opt DeployOption) error {
 		return nil
 	}
 
-	time.Sleep(delayForServiceChanged) // wait for service created
+	sleepContext(ctx, delayForServiceChanged) // wait for service created
 
 	sv, err := d.DescribeService(ctx)
 	if err != nil {

--- a/deploy.go
+++ b/deploy.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	"time"
 
 	"github.com/kayac/ecspresso/v2/appspec"
 	"github.com/samber/lo"
@@ -192,7 +191,7 @@ func (d *App) UpdateServiceTasks(ctx context.Context, taskDefinitionArn string, 
 	if err != nil {
 		return fmt.Errorf("failed to update service tasks: %w", err)
 	}
-	time.Sleep(delayForServiceChanged) // wait for service updated
+	sleepContext(ctx, delayForServiceChanged) // wait for service updated
 	return nil
 }
 
@@ -261,7 +260,7 @@ func (d *App) UpdateServiceAttributes(ctx context.Context, sv *Service, taskDefi
 	} else {
 		sv.ServiceArn = out.Service.ServiceArn
 	}
-	time.Sleep(delayForServiceChanged) // wait for service updated
+	sleepContext(ctx, delayForServiceChanged) // wait for service updated
 	return nil
 }
 

--- a/deregister.go
+++ b/deregister.go
@@ -172,7 +172,7 @@ func (d *App) deregisterKeeps(ctx context.Context, opt DeregisterOption, inUse m
 			return fmt.Errorf("failed to deregister task definition: %w", err)
 		}
 		d.LogInfo("%s was deregistered successfully", name)
-		time.Sleep(time.Second)
+		sleepContext(ctx, time.Second)
 		deregistered++
 	}
 	d.LogInfo("%d task definitions were deregistered", deregistered)

--- a/export_test.go
+++ b/export_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
@@ -61,4 +62,9 @@ func (opt *DiffOption) SetWriter(w io.Writer) {
 
 func (i *ConfigIgnore) FilterTags(tags []types.Tag) []types.Tag {
 	return i.filterTags(tags)
+}
+
+// SleepContext exposes sleepContext for testing
+func SleepContext(ctx context.Context, d time.Duration) {
+	sleepContext(ctx, d)
 }

--- a/rollback.go
+++ b/rollback.go
@@ -78,7 +78,7 @@ func (d *App) Rollback(ctx context.Context, opt RollbackOption) error {
 		return nil
 	}
 
-	time.Sleep(delayForServiceChanged) // wait for service updated
+	sleepContext(ctx, delayForServiceChanged) // wait for service updated
 	if err := doWait(ctx, sv); err != nil {
 		if errors.As(err, &errNotFound) {
 			d.LogInfo("%s", err)

--- a/run.go
+++ b/run.go
@@ -199,7 +199,7 @@ func (d *App) WaitRunTask(ctx context.Context, task *types.Task, watchContainer 
 
 	d.LogInfo("Watching container: %s", *watchContainer.Name)
 	logGroup, logStream := d.GetLogInfo(task, watchContainer)
-	time.Sleep(3 * time.Second) // wait for log stream
+	sleepContext(ctx, 3*time.Second) // wait for log stream
 
 	go func() {
 		ticker := time.NewTicker(5 * time.Second)

--- a/util.go
+++ b/util.go
@@ -1,10 +1,12 @@
 package ecspresso
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
@@ -139,4 +141,11 @@ func serviceVolumeConfigurationsToTask(vcs []types.ServiceVolumeConfiguration, d
 		})
 	}
 	return tvc
+}
+
+func sleepContext(ctx context.Context, d time.Duration) {
+	select {
+	case <-time.After(d):
+	case <-ctx.Done():
+	}
 }

--- a/util_test.go
+++ b/util_test.go
@@ -2,9 +2,11 @@ package ecspresso_test
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
@@ -206,4 +208,42 @@ func TestCompareTags(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSleepContext(t *testing.T) {
+	t.Run("normal sleep", func(t *testing.T) {
+		ctx := context.Background()
+		start := time.Now()
+		duration := 100 * time.Millisecond
+
+		ecspresso.SleepContext(ctx, duration)
+
+		elapsed := time.Since(start)
+		if elapsed < duration {
+			t.Errorf("Sleep duration was too short: %v, expected at least %v", elapsed, duration)
+		}
+	})
+
+	t.Run("context canceled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		start := time.Now()
+		duration := 1 * time.Second
+
+		// Cancel the context after a short delay
+		go func() {
+			time.Sleep(100 * time.Millisecond)
+			cancel()
+		}()
+
+		// This should return as soon as the context is canceled
+		ecspresso.SleepContext(ctx, duration)
+
+		elapsed := time.Since(start)
+		if elapsed >= duration {
+			t.Errorf("Sleep did not respect context cancellation, duration: %v", elapsed)
+		}
+		if elapsed < 50*time.Millisecond {
+			t.Errorf("Sleep returned too quickly, expected at least some delay: %v", elapsed)
+		}
+	})
 }

--- a/wait.go
+++ b/wait.go
@@ -159,7 +159,7 @@ func (d *App) WaitServiceStable(ctx context.Context, sv *Service) error {
 
 func (d *App) WaitServiceDeployCompleted(ctx context.Context, sv *Service) error {
 	d.LogInfo("Waiting for service deployed...(it will take a few minutes)")
-	time.Sleep(10 * time.Second) // wait for new deployment created
+	sleepContext(ctx, 10*time.Second) // wait for new deployment created
 
 	listResp, err := d.ecs.ListServiceDeployments(ctx, &ecs.ListServiceDeploymentsInput{
 		Cluster: &d.Cluster,
@@ -382,6 +382,6 @@ func (d *App) WaitTaskSetStable(ctx context.Context, sv *Service) error {
 				prev = ts.StabilityStatus
 			}
 		}
-		time.Sleep(10 * time.Second)
+		sleepContext(ctx, 10*time.Second)
 	}
 }


### PR DESCRIPTION
This change replaces all time.Sleep calls with sleepContext to properly handle context cancellation. The new sleepContext function allows ecspresso to immediately respond to context cancellation (like Ctrl+C) when sleeping, instead of having to wait for the sleep duration to complete.

- Added sleepContext function to util.go
- Added SleepContext export for testing in export_test.go
- Added tests for the new function in util_test.go
- Replaced all time.Sleep with sleepContext in create.go, deploy.go, deregister.go, rollback.go, run.go, and wait.go