### PR TITLE
add retry option for better reliability

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,7 +48,7 @@ runs:
         echo "DOWNLOAD_URL=${DOWNLOAD_URL}"
         mkdir -p ${RUNNER_TOOL_CACHE}/ecspresso
         cd /tmp
-        curl -sfLO ${DOWNLOAD_URL}
+        curl -sfLO --retry 3 ${DOWNLOAD_URL}
         if [[ "${DOWNLOAD_URL}" =~ \.tar\.gz$ ]]; then
           FILENAME=$(basename $DOWNLOAD_URL .tar.gz)
           tar xzvf ${FILENAME}.tar.gz


### PR DESCRIPTION
When the -f flag is provided, the program exits immediately with error 22 if the server fails to return a file for any reason.
I believe it would be reasonable to retry a few times to handle scenarios where the server is temporarily unavailable.