### PR TITLE
Fix service connect configuration removal on deployment

### DIFF
--- a/deploy.go
+++ b/deploy.go
@@ -226,6 +226,12 @@ func svToUpdateServiceInput(sv *Service) *ecs.UpdateServiceInput {
 	if len(sv.VpcLatticeConfigurations) == 0 {
 		in.VpcLatticeConfigurations = []types.VpcLatticeConfiguration{}
 	}
+	// explicitly disable ServiceConnect (to remove the configuration)
+	if sv.ServiceConnectConfiguration == nil {
+		in.ServiceConnectConfiguration = &types.ServiceConnectConfiguration{
+			Enabled: false,
+		}
+	}
 	return in
 }
 


### PR DESCRIPTION
Fixed an issue where service connect configuration could not be removed from ECS services during deployment.

# Expected behavior
When service connect configuration is removed from the service definition file, `ecspresso diff` shows the configuration will be deleted, and `ecspresso deploy` should remove the service connect configuration from the ECS service.

# Actual behavior
- `ecspresso diff` correctly shows the service connect configuration will be removed
- However, after running `ecspresso deploy`, the service connect remains enabled on the ECS service
- This happens because sending `nil` for `ServiceConnectConfiguration` is interpreted by AWS ECS API as "no change" rather than "remove"

# Solution
Added explicit handling to set `ServiceConnectConfiguration.Enabled = false` when the configuration is nil, similar to how `VolumeConfigurations` and `VpcLatticeConfigurations` are handled.

NOTE: The `ecspresso diff` output will slightly change after this fix.

## Before

```diff
   "platformVersion": "1.4.0",
   "propagateTags": "TASK_DEFINITION",
-  "serviceConnectConfiguration": {
-    "enabled": true,
-    "logConfiguration": {
-      "logDriver": "awsfirelens",
-      "options": {
-        "Name": "s3",
- (snip)
-      }
-    },
-    "namespace": "ecs.dev.local"
-  },
   "tags": [
```

## After

```diff
   "platformVersion": "1.4.0",
   "propagateTags": "TASK_DEFINITION",
   "serviceConnectConfiguration": {
-    "enabled": true,
-    "logConfiguration": {
-      "logDriver": "awsfirelens",
-      "options": {
-        "Name": "s3",
- (snip)
-      }
-    },
-    "namespace": "ecs.dev.local"
+    "enabled": false
   },
   "tags": [
     {
```
