### PR TITLE
Add secretsmanager-arnf.

### DIFF
--- a/secretsmanager/funcs.go
+++ b/secretsmanager/funcs.go
@@ -58,6 +58,10 @@ func (a *App) FuncMap(ctx context.Context) template.FuncMap {
 		"secretsmanager_arn": func(id string) (string, error) {
 			return a.ResolveArn(ctx, id)
 		},
+		"secretsmanager_arnf": func(format string, args ...interface{}) (string, error) {
+			id := fmt.Sprintf(format, args...)
+			return a.ResolveArn(ctx, id)
+		},
 	}
 	return funcs
 }
@@ -72,6 +76,25 @@ func (a *App) JsonnetNativeFuncs(ctx context.Context) []*jsonnet.NativeFunction 
 				if !ok {
 					return nil, fmt.Errorf("secretsmanager_arn: id must be string")
 				}
+				return a.ResolveArn(ctx, id)
+			},
+		},
+		{
+			Name:   "secretsmanager_arnf",
+			Params: []ast.Identifier{"format", "args"},
+			Func: func(args []any) (any, error) {
+				if len(args) < 1 {
+					return nil, fmt.Errorf("secretsmanager_arnf: format argument is required")
+				}
+				format, ok := args[0].(string)
+				if !ok {
+					return nil, fmt.Errorf("secretsmanager_arnf: format must be string")
+				}
+				var formatArgs []interface{}
+				if len(args) > 1 {
+					formatArgs = args[1:]
+				}
+				id := fmt.Sprintf(format, formatArgs...)
 				return a.ResolveArn(ctx, id)
 			},
 		},

--- a/secretsmanager/funcs_test.go
+++ b/secretsmanager/funcs_test.go
@@ -1,11 +1,13 @@
 package secretsmanager_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
+	"text/template"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
@@ -42,5 +44,67 @@ func TestJsonnetNativeFuncs(t *testing.T) {
 
 	if strings.TrimSuffix(out, "\n") != expect {
 		t.Fatalf("expected secretsmanager_arn function to return %s, got %s", expect, out)
+	}
+}
+
+func TestJsonnetNativeFuncsSecretsManagerArnf(t *testing.T) {
+	app := sm.MockNewApp(&mockSecretsManagerClient{})
+	funcs := app.JsonnetNativeFuncs(context.Background())
+	vm := jsonnet.MakeVM()
+	for _, f := range funcs {
+		vm.NativeFunction(f)
+	}
+	out, err := vm.EvaluateAnonymousSnippet("test.jsonnet", `
+		local arnf = std.native('secretsmanager_arnf');
+		arnf('my-%s', 'secret')
+	`)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	b, _ := json.Marshal(fmt.Sprintf(arnFmt, "my-secret"))
+	expect := string(b)
+
+	if strings.TrimSuffix(out, "\n") != expect {
+		t.Fatalf("expected secretsmanager_arnf function to return %s, got %s", expect, out)
+	}
+}
+
+func TestFuncMapSecretsManagerArnf(t *testing.T) {
+	app := sm.MockNewApp(&mockSecretsManagerClient{})
+	funcMap := app.FuncMap(context.Background())
+	
+	tmpl, err := template.New("test").Funcs(funcMap).Parse(`{{ secretsmanager_arnf "my-%s" "secret" }}`)
+	if err != nil {
+		t.Fatalf("failed to parse template: %v", err)
+	}
+	
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, nil); err != nil {
+		t.Fatalf("failed to execute template: %v", err)
+	}
+	
+	expected := fmt.Sprintf(arnFmt, "my-secret")
+	if buf.String() != expected {
+		t.Fatalf("expected secretsmanager_arnf function to return %s, got %s", expected, buf.String())
+	}
+}
+
+func TestFuncMapSecretsManagerArnfMultipleArgs(t *testing.T) {
+	app := sm.MockNewApp(&mockSecretsManagerClient{})
+	funcMap := app.FuncMap(context.Background())
+	
+	tmpl, err := template.New("test").Funcs(funcMap).Parse(`{{ secretsmanager_arnf "%s-%s-%s" "my" "test" "secret" }}`)
+	if err != nil {
+		t.Fatalf("failed to parse template: %v", err)
+	}
+	
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, nil); err != nil {
+		t.Fatalf("failed to execute template: %v", err)
+	}
+	
+	expected := fmt.Sprintf(arnFmt, "my-test-secret")
+	if buf.String() != expected {
+		t.Fatalf("expected secretsmanager_arnf function to return %s, got %s", expected, buf.String())
 	}
 }


### PR DESCRIPTION
This PR adds a new `secretsmanager_arnf` function that allows formatting secret IDs using printf-style format strings before resolving them to ARNs.

  ## Changes

  ### New functionality:
  - `secretsmanager_arnf` template function: Accepts a format string and variadic arguments, formats them using `fmt.Sprintf`, then resolves the resulting secret ID to an ARN
  - `secretsmanager_arnf` Jsonnet native function: Same functionality for Jsonnet templates

  ### Implementation details:
  - Added to both `FuncMap` and `JsonnetNativeFuncs` in `secretsmanager/funcs.go`
  - Includes proper error handling for missing or invalid format arguments
  - Uses the existing `ResolveArn` method for consistent ARN resolution and caching

  ### Tests added:
  - `TestJsonnetNativeFuncsSecretsManagerArnf`: Tests Jsonnet native function with single format argument
  - `TestFuncMapSecretsManagerArnf`: Tests template function with single format argument
  - `TestFuncMapSecretsManagerArnfMultipleArgs`: Tests template function with multiple format arguments

  ## Usage Examples

  ### Template usage:
  ```go
  {{ secretsmanager_arnf "my-%s" "secret" }}
  {{ secretsmanager_arnf "%s-%s-%s" "my" "test" "secret" }}
  {{ secretsmanager_arnf "aws_secret_%s" (must_env "ENVIRONMENT") }}

  Jsonnet usage:

  local arnf = std.native('secretsmanager_arnf');
  arnf('my-%s', 'secret')
  ```
This enhancement provides more flexibility when working with dynamically constructed secret names while maintaining the same caching and error handling behavior as the existing secretsmanager_arn function.