### PR TITLE
docs: Add rollback command documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,59 @@ Events:
 2017/11/09 23:23:29 myService/default Service is stable now. Completed!
 ```
 
+### Blue/Green deployment (with ECS deployment controller)
+
+`ecspresso deploy` supports blue/green deployment using the ECS deployment controller. Configure ecs-service-def.json as follows. For minimal settings, use can set `deploymentController.type` and `deploymentConfiguration.strategy` as shown below.
+
+```json
+{
+  "deploymentController": {
+    "type": "ECS"
+  },
+  "deploymentConfiguration": {
+    "strategy": "BLUE_GREEN"
+  },
+  // ...
+```
+
+For more advanced settings, you can define `deploymentConfiguration` in ecs-service-def.json. For example, to set lifecycle hooks and deployment circuit breaker, you can use the following configuration:
+
+```json
+{
+  "deploymentController": {
+    "type": "ECS"
+  },
+  "deploymentConfiguration": {
+    "bakeTimeInMinutes": 1,
+    "deploymentCircuitBreaker": {
+      "enable": false,
+      "rollback": false
+    },
+    "lifecycleHooks": [
+      {
+        "hookTargetArn": "arn:aws:lambda:ap-northeast-1:123456789012:function:bg-hook",
+        "lifecycleStages": [
+          "PRE_SCALE_UP",
+          "POST_SCALE_UP",
+          "TEST_TRAFFIC_SHIFT",
+          "POST_TEST_TRAFFIC_SHIFT",
+          "PRODUCTION_TRAFFIC_SHIFT",
+          "POST_PRODUCTION_TRAFFIC_SHIFT"
+        ],
+        "roleArn": "arn:aws:iam::123456789012:role/ECSServiceRole"
+      }
+    ],
+    "maximumPercent": 200,
+    "minimumHealthyPercent": 100,
+    "strategy": "BLUE_GREEN"
+  }
+  // ...
+```
+
+For more details, See [Amazon ECS blue/green deployments
+](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/deployment-type-blue-green.html).
+
+
 ### Blue/Green deployment (with AWS CodeDeploy)
 
 `ecspresso deploy` can deploy services using the CODE_DEPLOY deployment controller. Configure ecs-service-def.json as follows.
@@ -432,6 +485,20 @@ Keys are in the same format as `aws ecs describe-services` output.
 - placementStrategy
 - role
 - etc.
+
+## Rollback
+
+`ecspresso rollback` rolls back a service to the previous task definition revision.
+
+```console
+$ ecspresso rollback --config ecspresso.yml
+```
+
+By default, ecspresso finds the previous task definition revision by listing the task definition family in descending order and selecting the revision immediately before the current one.
+
+For services using the ECS deployment controller, if there's an active deployment in progress, ecspresso will stop it with rollback. Otherwise, it updates the service with the previous task definition.
+
+For services using the CodeDeploy deployment controller, if there's an active deployment, ecspresso stops it with rollback. Otherwise, it creates a new deployment with the previous task definition.
 
 ## Example of run task
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Action `kayac/ecspresso@v2` supports `version-file: path/to/file`, which install
 
 ## Usage
 
-```
+```console
 Usage: ecspresso <command>
 
 Flags:
@@ -270,7 +270,7 @@ By default, ecspresso provides the following as template functions.
 
 ### `env`
 
-```
+```go-template
 "{{ env `NAME` `default value` }}"
 ```
 
@@ -278,7 +278,7 @@ This replaces the placeholder with the value of the environment variable NAME. I
 
 ### `must_env`
 
-```
+```go-template
 "{{ must_env `NAME` }}"
 ```
 
@@ -288,7 +288,7 @@ Defining critical values with `must_env` helps prevent unintended deployments by
 
 ### `json_escape`
 
-```
+```go-template
 "{{ must_env `JSON_VALUE` | json_escape }}"
 ```
 
@@ -324,7 +324,7 @@ Events:
 
 `ecspresso deploy` supports blue/green deployment using the ECS deployment controller. Configure ecs-service-def.json as follows. For minimal settings, use can set `deploymentController.type` and `deploymentConfiguration.strategy` as shown below.
 
-```json
+```jsonnet
 {
   "deploymentController": {
     "type": "ECS"
@@ -337,7 +337,7 @@ Events:
 
 For more advanced settings, you can define `deploymentConfiguration` in ecs-service-def.json. For example, to set lifecycle hooks and deployment circuit breaker, you can use the following configuration:
 
-```json
+```jsonnet
 {
   "deploymentController": {
     "type": "ECS"
@@ -377,7 +377,7 @@ For more details, See [Amazon ECS blue/green deployments
 
 `ecspresso deploy` can deploy services using the CODE_DEPLOY deployment controller. Configure ecs-service-def.json as follows.
 
-```json
+```jsonnet
 {
   "deploymentController": {
     "type": "CODE_DEPLOY"
@@ -695,7 +695,7 @@ ecspresso supports [Amazon EBS Volumes](https://docs.aws.amazon.com/ja_jp/Amazon
 To configure, define `volumeConfigurations` in service definitions, and `mountPoints` and `volumes` in task definitions.
 
 
-```json
+```jsonnet
 // ecs-service-def.json
   "volumeConfigurations": [
     {
@@ -716,7 +716,7 @@ To configure, define `volumeConfigurations` in service definitions, and `mountPo
   ]
 ```
 
-```json
+```jsonnet
 // ecs-task-def.json
 // containerDefinitions[].mountPoints
       "mountPoints": [
@@ -752,18 +752,18 @@ ecspresso supports [VPC Lattice](https://aws.amazon.com/vpc/lattice/) integratio
 1. Define `portMappings` in the task definition. The `name` field is required.
 ```json
 {
-    "containerDefinitions": [
+  "containerDefinitions": [
+    {
+      "name": "webserver",
+      "portMappings": [
         {
-            "name": "webserver",
-            "portMappings": [
-                {
-                    "name": "web-80-tcp",
-                    "containerPort": 80,
-                    "hostPort": 80,
-                    "protocol": "tcp",
-                    "appProtocol": "http"
-                }
-            ],
+          "name": "web-80-tcp",
+          "containerPort": 80,
+          "hostPort": 80,
+          "protocol": "tcp",
+          "appProtocol": "http"
+        }
+      ],
 ```
 
 2. Define `vpcLatticeConfigurations` in the service definition. The `portName`, `roleArn`, and `targetGroupArn` fields are required.`
@@ -1048,7 +1048,7 @@ plugins:
 
 In templates, functions are called with the specified prefixes.
 
-```json
+```go-template
 [
   "{{ first_tfstate `aws_s3_bucket.main.arn` }}",
   "{{ second_tfstate `aws_s3_bucket.main.arn` }}"
@@ -1181,7 +1181,7 @@ local ssm_list = std.native('ssm_list');
 
 The `secretsmanager_arn` template function resolves the Secrets Manager secret ARN by secret name.
 
-```json
+```go-template
   "secrets": [
     {
       "name": "FOO",
@@ -1263,7 +1263,7 @@ local jq = std.native('jq');
 }
 ```
 
-```json
+```go-template
 {
   "today": "{{ (jq `{Now: now | todateiso8601}`).Now }}"
 }


### PR DESCRIPTION
Add a dedicated section explaining the ecspresso rollback command, including how it finds the previous task definition and its behavior with different deployment controllers (ECS and CodeDeploy).

🤖 Generated with [Claude Code](https://claude.ai/code)