### PR TITLE
Fix deployment log message for ECS B/G Deploy

### DIFF
--- a/deploy.go
+++ b/deploy.go
@@ -248,7 +248,11 @@ func (d *App) UpdateServiceAttributes(ctx context.Context, sv *Service, taskDefi
 		in.TaskDefinition = nil
 		in.CapacityProviderStrategy = nil
 	} else {
-		d.LogInfo("deployment by ECS rolling update")
+		if sv.DeploymentConfiguration != nil && sv.DeploymentConfiguration.Strategy == types.DeploymentStrategyBlueGreen {
+			d.LogInfo("deployment by ECS blue/green")
+		} else {
+			d.LogInfo("deployment by ECS rolling update")
+		}
 		in.ForceNewDeployment = opt.ForceNewDeployment
 		in.TaskDefinition = aws.String(taskDefinitionArn)
 	}


### PR DESCRIPTION
Fixed an issue where deployment log messages were incorrect for ECS native Blue/Green deployments

# Expected behavior
When using ECS Blue/Green deployment strategy, ecspresso should log "deployment by ECS blue/green" to clearly indicate the deployment method being used.

# Actual behavior
- All deployments were logged as "deployment by ECS rolling update" regardless of the actual deployment strategy
- This was misleading when Blue/Green deployment was actually being used

# Solution
Added conditional logic to check `DeploymentConfiguration.Strategy` and log the appropriate message:
- When `Strategy == types.DeploymentStrategyBlueGreen`: logs "deployment by ECS blue/green"
- Otherwise: logs "deployment by ECS rolling update"