### PR TITLE
enables to remove load balancers from ECS service.

### DIFF
--- a/deploy.go
+++ b/deploy.go
@@ -219,6 +219,10 @@ func svToUpdateServiceInput(sv *Service) *ecs.UpdateServiceInput {
 		in.PlacementStrategy = nil
 	}
 
+	// explicitly set empty slice (to remove the load balancers)
+	if len(sv.LoadBalancers) == 0 {
+		in.LoadBalancers = []types.LoadBalancer{}
+	}
 	// explicitly set empty slice (to remove the attribute)
 	if len(sv.VolumeConfigurations) == 0 {
 		in.VolumeConfigurations = []types.ServiceVolumeConfiguration{}


### PR DESCRIPTION
This pull request includes a small but important change to the `deploy.go` file. The change ensures that an empty slice is explicitly set for the `LoadBalancers` field in `ecs.UpdateServiceInput` when there are no load balancers, which allows the load balancers to be removed during an update.