### PR TITLE
refactor: replace interface{} to any

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -59,7 +59,7 @@ func (opt *CLIOptions) resolveConfigFilePath() (path string) {
 	return
 }
 
-func (opts *CLIOptions) ForSubCommand(sub string) interface{} {
+func (opts *CLIOptions) ForSubCommand(sub string) any {
 	switch sub {
 	case "appspec":
 		return opts.Appspec

--- a/diff.go
+++ b/diff.go
@@ -264,7 +264,7 @@ func tdToTaskDefinitionInput(td *TaskDefinition, tdTags []types.Tag) *TaskDefini
 	return tdi
 }
 
-func jsonStr(v interface{}) string {
+func jsonStr(v any) string {
 	s, _ := json.Marshal(v)
 	return string(s)
 }

--- a/duration.go
+++ b/duration.go
@@ -28,8 +28,8 @@ func (d *Duration) MarshalYAML() ([]byte, error) {
 	return d.marshal()
 }
 
-func (d *Duration) unmarshal(b []byte, unmarshaler func([]byte, interface{}) error) error {
-	var unmarshalled interface{}
+func (d *Duration) unmarshal(b []byte, unmarshaler func([]byte, any) error) error {
+	var unmarshalled any
 
 	err := unmarshaler(b, &unmarshalled)
 	if err != nil {

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -555,7 +555,7 @@ func (d *App) LoadTaskDefinition(path string) (*TaskDefinitionInput, error) {
 	return &td, nil
 }
 
-func unmarshalYAML(src []byte, v interface{}, path string) error {
+func unmarshalYAML(src []byte, v any, path string) error {
 	b, err := yaml.YAMLToJSON(src)
 	if err != nil {
 		return fmt.Errorf("failed to parse %s: %w", path, err)
@@ -563,7 +563,7 @@ func unmarshalYAML(src []byte, v interface{}, path string) error {
 	return unmarshalJSON(b, v, path)
 }
 
-func unmarshalJSON(src []byte, v interface{}, path string) error {
+func unmarshalJSON(src []byte, v any, path string) error {
 	strict := json.NewDecoder(bytes.NewReader(src))
 	strict.DisallowUnknownFields()
 	if err := strict.Decode(&v); err != nil {

--- a/json.go
+++ b/json.go
@@ -9,7 +9,7 @@ import (
 	"github.com/itchyny/gojq"
 )
 
-func OutputJSONForAPI(w io.Writer, v interface{}) (int, error) {
+func OutputJSONForAPI(w io.Writer, v any) (int, error) {
 	b, err := MarshalJSONForAPI(v)
 	if err != nil {
 		return 0, fmt.Errorf("failed to marshal json: %w", err)
@@ -17,7 +17,7 @@ func OutputJSONForAPI(w io.Writer, v interface{}) (int, error) {
 	return w.Write(b)
 }
 
-func MustMarshalJSONStringForAPI(v interface{}) string {
+func MustMarshalJSONStringForAPI(v any) string {
 	b, err := MarshalJSONForAPI(v)
 	if err != nil {
 		panic(err)
@@ -25,7 +25,7 @@ func MustMarshalJSONStringForAPI(v interface{}) string {
 	return string(b)
 }
 
-func MarshalJSONForAPI(v interface{}, queries ...string) ([]byte, error) {
+func MarshalJSONForAPI(v any, queries ...string) ([]byte, error) {
 	if v == nil {
 		return nil, nil
 	}
@@ -33,7 +33,7 @@ func MarshalJSONForAPI(v interface{}, queries ...string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	m := map[string]interface{}{}
+	m := map[string]any{}
 	if err := json.Unmarshal(b, &m); err != nil {
 		return nil, err
 	}
@@ -53,8 +53,8 @@ func MarshalJSONForAPI(v interface{}, queries ...string) ([]byte, error) {
 	return bs, nil
 }
 
-func UnmarshalJSONForStruct(src []byte, v interface{}, path string) error {
-	m := map[string]interface{}{}
+func UnmarshalJSONForStruct(src []byte, v any, path string) error {
+	m := map[string]any{}
 	if err := json.Unmarshal(src, &m); err != nil {
 		return err
 	}
@@ -80,7 +80,7 @@ func jsonKeyForStruct(s string) string {
 	return strings.ToUpper(s[:1]) + s[1:]
 }
 
-func walkMap(m map[string]interface{}, fn func(string) string) {
+func walkMap(m map[string]any, fn func(string) string) {
 	for key, value := range m {
 		delete(m, key)
 		newKey := key
@@ -91,14 +91,14 @@ func walkMap(m map[string]interface{}, fn func(string) string) {
 			m[newKey] = value
 		}
 		switch value := value.(type) {
-		case map[string]interface{}:
+		case map[string]any:
 			switch strings.ToLower(key) {
 			case "dockerlabels", "options":
 				walkMap(value, nil) // do not rewrite keys for map[string]string
 			default:
 				walkMap(value, fn)
 			}
-		case []interface{}:
+		case []any:
 			if len(value) > 0 {
 				walkArray(value, fn)
 			} else {
@@ -109,19 +109,19 @@ func walkMap(m map[string]interface{}, fn func(string) string) {
 	}
 }
 
-func walkArray(a []interface{}, fn func(string) string) {
+func walkArray(a []any, fn func(string) string) {
 	for _, value := range a {
 		switch value := value.(type) {
-		case map[string]interface{}:
+		case map[string]any:
 			walkMap(value, fn)
-		case []interface{}:
+		case []any:
 			walkArray(value, fn)
 		default:
 		}
 	}
 }
 
-func jqFilter(m map[string]interface{}, q string) (map[string]interface{}, error) {
+func jqFilter(m map[string]any, q string) (map[string]any, error) {
 	query, err := gojq.Parse(q)
 	if err != nil {
 		return nil, err
@@ -135,8 +135,8 @@ func jqFilter(m map[string]interface{}, q string) (map[string]interface{}, error
 		if err, ok := v.(error); ok {
 			return nil, err
 		}
-		if m, ok = v.(map[string]interface{}); !ok {
-			return nil, fmt.Errorf("query result is not map[string]interface{}: %v", v)
+		if m, ok = v.(map[string]any); !ok {
+			return nil, fmt.Errorf("query result is not map[string]any: %v", v)
 		}
 	}
 	return m, nil

--- a/logger.go
+++ b/logger.go
@@ -46,47 +46,47 @@ func newLogger(w io.Writer) *slog.Logger {
 	}
 }
 
-func LogDebug(f string, v ...interface{}) {
+func LogDebug(f string, v ...any) {
 	msg := fmt.Sprintf(f, v...)
 	commonLogger.Debug(msg)
 }
 
-func LogInfo(f string, v ...interface{}) {
+func LogInfo(f string, v ...any) {
 	msg := fmt.Sprintf(f, v...)
 	commonLogger.Info(msg)
 }
 
-func LogWarn(f string, v ...interface{}) {
+func LogWarn(f string, v ...any) {
 	msg := fmt.Sprintf(f, v...)
 	commonLogger.Warn(msg)
 }
 
-func LogError(f string, v ...interface{}) {
+func LogError(f string, v ...any) {
 	msg := fmt.Sprintf(f, v...)
 	commonLogger.Error(msg)
 }
 
-func (d *App) LogDebug(f string, v ...interface{}) {
+func (d *App) LogDebug(f string, v ...any) {
 	msg := fmt.Sprintf(f, v...)
 	d.logger.Debug(msg)
 }
 
-func (d *App) LogInfo(f string, v ...interface{}) {
+func (d *App) LogInfo(f string, v ...any) {
 	msg := fmt.Sprintf(f, v...)
 	d.logger.Info(msg)
 }
 
-func (d *App) LogWarn(f string, v ...interface{}) {
+func (d *App) LogWarn(f string, v ...any) {
 	msg := fmt.Sprintf(f, v...)
 	d.logger.Warn(msg)
 }
 
-func (d *App) LogError(f string, v ...interface{}) {
+func (d *App) LogError(f string, v ...any) {
 	msg := fmt.Sprintf(f, v...)
 	d.logger.Error(msg)
 }
 
-func (d *App) LogJSON(v interface{}) {
+func (d *App) LogJSON(v any) {
 	b, err := json.Marshal(v)
 	if err != nil {
 		d.logger.Warn("failed to marshal json", "error", err.Error())

--- a/verify.go
+++ b/verify.go
@@ -99,7 +99,7 @@ func (v *verifier) existsSecretValue(ctx context.Context, from string) error {
 		if key == "" {
 			return nil
 		}
-		var m map[string]interface{}
+		var m map[string]any
 		if err := json.Unmarshal([]byte(*res.SecretString), &m); err != nil {
 			return fmt.Errorf("failed to parse secret string from %s secret id %s: %w", from, secretArn, err)
 		}


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is still a draft because its operation has not yet been verified.

I replaced `interface{}` with `any` in the Go code to improve readability and unify the notation.

However, if `interface{}` is used as a function argument, simply replacing it may not work, and in such cases, it needs to be replaced with Generics.