### PR TITLE
add args input to run ecspresso after installation

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -91,3 +91,11 @@ jobs:
           version: v2.3.3
       - run: |
           ecspresso version 2>&1 | fgrep v2.3.3
+      - uses: kayac/ecspresso@v2-action-testing
+        with:
+          version: latest
+          args: "render config --jsonnet"
+        env:
+          AWS_REGION: ap-northeast-1
+          ECSPRESSO_LOG_FORMAT: json
+          ECSPRESSO_CONFIG: tests/ecspresso.yml

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Orb `fujiwara/ecspresso@2.0.2` supports `version-file: path/to/file`, which inst
 
 ### GitHub Actions
 
-Action kayac/ecspresso@v2 installs an ecspresso binary for Linux(x86_64) into /usr/local/bin. This action runs install only.
+Action kayac/ecspresso@v2 installs an ecspresso binary for Linux(x86_64) into /usr/local/bin. This action installs ecspresso. When `args` input is provided, it runs `ecspresso` with the specified arguments after installation.
 
 ```yml
 jobs:
@@ -111,6 +111,19 @@ To use the latest version of ecspresso, pass the parameter "latest".
 Note: `version: latest` is not recommended as it may cause unexpected behavior when a new version of ecspresso is released.
 
 Action `kayac/ecspresso@v2` supports `version-file: path/to/file`, which installs the ecspresso version specified in the file. This version number does not have a `v` prefix, For example `2.3.0`.
+
+### Run ecspresso after installation
+
+When the `args` input is provided, the action runs `ecspresso` with the specified arguments after installation.
+
+```yaml
+      - uses: kayac/ecspresso@v2
+        with:
+          version: latest
+          args: deploy
+        env:
+          ECSPRESSO_CONFIG: ecspresso.yml
+```
 
 ## Usage
 

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: "The token used when calling GitHub API"
     required: false
     default: ${{ github.token }}
+  args:
+    description: "Arguments to pass to ecspresso"
+    required: false
+    default: ""
 runs:
   using: "composite"
   steps:
@@ -62,3 +66,9 @@ runs:
         echo "Adding ${RUNNER_TOOL_CACHE}/ecspresso to path..."
         echo "${RUNNER_TOOL_CACHE}/ecspresso" >> $GITHUB_PATH
         "${RUNNER_TOOL_CACHE}/ecspresso/ecspresso" version
+    - name: Run ecspresso with args
+      shell: bash
+      run: |
+        set -e
+        ecspresso ${{ inputs.args }}
+      if: ${{ inputs.args != '' }}


### PR DESCRIPTION
### Run ecspresso after installation

When the `args` input is provided, the action runs `ecspresso` with the specified arguments after installation.

```yaml
      - uses: kayac/ecspresso@v2
        with:
          version: latest
          args: deploy
        env:
          ECSPRESSO_CONFIG: ecspresso.yml
```