### PR TITLE
Add support for waiting on specific CodeDeploy lifecycle events

### DIFF
--- a/cli_test.go
+++ b/cli_test.go
@@ -212,6 +212,24 @@ var cliTests = []struct {
 		},
 	},
 	{
+		args: []string{"deploy", "--wait-until=codedeploy:AllowTraffic"},
+		sub:  "deploy",
+		subOption: &ecspresso.DeployOption{
+			SuspendAutoScaling:   nil,
+			ResumeAutoScaling:    nil,
+			DryRun:               false,
+			DesiredCount:         ptr(int32(-1)),
+			SkipTaskDefinition:   false,
+			Revision:             0,
+			ForceNewDeployment:   false,
+			Wait:                 true,
+			WaitUntil:            "codedeploy:AllowTraffic",
+			RollbackEvents:       "",
+			UpdateService:        true,
+			LatestTaskDefinition: false,
+		},
+	},
+	{
 		args: []string{"scale", "--tasks=5"},
 		sub:  "scale",
 		subOption: &ecspresso.ScaleOption{
@@ -900,6 +918,17 @@ func TestParseCLIv2(t *testing.T) {
 				tt.fn(t, opt.ForSubCommand(sub))
 			}
 		})
+	}
+}
+
+func TestParseCLIv2WithInvalidWaitUntilOption(t *testing.T) {
+	_, _, _, err := ecspresso.ParseCLIv2([]string{"deploy", "--wait-until=UNSUPPORTED"})
+	if err == nil || err.Error() != "failed to parse args: deploy: invalid --wait-until value: UNSUPPORTED (expected: stable, deployed, or codedeploy:*)" {
+		t.Errorf("waitUntil is parsed unexpectedly; %v", err)
+	}
+	_, _, _, err = ecspresso.ParseCLIv2([]string{"deploy", "--wait-until=codedeploy:"}) // lifecycle event name is empty (i.e., prefix only)
+	if err == nil || err.Error() != "failed to parse args: deploy: invalid --wait-until value: codedeploy: (expected: stable, deployed, or codedeploy:*)" {
+		t.Errorf("waitUntil is parsed unexpectedly; %v", err)
 	}
 }
 

--- a/deploy.go
+++ b/deploy.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"regexp"
 	"strings"
 
 	"github.com/kayac/ecspresso/v2/appspec"
@@ -31,7 +32,7 @@ type DeployOption struct {
 	Revision             int64  `help:"revision of the task definition to run when --skip-task-definition" default:"0"`
 	ForceNewDeployment   bool   `help:"force a new deployment of the service" default:"false"`
 	Wait                 bool   `help:"wait for service stable" default:"true" negatable:""`
-	WaitUntil            string `help:"Choose whether to wait for service stable or the deployment finishes. (stable|deployed)" default:"deployed" enum:"stable,deployed"`
+	WaitUntil            string `help:"Choose whether to wait for service stable or the deployment finishes. For ECS deployment controller: \"(stable|deployed)\"; For CodeDeploy deployment controller: \"codedeploy:*\", this accepts CodeDeploy lifecycle event (e.g., \"codedeploy:AfterAllowTraffic\")" default:"deployed"`
 	SuspendAutoScaling   *bool  `help:"suspend application auto-scaling attached with the ECS service"`
 	ResumeAutoScaling    *bool  `help:"resume application auto-scaling attached with the ECS service"`
 	AutoScalingMin       *int32 `help:"set minimum capacity of application auto-scaling attached with the ECS service"`
@@ -46,6 +47,19 @@ func (opt DeployOption) DryRunString() string {
 		return dryRunStr
 	}
 	return ""
+}
+
+var codedeployWaitUntilPattern = regexp.MustCompile("^codedeploy:(.+)")
+
+func (opt DeployOption) Validate() error {
+	// Validate WaitUntil option
+	// The reason this validation exists is that the `enum` directive in `DeployOption.WaitUntil` does not support wildcards
+	if opt.WaitUntil != "stable" &&
+		opt.WaitUntil != "deployed" &&
+		!codedeployWaitUntilPattern.MatchString(opt.WaitUntil) {
+		return fmt.Errorf("invalid --wait-until value: %s (expected: stable, deployed, or codedeploy:*)", opt.WaitUntil)
+	}
+	return nil
 }
 
 func (opt DeployOption) ModifyAutoScalingParams() *modifyAutoScalingParams {

--- a/wait.go
+++ b/wait.go
@@ -24,6 +24,7 @@ type waitUntil string
 const (
 	waitUntilStable   waitUntil = "stable"
 	waitUntilDeployed waitUntil = "deployed"
+	// NOTE: waitUntil type also accepts a string according to "codedeploy:*" format
 )
 
 type waitFunc func(ctx context.Context, sv *Service) error
@@ -50,6 +51,10 @@ func (d *App) WaitFunc(sv *Service, confirm confirmFunc, until waitUntil) (waitF
 	if dc := sv.DeploymentController; dc != nil {
 		switch dc.Type {
 		case types.DeploymentControllerTypeCodeDeploy:
+			match := codedeployWaitUntilPattern.FindStringSubmatch(string(until))
+			if len(match) >= 2 {
+				return d.WaitForCodeDeployLifecycle(match[1]), nil
+			}
 			return d.WaitForCodeDeploy, nil
 		case types.DeploymentControllerTypeEcs:
 			switch until {
@@ -209,11 +214,10 @@ func (d *App) WaitServiceDeployCompleted(ctx context.Context, sv *Service) error
 	}
 }
 
-func (d *App) WaitForCodeDeploy(ctx context.Context, sv *Service) error {
-	d.LogDebug("wait for CodeDeploy")
+func (d *App) getCodeDeployDeploymentID(ctx context.Context) (string, error) {
 	dp, err := d.findDeploymentInfo(ctx)
 	if err != nil {
-		return err
+		return "", err
 	}
 	out, err := d.codedeploy.ListDeployments(
 		ctx,
@@ -229,13 +233,21 @@ func (d *App) WaitForCodeDeploy(ctx context.Context, sv *Service) error {
 		},
 	)
 	if err != nil {
-		return err
+		return "", err
 	}
 	if len(out.Deployments) == 0 {
-		return ErrNotFound("No deployments found in progress on CodeDeploy")
+		return "", ErrNotFound("No deployments found in progress on CodeDeploy")
 	}
 
-	dpID := out.Deployments[0]
+	return out.Deployments[0], nil
+}
+
+func (d *App) WaitForCodeDeploy(ctx context.Context, sv *Service) error {
+	d.LogDebug("wait for CodeDeploy")
+	dpID, err := d.getCodeDeployDeploymentID(ctx)
+	if err != nil {
+		return err
+	}
 	d.LogInfo("Waiting for a deployment successful ID: " + dpID)
 	go d.codeDeployProgressBar(ctx, dpID)
 
@@ -247,6 +259,78 @@ func (d *App) WaitForCodeDeploy(ctx context.Context, sv *Service) error {
 		&codedeploy.GetDeploymentInput{DeploymentId: &dpID},
 		d.Timeout(),
 	)
+}
+
+func (d *App) WaitForCodeDeployLifecycle(targetLifecycleEvent string) waitFunc {
+	return func(ctx context.Context, sv *Service) error {
+		d.LogDebug("wait for CodeDeploy lifecycle event: %s", targetLifecycleEvent)
+		dpID, err := d.getCodeDeployDeploymentID(ctx)
+		if err != nil {
+			return err
+		}
+		d.LogInfo("Waiting for a deployment lifecycle event: %s (ID: %s)", targetLifecycleEvent, dpID)
+
+		t := time.NewTicker(refreshInterval)
+		defer t.Stop()
+		lifecycle2Status := map[string]cdTypes.LifecycleEventStatus{}
+		targetEventFound := false
+
+		for {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-t.C:
+			}
+
+			target, err := d.codedeploy.GetDeploymentTarget(ctx, &codedeploy.GetDeploymentTargetInput{
+				DeploymentId: &dpID,
+				TargetId:     aws.String(d.Cluster + ":" + d.Service),
+			})
+			if err != nil {
+				d.LogWarn("%s", err.Error())
+				continue
+			}
+
+			dep := target.DeploymentTarget
+			d.LogDebug("deployment target status: %s", dep.EcsTarget.Status)
+
+			// Check lifecycle events
+			for _, ev := range dep.EcsTarget.LifecycleEvents {
+				lifecycleEvent := *ev.LifecycleEventName
+				if lifecycle2Status[lifecycleEvent] != ev.Status {
+					if ev.Status != cdTypes.LifecycleEventStatusPending {
+						d.LogInfo("%s: %s", lifecycleEvent, ev.Status)
+					}
+					lifecycle2Status[lifecycleEvent] = ev.Status
+				}
+
+				if lifecycleEvent == targetLifecycleEvent {
+					targetEventFound = true
+					switch ev.Status {
+					case cdTypes.LifecycleEventStatusSucceeded:
+						d.LogInfo("Lifecycle event %s completed successfully", targetLifecycleEvent)
+						return nil
+					case cdTypes.LifecycleEventStatusFailed:
+						return fmt.Errorf("lifecycle event %s failed", targetLifecycleEvent)
+					case cdTypes.LifecycleEventStatusSkipped:
+						d.LogInfo("Lifecycle event %s was skipped", targetLifecycleEvent)
+						return nil
+					default:
+						// NOP for "Pending", "InProgress", and "Unknown"
+					}
+				}
+			}
+
+			// Check deployment status
+			if dep.EcsTarget.Status != cdTypes.TargetStatusInProgress {
+				if !targetEventFound {
+					return fmt.Errorf("lifecycle event %s not found in deployment", targetLifecycleEvent)
+				}
+				d.LogInfo("Deployment completed but lifecycle event %s did not complete as expected", targetLifecycleEvent)
+				return nil
+			}
+		}
+	}
 }
 
 type showState struct {


### PR DESCRIPTION
## Motivation

When deploying ECS services with CodeDeploy (blue/green deployments), ecspresso currently waits for the entire deployment to complete successfully.

However, in some scenarios, users need more granular control over the deployment lifecycle in order to:

- Perform manual validation or testing after the new task set is installed but before traffic is shifted
- Run automated smoke tests during the `BeforeAllowTraffic` hook phase
- Exit early from the deployment process after certain lifecycle events complete (for example, in a canary deployment)

Currently, there is no option that allows waiting for specific lifecycle event checkpoints during the deployment process. Fortunately, CodeDeploy provides lifecycle event hooks that can be leveraged for this purpose.

## Proposed Solution

Expands `--wait-until` option that allows users to specify a CodeDeploy lifecycle event to wait for.
The command will return once the specified lifecycle event has completed (succeeded, failed, or been skipped), rather than waiting for the entire deployment to finish.

## Example Usage

```
$ ecspresso deploy --wait-until=codedeploy:Install
2025-10-24T01:38:28.255+09:00 [INFO] ecspresso version: v2.1.0+nightly-0d58986f5320294f990afb2460416779d2b8f9bb-502-g7c37514
2025-10-24T01:38:28.257+09:00 [INFO] [myapp] Starting deploy
<snip>
2025-10-24T01:38:29.183+09:00 [INFO] [myapp] Registering a new task definition...
2025-10-24T01:38:29.243+09:00 [INFO] [myapp] Task definition is registered myapp:4
2025-10-24T01:38:29.245+09:00 [INFO] [myapp] deployment by CodeDeploy
2025-10-24T01:38:29.245+09:00 [INFO] [myapp] Updating service attributes...
2025-10-24T01:38:32.649+09:00 [INFO] [myapp] desired count: 1
2025-10-24T01:38:32.649+09:00 [INFO] [myapp] updating desired count to 1
2025-10-24T01:38:34.426+09:00 [INFO] [myapp] Deployment d-XXXXXXXXX is created on CodeDeploy:
2025-10-24T01:38:34.426+09:00 [INFO] [myapp] https://ap-northeast-1.console.aws.amazon.com/codesuite/codedeploy/deployments/d-XXXXXXXXX?region=ap-northeast-1
2025-10-24T01:38:35.259+09:00 [INFO] [myapp] Waiting for a deployment lifecycle event: Install (ID: d-XXXXXXXXX)
2025-10-24T01:38:45.518+09:00 [INFO] [myapp] BeforeInstall: Succeeded
2025-10-24T01:38:45.518+09:00 [INFO] [myapp] Install: InProgress
2025-10-24T01:41:25.362+09:00 [INFO] [myapp] Install: Succeeded
2025-10-24T01:41:25.362+09:00 [INFO] [myapp] Lifecycle event Install completed successfully
2025-10-24T01:41:25.362+09:00 [INFO] [myapp] Service is deployed now. Completed!
```

Like the above, the `ecspresso deploy` command finishes after the `Install` phase (specified via `--wait-until` option) has been completed.