### PR TITLE
refactor parsing --wait-until=codedeploy:

### DIFF
--- a/cli_test.go
+++ b/cli_test.go
@@ -923,12 +923,12 @@ func TestParseCLIv2(t *testing.T) {
 
 func TestParseCLIv2WithInvalidWaitUntilOption(t *testing.T) {
 	_, _, _, err := ecspresso.ParseCLIv2([]string{"deploy", "--wait-until=UNSUPPORTED"})
-	if err == nil || err.Error() != "failed to parse args: deploy: invalid --wait-until value: UNSUPPORTED (expected: stable, deployed, or codedeploy:*)" {
-		t.Errorf("waitUntil is parsed unexpectedly; %v", err)
+	if err == nil {
+		t.Errorf("invalid wait-until should return error")
 	}
 	_, _, _, err = ecspresso.ParseCLIv2([]string{"deploy", "--wait-until=codedeploy:"}) // lifecycle event name is empty (i.e., prefix only)
-	if err == nil || err.Error() != "failed to parse args: deploy: invalid --wait-until value: codedeploy: (expected: stable, deployed, or codedeploy:*)" {
-		t.Errorf("waitUntil is parsed unexpectedly; %v", err)
+	if err == nil {
+		t.Errorf("invalid wait-until should return error")
 	}
 }
 

--- a/deploy.go
+++ b/deploy.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"regexp"
 	"strings"
 
 	"github.com/kayac/ecspresso/v2/appspec"
@@ -49,17 +48,11 @@ func (opt DeployOption) DryRunString() string {
 	return ""
 }
 
-var codedeployWaitUntilPattern = regexp.MustCompile("^codedeploy:(.+)")
-
 func (opt DeployOption) Validate() error {
 	// Validate WaitUntil option
 	// The reason this validation exists is that the `enum` directive in `DeployOption.WaitUntil` does not support wildcards
-	if opt.WaitUntil != "stable" &&
-		opt.WaitUntil != "deployed" &&
-		!codedeployWaitUntilPattern.MatchString(opt.WaitUntil) {
-		return fmt.Errorf("invalid --wait-until value: %s (expected: stable, deployed, or codedeploy:*)", opt.WaitUntil)
-	}
-	return nil
+	u := waitUntil(opt.WaitUntil)
+	return u.Validate()
 }
 
 func (opt DeployOption) ModifyAutoScalingParams() *modifyAutoScalingParams {

--- a/wait.go
+++ b/wait.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -22,10 +23,31 @@ import (
 type waitUntil string
 
 const (
-	waitUntilStable   waitUntil = "stable"
-	waitUntilDeployed waitUntil = "deployed"
-	// NOTE: waitUntil type also accepts a string according to "codedeploy:*" format
+	waitUntilStable           waitUntil = "stable"
+	waitUntilDeployed         waitUntil = "deployed"
+	waitUntilCodeDeployPrefix           = "codedeploy:"
 )
+
+func (u waitUntil) Validate() error {
+	if u == waitUntilStable || u == waitUntilDeployed {
+		return nil
+	}
+	if strings.HasPrefix(string(u), waitUntilCodeDeployPrefix) && len(u) > len(waitUntilCodeDeployPrefix) {
+		return nil
+	}
+	return fmt.Errorf("invalid waitUntil value: %s (expected: stable, deployed, or codedeploy:*)", u)
+}
+
+func (u waitUntil) forCodeDeployLifecycle() bool {
+	return strings.HasPrefix(string(u), waitUntilCodeDeployPrefix)
+}
+
+func (u waitUntil) codeDeployLifecycleEvent() string {
+	if u.forCodeDeployLifecycle() {
+		return strings.TrimPrefix(string(u), waitUntilCodeDeployPrefix)
+	}
+	return ""
+}
 
 type waitFunc func(ctx context.Context, sv *Service) error
 
@@ -51,9 +73,8 @@ func (d *App) WaitFunc(sv *Service, confirm confirmFunc, until waitUntil) (waitF
 	if dc := sv.DeploymentController; dc != nil {
 		switch dc.Type {
 		case types.DeploymentControllerTypeCodeDeploy:
-			match := codedeployWaitUntilPattern.FindStringSubmatch(string(until))
-			if len(match) >= 2 {
-				return d.WaitForCodeDeployLifecycle(match[1]), nil
+			if until.forCodeDeployLifecycle() {
+				return d.WaitForCodeDeployLifecycle(until.codeDeployLifecycleEvent()), nil
 			}
 			return d.WaitForCodeDeploy, nil
 		case types.DeploymentControllerTypeEcs:
@@ -317,6 +338,7 @@ func (d *App) WaitForCodeDeployLifecycle(targetLifecycleEvent string) waitFunc {
 						return nil
 					default:
 						// NOP for "Pending", "InProgress", and "Unknown"
+						d.LogDebug("Lifecycle event %s is ignored", ev.Status)
 					}
 				}
 			}


### PR DESCRIPTION
- refs #884
- Use strings.(Has|Trim)Prefix instead of regex.
- Delegate validation to a waitUntil type.
