### PR TITLE
Improve deployment strategy log message to support all strategies

### DIFF
--- a/deploy.go
+++ b/deploy.go
@@ -259,8 +259,8 @@ func (d *App) UpdateServiceAttributes(ctx context.Context, sv *Service, taskDefi
 		in.TaskDefinition = nil
 		in.CapacityProviderStrategy = nil
 	} else {
-		if sv.DeploymentConfiguration != nil && sv.DeploymentConfiguration.Strategy == types.DeploymentStrategyBlueGreen {
-			d.LogInfo("deployment by ECS blue/green")
+		if dc := sv.DeploymentConfiguration; dc != nil {
+			d.LogInfo("deployment by ECS %s strategy", dc.Strategy)
 		} else {
 			d.LogInfo("deployment by ECS rolling update")
 		}


### PR DESCRIPTION
## Summary
- Display actual deployment strategy name (ROLLING/BLUE_GREEN/LINEAR/CANARY) instead of hardcoding specific strategies
- Fix missing log messages for LINEAR and CANARY strategies added in ECS SDK v1.66.0
- Make the code more maintainable for future deployment strategies

## Changes
Previously, only BLUE_GREEN was explicitly logged, and LINEAR/CANARY strategies fell back to the generic "rolling update" message. Now all strategies are displayed with their actual names.

Before:
```
deployment by ECS blue/green  (only for BLUE_GREEN)
deployment by ECS rolling update  (for ROLLING, LINEAR, CANARY)
```

After:
```
deployment by ECS ROLLING strategy
deployment by ECS BLUE_GREEN strategy
deployment by ECS LINEAR strategy
deployment by ECS CANARY strategy
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)