### PR TITLE
fix(diff): When MaximumPercent or MinimumHealthyPercent is nil, set default

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -319,6 +319,12 @@ func ServiceDefinitionForDiff(sv *Service) *ServiceForDiff {
 			if sv.DeploymentConfiguration.Strategy == "" {
 				sv.DeploymentConfiguration.Strategy = types.DeploymentStrategyRolling
 			}
+			if sv.DeploymentConfiguration.MaximumPercent == nil {
+				sv.DeploymentConfiguration.MaximumPercent = aws.Int32(200)
+			}
+			if sv.DeploymentConfiguration.MinimumHealthyPercent == nil {
+				sv.DeploymentConfiguration.MinimumHealthyPercent = aws.Int32(100)
+			}
 			if sv.DeploymentConfiguration.BakeTimeInMinutes == nil {
 				sv.DeploymentConfiguration.BakeTimeInMinutes = aws.Int32(0)
 			}

--- a/diff_test.go
+++ b/diff_test.go
@@ -303,6 +303,72 @@ func TestDiffServices(t *testing.T) {
 			t.Errorf("unexpected diff. has many minus diffs: %s", ds)
 		}
 	})
+
+	t.Run("when local.DeploymentConfiguration.MaximumPercent is nil, filled with default and no diff", func(t *testing.T) {
+		b.Reset()
+		local := &ecspresso.Service{
+			Service: types.Service{
+				DeploymentConfiguration: &types.DeploymentConfiguration{
+					MinimumHealthyPercent: aws.Int32(100),
+					Strategy:              types.DeploymentStrategyRolling,
+				},
+				SchedulingStrategy: types.SchedulingStrategyReplica,
+			},
+		}
+		remote := &ecspresso.Service{
+			Service: types.Service{
+				DeploymentConfiguration: &types.DeploymentConfiguration{
+					MaximumPercent:        aws.Int32(200),
+					MinimumHealthyPercent: aws.Int32(100),
+					Strategy:              types.DeploymentStrategyRolling,
+				},
+				SchedulingStrategy: types.SchedulingStrategyReplica,
+			},
+		}
+		diff, err := ecspresso.DiffServices(ctx, local, remote, "file", opt)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if diff {
+			t.Fatalf("unexpected diff: %s", b.String())
+		}
+		if ds := b.String(); ds != "" {
+			t.Fatalf("unexpected diff output: %s", ds)
+		}
+	})
+
+	t.Run("when local.DeploymentConfiguration.MinimumHealthyPercent is nil, filled with default and no diff", func(t *testing.T) {
+		b.Reset()
+		local := &ecspresso.Service{
+			Service: types.Service{
+				DeploymentConfiguration: &types.DeploymentConfiguration{
+					MaximumPercent: aws.Int32(200),
+					Strategy:       types.DeploymentStrategyRolling,
+				},
+				SchedulingStrategy: types.SchedulingStrategyReplica,
+			},
+		}
+		remote := &ecspresso.Service{
+			Service: types.Service{
+				DeploymentConfiguration: &types.DeploymentConfiguration{
+					MaximumPercent:        aws.Int32(200),
+					MinimumHealthyPercent: aws.Int32(100),
+					Strategy:              types.DeploymentStrategyRolling,
+				},
+				SchedulingStrategy: types.SchedulingStrategyReplica,
+			},
+		}
+		diff, err := ecspresso.DiffServices(ctx, local, remote, "file", opt)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if diff {
+			t.Fatalf("unexpected diff: %s", b.String())
+		}
+		if ds := b.String(); ds != "" {
+			t.Fatalf("unexpected diff output: %s", ds)
+		}
+	})
 }
 
 func TestDiffTaskDefs(t *testing.T) {


### PR DESCRIPTION
closes https://github.com/kayac/ecspresso/issues/894

When I omitted `maximumPercent` or `minimumHealthyPercent` in `ecs-service-def.json` like this, there was always a diff.

```json
  # ...
  "deploymentConfiguration": {
    "bakeTimeInMinutes": 0,
    "deploymentCircuitBreaker": {
      "enable": true,
      "rollback": true
    },
    "strategy": "BLUE_GREEN"
  },
  # ...
```

```console
$ ecspresso version
ecspresso v2.6.3

$ ecspresso diff
2025-11-14T11:08:52.880+09:00 [INFO] ecspresso version: v2.6.3
--- arn:aws:ecs:ap-northeast-1:<masked>
+++ ecs-service-def.json
@@ -13,8 +13,6 @@
       "enable": true,
       "rollback": true
     },
-    "maximumPercent": 200,
-    "minimumHealthyPercent": 100,
     "strategy": "BLUE_GREEN"
   },
   "desiredCount": 0,
```

So I fixed it to set default values when `maximumPercent` or `minimumHealthyPercent` is omitted. The default values were referenced from the following documentation.
- https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service_definition_parameters.html#maximumPercent
- https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service_definition_parameters.html#minimumHealthyPercent

In my case, the issue occurred when using BLUE_GREEN, but since this problem can also happen when using ROLLING, I made it set default values regardless of the strategy.

After fixed, I confirmed there are no diff as expected:

```console
$ ~/github.com/mi-wada/ecspresso/ecspresso diff
2025-11-14T11:33:24.326+09:00 [INFO] ecspresso version:
```
