### PR TITLE
doc: fix asdf command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $ asdf plugin add ecspresso
 $ asdf plugin add ecspresso https://github.com/kayac/asdf-ecspresso.git
 
 $ asdf install ecspresso 2.3.0
-$ asdf global ecspresso 2.3.0
+$ asdf set -u ecspresso 2.3.0
 ```
 
 ### aqua (macOS and Linux)


### PR DESCRIPTION
The `asdf global` command has been replaced with `asdf set` since v0.16.0.
This PR updates the documentation to reflect this change.

Reference: https://github.com/asdf-vm/asdf/blob/651275a34942cc6898741a4a523afd8bdea0f31f/docs/guide/upgrading-to-v0-16.md?plain=1#L147

Thank you for maintaining this useful tool.