### PR TITLE
Bye-bye remaining `interface{}`

### DIFF
--- a/json.go
+++ b/json.go
@@ -136,7 +136,7 @@ func jqFilter(m map[string]any, q string) (map[string]any, error) {
 			return nil, err
 		}
 		if m, ok = v.(map[string]any); !ok {
-			return nil, fmt.Errorf("query result is not map[string]interface{}: %v", v)
+			return nil, fmt.Errorf("query result is not map[string]any: %v", v)
 		}
 	}
 	return m, nil


### PR DESCRIPTION
This is a missing replacement in this PR: https://github.com/kayac/ecspresso/pull/883
