### PR TITLE
verify: Support digest-based image reference

### DIFF
--- a/registry/client.go
+++ b/registry/client.go
@@ -104,8 +104,8 @@ func (c *Repository) login(ctx context.Context, endpoint, service, scope string)
 	return nil
 }
 
-func (c *Repository) fetchManifests(ctx context.Context, method, tag string) (*http.Response, error) {
-	u := fmt.Sprintf("https://%s/v2/%s/manifests/%s", c.host, c.repo, tag)
+func (c *Repository) fetchManifests(ctx context.Context, method, tagOrDigest string) (*http.Response, error) {
+	u := fmt.Sprintf("https://%s/v2/%s/manifests/%s", c.host, c.repo, tagOrDigest)
 	req, err := http.NewRequestWithContext(ctx, method, u, nil)
 	if err != nil {
 		return nil, err
@@ -119,10 +119,10 @@ func (c *Repository) fetchManifests(ctx context.Context, method, tag string) (*h
 	return c.client.Do(req)
 }
 
-func (c *Repository) getAvailability(ctx context.Context, tag string) (*http.Response, error) {
+func (c *Repository) getAvailability(ctx context.Context, tagOrDigest string) (*http.Response, error) {
 	retryer := retryPolicy.Start(ctx)
 	for retryer.Continue() {
-		resp, err := c.fetchManifests(ctx, http.MethodHead, tag)
+		resp, err := c.fetchManifests(ctx, http.MethodHead, tagOrDigest)
 		if err != nil {
 			return nil, err
 		}
@@ -199,9 +199,9 @@ func match(want, got string) bool {
 	return want == "" || want == got
 }
 
-// HasPlatformImage returns an image tag for arch/os exists or not in the repository.
-func (c *Repository) HasPlatformImage(ctx context.Context, tag, arch, os string) (bool, error) {
-	mediaType, rc, err := c.getManifests(ctx, tag)
+// HasPlatformImage returns whether an image with the specified tagOrDigest exists for the given arch/os in the repository.
+func (c *Repository) HasPlatformImage(ctx context.Context, tagOrDigest, arch, os string) (bool, error) {
+	mediaType, rc, err := c.getManifests(ctx, tagOrDigest)
 	if err != nil {
 		return false, err
 	}
@@ -265,12 +265,12 @@ func (c *Repository) HasPlatformImage(ctx context.Context, tag, arch, os string)
 	return false, nil
 }
 
-// HasImage returns an image tag exists or not in the repository.
-func (c *Repository) HasImage(ctx context.Context, tag string) (bool, error) {
+// HasImage returns whether an image with the specified tagOrDigest exists in the repository.
+func (c *Repository) HasImage(ctx context.Context, tagOrDigest string) (bool, error) {
 	tries := 2
 	for tries > 0 {
 		tries--
-		resp, err := c.getAvailability(ctx, tag)
+		resp, err := c.getAvailability(ctx, tagOrDigest)
 		if err != nil {
 			return false, err
 		}

--- a/registry/client_test.go
+++ b/registry/client_test.go
@@ -3,6 +3,7 @@ package registry_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -11,76 +12,95 @@ import (
 )
 
 var testImages = []struct {
-	image string
-	tag   string
-	arch  string
-	os    string
+	image       string
+	tagOrDigest string
+	arch        string
+	os          string
 }{
-	{image: "debian", tag: "latest", arch: "arm64", os: "linux"},
-	{image: "katsubushi/katsubushi", tag: "v1.6.0", arch: "amd64", os: "linux"},
-	{image: "public.ecr.aws/mackerel/mackerel-container-agent", tag: "plugins", arch: "amd64", os: "linux"},
-	{image: "gcr.io/kaniko-project/executor", tag: "v0.10.0", arch: "amd64", os: "linux"},
-	{image: "ghcr.io/github/super-linter", tag: "v3", arch: "amd64", os: "linux"},
-	{image: "mcr.microsoft.com/windows/servercore/iis", tag: "windowsservercore-ltsc2019", arch: "amd64", os: "windows"},
+	{image: "debian", tagOrDigest: "latest", arch: "arm64", os: "linux"},
+	{image: "debian", tagOrDigest: "sha256:8f6a88feef3ed01a300dafb87f208977f39dccda1fd120e878129463f7fa3b8f", arch: "arm64", os: "linux"},
+	{image: "katsubushi/katsubushi", tagOrDigest: "v1.6.0", arch: "amd64", os: "linux"},
+	{image: "katsubushi/katsubushi", tagOrDigest: "sha256:9426deec3ed0c1f41f070509c4e9729ac32d65920b919f0adc09809812c0f247", arch: "amd64", os: "linux"},
+	{image: "public.ecr.aws/mackerel/mackerel-container-agent", tagOrDigest: "plugins", arch: "amd64", os: "linux"},
+	{image: "public.ecr.aws/mackerel/mackerel-container-agent", tagOrDigest: "sha256:c7d960d3f87cc9f9b6e5afee8ad2fe5d0af14ec70d5c089ec1a77304ccb40e2d", arch: "amd64", os: "linux"},
+	{image: "gcr.io/kaniko-project/executor", tagOrDigest: "v0.10.0", arch: "amd64", os: "linux"},
+	{image: "gcr.io/kaniko-project/executor", tagOrDigest: "sha256:78d44ec4e9cb5545d7f85c1924695c89503ded86a59f92c7ae658afa3cff5400", arch: "amd64", os: "linux"},
+	{image: "ghcr.io/github/super-linter", tagOrDigest: "v3", arch: "amd64", os: "linux"},
+	{image: "ghcr.io/github/super-linter", tagOrDigest: "sha256:b1a1417c30483783987536fd8beb64d85f2509d27b5fb72afbe327a22f0ed59b", arch: "amd64", os: "linux"},
+	{image: "mcr.microsoft.com/windows/servercore/iis", tagOrDigest: "windowsservercore-ltsc2019", arch: "amd64", os: "windows"},
+	{image: "mcr.microsoft.com/windows/servercore/iis", tagOrDigest: "sha256:c077419bb006eb5c9a0fe3e5a9cdf018cdcc2b50c5ea11ad39ffbecf93fd3f07", arch: "amd64", os: "windows"},
 }
 
 var testFailImages = []struct {
-	image string
-	tag   string
-	arch  string
-	os    string
+	image       string
+	tagOrDigest string
+	arch        string
+	os          string
 }{
-	{image: "debian", tag: "xxx", arch: "arm64", os: "linux"},
-	{image: "katsubushi/katsubushi", tag: "xxx", arch: "amd64", os: "linux"},
-	{image: "public.ecr.aws/mackerel/mackerel-container-agent", tag: "xxx", arch: "amd64", os: "linux"},
-	{image: "gcr.io/kaniko-project/executor", tag: "xxx", arch: "amd64", os: "linux"},
-	{image: "ghcr.io/github/super-linter", tag: "xxx", arch: "amd64", os: "linux"},
-	{image: "mcr.microsoft.com/windows/servercore/iis", tag: "xxx", arch: "amd64", os: "windows"},
-	{image: "xxx", tag: "xxx", arch: "xxx", os: "xxx"},
+	{image: "debian", tagOrDigest: "xxx", arch: "arm64", os: "linux"},
+	{image: "debian", tagOrDigest: "sha256:xxx", arch: "arm64", os: "linux"},
+	{image: "katsubushi/katsubushi", tagOrDigest: "xxx", arch: "amd64", os: "linux"},
+	{image: "public.ecr.aws/mackerel/mackerel-container-agent", tagOrDigest: "xxx", arch: "amd64", os: "linux"},
+	{image: "gcr.io/kaniko-project/executor", tagOrDigest: "xxx", arch: "amd64", os: "linux"},
+	{image: "ghcr.io/github/super-linter", tagOrDigest: "xxx", arch: "amd64", os: "linux"},
+	{image: "mcr.microsoft.com/windows/servercore/iis", tagOrDigest: "xxx", arch: "amd64", os: "windows"},
+	{image: "xxx", tagOrDigest: "xxx", arch: "xxx", os: "xxx"},
 }
 
 func TestImages(t *testing.T) {
 	for _, c := range testImages {
-		t.Logf("testing %s:%s", c.image, c.tag)
+		var fullImage string
+		if strings.HasPrefix(c.tagOrDigest, "sha256:") {
+			fullImage = fmt.Sprintf("%s@%s", c.image, c.tagOrDigest)
+		} else {
+			fullImage = fmt.Sprintf("%s:%s", c.image, c.tagOrDigest)
+		}
+		t.Logf("testing %s", fullImage)
 		client := registry.New(c.image, "", "")
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
-		if ok, err := client.HasImage(ctx, c.tag); err != nil {
+		if ok, err := client.HasImage(ctx, c.tagOrDigest); err != nil {
 			if isTemporary(err) {
 				t.Logf("skip testing for %s: %s", c.image, err)
 				continue
 			}
-			t.Errorf("%s:%s error %s", c.image, c.tag, err)
+			t.Errorf("%s error %s", fullImage, err)
 		} else if !ok {
-			t.Errorf("%s:%s not found", c.image, c.tag)
+			t.Errorf("%s not found", fullImage)
 		}
-		if ok, err := client.HasPlatformImage(ctx, c.tag, c.arch, c.os); err != nil {
+		if ok, err := client.HasPlatformImage(ctx, c.tagOrDigest, c.arch, c.os); err != nil {
 			if isTemporary(err) {
 				t.Logf("skip testing for %s: %s", c.image, err)
 				continue
 			}
-			t.Errorf("%s:%s %s/%s error %s", c.image, c.tag, c.arch, c.os, err)
+			t.Errorf("%s %s/%s error %s", fullImage, c.arch, c.os, err)
 		} else if !ok {
-			t.Errorf("%s:%s %s/%s not found", c.image, c.tag, c.arch, c.os)
+			t.Errorf("%s %s/%s not found", fullImage, c.arch, c.os)
 		}
 	}
 }
 
 func TestFailImages(t *testing.T) {
 	for _, c := range testFailImages {
-		t.Logf("testing (will be fail) %s:%s", c.image, c.tag)
+		var fullImage string
+		if strings.HasPrefix(c.tagOrDigest, "sha256:") {
+			fullImage = fmt.Sprintf("%s@%s", c.image, c.tagOrDigest)
+		} else {
+			fullImage = fmt.Sprintf("%s:%s", c.image, c.tagOrDigest)
+		}
+		t.Logf("testing (will be fail) %s", fullImage)
 		client := registry.New(c.image, "", "")
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
-		if ok, err := client.HasImage(ctx, c.tag); err == nil {
-			t.Errorf("HasImage %s:%s error %s", c.image, c.tag, err)
+		if ok, err := client.HasImage(ctx, c.tagOrDigest); err == nil {
+			t.Errorf("HasImage %s error %s", fullImage, err)
 		} else if ok {
-			t.Errorf("HasImage %s:%s should not be found", c.image, c.tag)
+			t.Errorf("HasImage %s should not be found", fullImage)
 		}
-		if ok, err := client.HasPlatformImage(ctx, c.tag, c.arch, c.os); err == nil {
-			t.Errorf("HasPlatformImage %s:%s %s/%s error %s", c.image, c.tag, c.arch, c.os, err)
+		if ok, err := client.HasPlatformImage(ctx, c.tagOrDigest, c.arch, c.os); err == nil {
+			t.Errorf("HasPlatformImage %s %s/%s error %s", fullImage, c.arch, c.os, err)
 		} else if ok {
-			t.Errorf("HasPlatformImage %s:%s %s/%s should not be found", c.image, c.tag, c.arch, c.os)
+			t.Errorf("HasPlatformImage %s %s/%s should not be found", fullImage, c.arch, c.os)
 		}
 	}
 }

--- a/registry/client_test.go
+++ b/registry/client_test.go
@@ -50,7 +50,7 @@ var testFailImages = []struct {
 func TestImages(t *testing.T) {
 	for _, c := range testImages {
 		var fullImage string
-		if strings.HasPrefix(c.tagOrDigest, "sha256:") {
+		if strings.Contains(c.tagOrDigest, ":") {
 			fullImage = fmt.Sprintf("%s@%s", c.image, c.tagOrDigest)
 		} else {
 			fullImage = fmt.Sprintf("%s:%s", c.image, c.tagOrDigest)
@@ -83,7 +83,7 @@ func TestImages(t *testing.T) {
 func TestFailImages(t *testing.T) {
 	for _, c := range testFailImages {
 		var fullImage string
-		if strings.HasPrefix(c.tagOrDigest, "sha256:") {
+		if strings.Contains(c.tagOrDigest, ":") {
 			fullImage = fmt.Sprintf("%s@%s", c.image, c.tagOrDigest)
 		} else {
 			fullImage = fmt.Sprintf("%s:%s", c.image, c.tagOrDigest)

--- a/verify.go
+++ b/verify.go
@@ -643,12 +643,14 @@ func (d *App) verifyECRImage(ctx context.Context, image, region string) error {
 func (d *App) verifyRegistryImage(ctx context.Context, image, user, password string) error {
 	var imageName string
 	var tagOrDigest string
-	if rr := strings.SplitN(image, "@", 2); len(rr) == 2 {
-		imageName = rr[0]
-		tagOrDigest = rr[1]
-	} else if rr := strings.SplitN(image, ":", 2); len(rr) == 2 {
-		imageName = rr[0]
-		tagOrDigest = rr[1]
+	if idx := strings.Index(image, "@"); idx != -1 {
+		imageName = image[:idx]
+		tagOrDigest = image[idx+1:]
+	} else if idx := strings.LastIndex(image, ":"); idx != -1 && !strings.Contains(image[idx+1:], "/") {
+		// The last colon is a tag separator only if there is no slash after it.
+		// If there is a slash (e.g. "host:443/repo"), the colon indicates a port.
+		imageName = image[:idx]
+		tagOrDigest = image[idx+1:]
 	} else {
 		imageName = image
 		tagOrDigest = "latest"

--- a/verify.go
+++ b/verify.go
@@ -641,23 +641,27 @@ func (d *App) verifyECRImage(ctx context.Context, image, region string) error {
 }
 
 func (d *App) verifyRegistryImage(ctx context.Context, image, user, password string) error {
-	rr := strings.SplitN(image, ":", 2)
-	image = rr[0]
-	var tag string
-	if len(rr) == 1 {
-		tag = "latest"
+	var imageName string
+	var tagOrDigest string
+	if rr := strings.SplitN(image, "@", 2); len(rr) == 2 {
+		imageName = rr[0]
+		tagOrDigest = rr[1]
+	} else if rr := strings.SplitN(image, ":", 2); len(rr) == 2 {
+		imageName = rr[0]
+		tagOrDigest = rr[1]
 	} else {
-		tag = rr[1]
+		imageName = image
+		tagOrDigest = "latest"
 	}
-	d.LogDebug("image=%s tag=%s", image, tag)
+	d.LogDebug("imageName=%s tagOrDigest=%s", imageName, tagOrDigest)
 
-	repo := registry.New(image, user, password)
-	ok, err := repo.HasImage(ctx, tag)
+	repo := registry.New(imageName, user, password)
+	ok, err := repo.HasImage(ctx, tagOrDigest)
 	if err != nil {
 		return err
 	}
 	if !ok {
-		return fmt.Errorf("%s:%s is not found in Registry", image, tag)
+		return fmt.Errorf("%s is not found in Registry", image)
 	}
 
 	td, err := d.LoadTaskDefinition(d.config.TaskDefinitionPath)
@@ -674,7 +678,7 @@ func (d *App) verifyRegistryImage(ctx context.Context, image, user, password str
 	if arch == "" && os == "" {
 		return nil
 	}
-	ok, err = repo.HasPlatformImage(ctx, tag, arch, os)
+	ok, err = repo.HasPlatformImage(ctx, tagOrDigest, arch, os)
 	if err != nil {
 		if errors.Is(err, registry.ErrDeprecatedManifest) || errors.Is(err, registry.ErrPullRateLimitExceeded) {
 			return ErrSkipVerify(err.Error())
@@ -684,7 +688,7 @@ func (d *App) verifyRegistryImage(ctx context.Context, image, user, password str
 	if ok {
 		return nil
 	}
-	return fmt.Errorf("%s:%s for arch=%s os=%s is not found in Registry", image, tag, arch, os)
+	return fmt.Errorf("%s for arch=%s os=%s is not found in Registry", image, arch, os)
 }
 
 func (d *App) isFargateService() (bool, error) {

--- a/verify_test.go
+++ b/verify_test.go
@@ -54,7 +54,15 @@ var testImagesIsECR = []struct {
 		isECR: true,
 	},
 	{
+		image: "123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/myimage@sha256:xxx",
+		isECR: true,
+	},
+	{
 		image: "ubuntu:latest",
+		isECR: false,
+	},
+	{
+		image: "ubuntu@sha256:8f6a88feef3ed01a300dafb87f208977f39dccda1fd120e878129463f7fa3b8f",
 		isECR: false,
 	},
 	{


### PR DESCRIPTION
close: https://github.com/kayac/ecspresso/issues/906

In `ecspresso verify`, support [digest-based image reference](https://docs.docker.com/dhi/core-concepts/digests/) in task
definition file like a:

```json
{
  # ...
  "containerDefinitions": [
    {
      "image": "nginx@sha256:553f64aecdc31b5bf944521731cd70e35da4faed96b2b7548a3d8e2598c52a42"
    }
  ]
  # ...
}
```

This change enables correct image existence checks and other operations even when using digest-based image references. Previously, the `verify` command only supported tag-based image references (e.g., `debian:latest`), so it would unconditionally return a 404 when using digest-based image references.

I confirmed that it works on my local:
```console
kayac/ecspresso/verify-failed-with-image-digest (main)🔥 on ☁️  (ap-northeast-1)
$ /Users/wada.mitsuaki/ghq/github.com/mi-wada/ecspresso/ecspresso verify --debug
2025-11-25T12:55:15.814+09:00 [INFO] ecspresso version:
2025-11-25T12:55:15.816+09:00 [DEBUG] [example/main] config file path: ecspresso.yml
2025-11-25T12:55:15.816+09:00 [DEBUG] [example/main] timeout: 10m0s
2025-11-25T12:55:15.817+09:00 [DEBUG] [example/main] dispatching subcommand: verify
2025-11-25T12:55:15.817+09:00 [INFO] [example/main] executionRoleArn is not set. Continue to verify with current session.
2025-11-25T12:55:15.817+09:00 [INFO] [example/main] Starting verify
2025-11-25T12:55:15.817+09:00 [DEBUG] [example/main] VERIFY Registry Image nginx@sha256:553f64aecdc31b5bf944521731cd70e35da4faed96b2b7548a3d8e2598c52a42
2025-11-25T12:55:15.817+09:00 [DEBUG] [example/main] imageName=nginx tagOrDigest=sha256:553f64aecdc31b5bf944521731cd70e35da4faed96b2b7548a3d8e2598c52a42
      Image[nginx@sha256:553f64aecdc31b5bf944521731cd70e35da4faed96b2b7548a3d8e2598c52a42]
      --> [OK]
    ContainerDefinition[]
    --> [OK]
  TaskDefinition
  --> [OK]
  ServiceDefinition
  --> [SKIP] no ServiceDefinition
  Cluster
  --> [OK]
2025-11-25T12:55:17.310+09:00 [INFO] [example/main] Verify OK!

kayac/ecspresso/verify-failed-with-image-digest (main)🔥 on ☁️  (ap-northeast-1)
$ cat ecspresso.yml
region: "ap-northeast-1"
cluster: main
service: example
task_definition: ecs-task-def.json
timeout: "10m0s"

kayac/ecspresso/verify-failed-with-image-digest (main)🔥 on ☁️  (ap-northeast-1)
$ cat ecs-task-def.json
{
  "containerDefinitions": [
    {
      "image": "nginx@sha256:553f64aecdc31b5bf944521731cd70e35da4faed96b2b7548a3d8e2598c52a42"
    }
  ]
}
```
