### PR TITLE
fix verify to parse IAM Trust Policy with array format Principal.Service

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,99 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+ecspresso is a deployment tool for Amazon ECS written in Go. It manages ECS services through configuration files (YAML, JSON, or Jsonnet) that define task definitions and service definitions.
+
+## Build Commands
+
+```bash
+# Build the binary
+make
+
+# Install to GOPATH/bin
+make install
+
+# Run all tests
+make test
+
+# Run a single test
+go test -v -run TestFunctionName ./...
+
+# Format code (run before committing)
+go fmt ./...
+
+# Build release packages
+make packages
+```
+
+## Architecture
+
+### Core Components
+
+- **App** (`ecspresso.go`): Main application struct that holds AWS clients (ECS, CodeDeploy, CloudWatch Logs, IAM, etc.) and orchestrates operations
+- **Config** (`config.go`): Configuration loading and validation. Supports YAML, JSON, and Jsonnet formats with template functions
+- **CLI** (`cli.go`, `cliv2.go`): Command-line interface using Kong. Each subcommand (deploy, run, diff, etc.) has its own option struct and handler
+
+### Command Structure
+
+Commands are defined as option structs in their respective files:
+- `deploy.go` - Deploy/update ECS services (rolling update, Blue/Green via ECS or CodeDeploy)
+- `run.go` - Run standalone ECS tasks
+- `rollback.go` - Rollback to previous task definition
+- `diff.go` - Show differences between local and remote definitions
+- `verify.go` - Validate configurations and AWS resources
+- `init.go` - Generate config from existing ECS service
+
+### Template System
+
+Definition files support Go template syntax via `github.com/kayac/go-config`:
+- `{{ env "VAR" "default" }}` - Environment variable with default
+- `{{ must_env "VAR" }}` - Required environment variable
+- `{{ tfstate "resource.attr" }}` - Terraform state lookup (plugin)
+
+### Plugin System (`plugin.go`)
+
+Plugins extend template functions and Jsonnet native functions:
+- `tfstate` - Terraform state lookups
+- `cloudformation` - CloudFormation output/export lookups
+- `ssm` - SSM Parameter Store lookups
+- `secretsmanager` - Secrets Manager ARN resolution
+- `external` - Execute external commands
+
+### AWS SDK Usage
+
+Uses AWS SDK for Go v2. Key clients are initialized in `New()` function based on configuration.
+
+### Key Types
+
+- `Service` - Wraps `types.Service` with additional fields (ServiceConnectConfiguration, VolumeConfigurations, VpcLatticeConfigurations)
+- `TaskDefinitionInput` - Wraps `ecs.RegisterTaskDefinitionInput`
+- `TaskDefinition` - Wraps `types.TaskDefinition`
+
+## Testing
+
+Tests use the standard Go testing framework. Test files are colocated with implementation files (`*_test.go`).
+
+```bash
+# Run specific test file
+go test -v ./... -run TestConfig
+
+# Run with race detection
+go test -race ./...
+```
+
+- Use `github.com/google/go-cmp/cmp` for value comparisons in tests
+  ```go
+  if diff := cmp.Diff(want, got); diff != "" {
+      t.Errorf("mismatch (-want +got):\n%s", diff)
+  }
+  ```
+
+## Code Style
+
+- Use `go fmt ./...` before committing
+- Error messages should be lowercase and not end with punctuation
+- Use `fmt.Errorf("failed to X: %w", err)` for error wrapping
+- Logging uses `slog` via helper methods (LogInfo, LogWarn, LogDebug)

--- a/export_test.go
+++ b/export_test.go
@@ -11,30 +11,37 @@ import (
 )
 
 var (
-	SortTaskDefinition  = sortTaskDefinition
-	ToNumberCPU         = toNumberCPU
-	ToNumberMemory      = toNumberMemory
-	CalcDesiredCount    = calcDesiredCount
-	ParseTags           = parseTags
-	ParseImageURL       = parseImageURL
-	ExtractRoleName     = extractRoleName
-	IsLongArnFormat     = isLongArnFormat
-	ECRImageURLRegex    = ecrImageURLRegex
-	NewLogger           = newLogger
-	NewConfigLoader     = newConfigLoader
-	LogLevel            = logLevel
-	SetLogFormat        = setLogFormat
-	NewVerifier         = newVerifier
-	ArnToName           = arnToName
-	NewVerifyState      = newVerifyState
-	Map2str             = map2str
-	DiffServices        = diffServices
-	DiffTaskDefs        = diffTaskDefs
-	IsPermissionError   = isPermissionError
-	WrapPermissionError = wrapPermissionError
+	SortTaskDefinition     = sortTaskDefinition
+	ToNumberCPU            = toNumberCPU
+	ToNumberMemory         = toNumberMemory
+	CalcDesiredCount       = calcDesiredCount
+	ParseTags              = parseTags
+	ParseImageURL          = parseImageURL
+	ExtractRoleName        = extractRoleName
+	IsLongArnFormat        = isLongArnFormat
+	ECRImageURLRegex       = ecrImageURLRegex
+	NewLogger              = newLogger
+	NewConfigLoader        = newConfigLoader
+	LogLevel               = logLevel
+	SetLogFormat           = setLogFormat
+	NewVerifier            = newVerifier
+	ArnToName              = arnToName
+	NewVerifyState         = newVerifyState
+	Map2str                = map2str
+	DiffServices           = diffServices
+	DiffTaskDefs           = diffTaskDefs
+	IsPermissionError      = isPermissionError
+	WrapPermissionError    = wrapPermissionError
+	ParseIAMPolicyDocument = parseIAMPolicyDocument
 )
 
 type ModifyAutoScalingParams = modifyAutoScalingParams
+type IAMPolicyDocument = iamPolicyDocument
+type StringOrSlice = stringOrSlice
+
+func (s StringOrSlice) Contains(v string) bool {
+	return s.contains(v)
+}
 
 func (d *App) SetLogger(logger *slog.Logger) {
 	d.logger = logger

--- a/verify.go
+++ b/verify.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -1042,11 +1043,35 @@ func (d *App) verifyRole(ctx context.Context, roleArn, principalService string) 
 		return fmt.Errorf("failed to parse IAM policy document: %w", err)
 	}
 	for _, st := range doc.Statement {
-		if st.Principal.Service == principalService && st.Action == "sts:AssumeRole" {
+		if st.Principal.Service.contains(principalService) && st.Action.contains("sts:AssumeRole") {
 			return nil
 		}
 	}
 	return fmt.Errorf("role %s has not a valid policy document", roleName)
+}
+
+// stringOrSlice is a type that can unmarshal from either a string or an array of strings.
+// IAM policy documents allow both formats for fields like Principal.Service and Action.
+type stringOrSlice []string
+
+func (s *stringOrSlice) UnmarshalJSON(data []byte) error {
+	// Try to unmarshal as a string first
+	var str string
+	if err := json.Unmarshal(data, &str); err == nil {
+		*s = []string{str}
+		return nil
+	}
+	// Try to unmarshal as an array of strings
+	var arr []string
+	if err := json.Unmarshal(data, &arr); err != nil {
+		return err
+	}
+	*s = arr
+	return nil
+}
+
+func (s stringOrSlice) contains(v string) bool {
+	return slices.Contains(s, v)
 }
 
 type iamPolicyDocument struct {
@@ -1054,9 +1079,9 @@ type iamPolicyDocument struct {
 	Statement []struct {
 		Effect    string `json:"Effect"`
 		Principal struct {
-			Service string `json:"Service"`
+			Service stringOrSlice `json:"Service"`
 		} `json:"Principal"`
-		Action string `json:"Action"`
+		Action stringOrSlice `json:"Action"`
 	} `json:"Statement"`
 }
 

--- a/verify_test.go
+++ b/verify_test.go
@@ -501,3 +501,90 @@ func TestWrapPermissionError(t *testing.T) {
 		})
 	}
 }
+
+func TestParseIAMPolicyDocument(t *testing.T) {
+	tests := []struct {
+		name            string
+		input           string
+		containsService string
+		containsAction  string
+		wantErr         bool
+	}{
+		{
+			name: "string format for Service and Action",
+			input: `{
+				"Version": "2012-10-17",
+				"Statement": [{
+					"Effect": "Allow",
+					"Principal": {"Service": "ecs-tasks.amazonaws.com"},
+					"Action": "sts:AssumeRole"
+				}]
+			}`,
+			containsService: "ecs-tasks.amazonaws.com",
+			containsAction:  "sts:AssumeRole",
+			wantErr:         false,
+		},
+		{
+			name: "array format for Service and Action",
+			input: `{
+				"Version": "2012-10-17",
+				"Statement": [{
+					"Effect": "Allow",
+					"Principal": {"Service": ["ecs-tasks.amazonaws.com"]},
+					"Action": ["sts:AssumeRole"]
+				}]
+			}`,
+			containsService: "ecs-tasks.amazonaws.com",
+			containsAction:  "sts:AssumeRole",
+			wantErr:         false,
+		},
+		{
+			name: "array format with multiple services",
+			input: `{
+				"Version": "2012-10-17",
+				"Statement": [{
+					"Effect": "Allow",
+					"Principal": {"Service": ["ecs-tasks.amazonaws.com", "ec2.amazonaws.com"]},
+					"Action": ["sts:AssumeRole", "sts:TagSession"]
+				}]
+			}`,
+			containsService: "ecs-tasks.amazonaws.com",
+			containsAction:  "sts:AssumeRole",
+			wantErr:         false,
+		},
+		{
+			name:            "URL encoded input",
+			input:           `%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Service%22%3A%22ecs-tasks.amazonaws.com%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%7D%5D%7D`,
+			containsService: "ecs-tasks.amazonaws.com",
+			containsAction:  "sts:AssumeRole",
+			wantErr:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc, err := ecspresso.ParseIAMPolicyDocument(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseIAMPolicyDocument() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+
+			if len(doc.Statement) == 0 {
+				t.Error("ParseIAMPolicyDocument() returned empty statement")
+				return
+			}
+
+			stmt := doc.Statement[0]
+
+			if !ecspresso.StringOrSlice(stmt.Principal.Service).Contains(tt.containsService) {
+				t.Errorf("ParseIAMPolicyDocument() Service does not contain %q, got %v", tt.containsService, stmt.Principal.Service)
+			}
+			if !ecspresso.StringOrSlice(stmt.Action).Contains(tt.containsAction) {
+				t.Errorf("ParseIAMPolicyDocument() Action does not contain %q, got %v", tt.containsAction, stmt.Action)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add `stringOrSlice` type to handle both string and array formats in IAM policy documents
- Fix `ecspresso verify` to correctly parse Trust Policies with `Principal.Service` defined as an array
- Refs #931

🤖 Generated with [Claude Code](https://claude.com/claude-code)