### PR TITLE
Add docs subcommand and LLM agent skill guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1192,13 +1192,23 @@ $ ecspresso docs --search "deploy" --json
 
 The JSON output contains structured sections with `level`, `title`, `content`, and `line` fields, making it easy for automated tools and LLM agents to consume ecspresso documentation programmatically.
 
+Available articles: `readme` (default), `skill`.
+
+Show the LLM agent skill guide:
+
+```console
+$ ecspresso docs --article skill
+```
+
 ### LLM agent integration
 
-ecspresso provides [`skills/SKILL.md`](skills/SKILL.md) as a guide for LLM agents (such as Claude Code, ChatGPT, etc.) to use ecspresso effectively. The skill file covers common workflows, command usage patterns, and best practices including the recommendation to use Jsonnet over JSON/YAML for definition files.
+ecspresso provides a skill guide for LLM agents (such as Claude Code, ChatGPT, etc.) to use ecspresso effectively. The skill guide covers common workflows, command usage patterns, and best practices including the recommendation to use Jsonnet over JSON/YAML for definition files.
+
+The skill guide is embedded in the binary and can be accessed via `ecspresso docs --article skill`. No separate file installation is needed.
 
 To integrate ecspresso with an LLM agent:
 
-1. Include `skills/SKILL.md` in the agent's context (e.g., via CLAUDE.md, system prompt, or tool description).
+1. Add a line to the agent's instructions (e.g., CLAUDE.md): `Run ecspresso docs --article skill to learn how to use ecspresso.`
 2. The agent can then use `ecspresso docs --search "<keyword>" --json` to look up specific topics at runtime.
 
 This combination allows an LLM agent to deploy, manage, and troubleshoot ECS services through ecspresso with minimal human guidance.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ ecspresso also supports ECS Express mode for simplified deployments and provides
   - [Diff and Verify](#how-to-check-diff-and-verify-servicetask-definitions-before-deploy)
   - [Manipulate ECS tasks](#manipulate-ecs-tasks)
   - [Show documentation](#show-documentation)
+  - [LLM agent integration](#llm-agent-integration)
 - [Plugins](#plugins)
   - [tfstate](#tfstate)
   - [CloudFormation](#cloudformation)
@@ -1190,6 +1191,17 @@ $ ecspresso docs --search "deploy" --json
 ```
 
 The JSON output contains structured sections with `level`, `title`, `content`, and `line` fields, making it easy for automated tools and LLM agents to consume ecspresso documentation programmatically.
+
+### LLM agent integration
+
+ecspresso provides [`skills/SKILL.md`](skills/SKILL.md) as a guide for LLM agents (such as Claude Code, ChatGPT, etc.) to use ecspresso effectively. The skill file covers common workflows, command usage patterns, and best practices including the recommendation to use Jsonnet over JSON/YAML for definition files.
+
+To integrate ecspresso with an LLM agent:
+
+1. Include `skills/SKILL.md` in the agent's context (e.g., via CLAUDE.md, system prompt, or tool description).
+2. The agent can then use `ecspresso docs --search "<keyword>" --json` to look up specific topics at runtime.
+
+This combination allows an LLM agent to deploy, manage, and troubleshoot ECS services through ecspresso with minimal human guidance.
 
 ## Plugins
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ ecspresso also supports ECS Express mode for simplified deployments and provides
   - [ECS Express mode support](#ecs-express-mode-support)
   - [Diff and Verify](#how-to-check-diff-and-verify-servicetask-definitions-before-deploy)
   - [Manipulate ECS tasks](#manipulate-ecs-tasks)
+  - [Show documentation](#show-documentation)
 - [Plugins](#plugins)
   - [tfstate](#tfstate)
   - [CloudFormation](#cloudformation)
@@ -217,6 +218,9 @@ Commands:
   diff
     show diff between task definition, service definition with current running
     service and task definition
+
+  docs
+    show documentation for ecspresso
 
   exec
     execute command on task
@@ -1148,6 +1152,44 @@ The `-L` option is a short expression for `local-port:host:port`. For example, `
 ```
 $ ecspresso exec --port-forward -L 8080:example.com:80
 ```
+
+### Show documentation
+
+The `docs` command shows the embedded documentation (this README) directly from the ecspresso binary. This command does not require AWS credentials or a configuration file.
+
+```
+Flags:
+      --article="readme"          article name to display
+      --index                     show table of contents
+      --search=""                 search keyword in documents
+      --json                      output in JSON format
+```
+
+Show the full README:
+
+```console
+$ ecspresso docs
+```
+
+Show the table of contents with section headings and line numbers:
+
+```console
+$ ecspresso docs --index
+```
+
+Search for sections containing a keyword (case-insensitive):
+
+```console
+$ ecspresso docs --search "fargate"
+```
+
+Output in JSON format (useful for LLM agents and other tools):
+
+```console
+$ ecspresso docs --search "deploy" --json
+```
+
+The JSON output contains structured sections with `level`, `title`, `content`, and `line` fields, making it easy for automated tools and LLM agents to consume ecspresso documentation programmatically.
 
 ## Plugins
 

--- a/cli.go
+++ b/cli.go
@@ -25,6 +25,7 @@ type CLIOptions struct {
 	Deploy     *DeployOption     `cmd:"" help:"deploy service"`
 	Deregister *DeregisterOption `cmd:"" help:"deregister task definition"`
 	Diff       *DiffOption       `cmd:"" help:"show diff between task definition, service definition with current running service and task definition"`
+	Docs       *DocsOption       `cmd:"" help:"show documentation for ecspresso"`
 	Exec       *ExecOption       `cmd:"" help:"execute command on task"`
 	Init       *InitOption       `cmd:"" help:"create configuration files from existing ECS service"`
 	Refresh    *RefreshOption    `cmd:"" help:"refresh service. equivalent to deploy --skip-task-definition --force-new-deployment --no-update-service"`
@@ -71,6 +72,8 @@ func (opts *CLIOptions) ForSubCommand(sub string) any {
 		return opts.Deregister
 	case "diff":
 		return opts.Diff
+	case "docs":
+		return opts.Docs
 	case "exec":
 		return opts.Exec
 	case "init":
@@ -107,6 +110,8 @@ func dispatchCLI(ctx context.Context, sub string, usage func(), opts *CLIOptions
 	case "version", "":
 		_, err := WriteOutput("ecspresso " + Version)
 		return err
+	case "docs":
+		return Docs(*opts.Docs)
 	}
 	var appOpts []AppOption
 	if sub == "init" {

--- a/cli_test.go
+++ b/cli_test.go
@@ -800,6 +800,11 @@ var cliTests = []struct {
 		subOption: &ecspresso.DocsOption{Article: "readme", Index: true, JSON: true},
 	},
 	{
+		args:      []string{"docs", "--article", "skill"},
+		sub:       "docs",
+		subOption: &ecspresso.DocsOption{Article: "skill"},
+	},
+	{
 		args: []string{"diff"},
 		sub:  "diff",
 		subOption: &ecspresso.DiffOption{

--- a/cli_test.go
+++ b/cli_test.go
@@ -775,6 +775,31 @@ var cliTests = []struct {
 		},
 	},
 	{
+		args:      []string{"docs"},
+		sub:       "docs",
+		subOption: &ecspresso.DocsOption{Article: "readme"},
+	},
+	{
+		args:      []string{"docs", "--index"},
+		sub:       "docs",
+		subOption: &ecspresso.DocsOption{Article: "readme", Index: true},
+	},
+	{
+		args:      []string{"docs", "--search", "fargate"},
+		sub:       "docs",
+		subOption: &ecspresso.DocsOption{Article: "readme", Search: "fargate"},
+	},
+	{
+		args:      []string{"docs", "--json"},
+		sub:       "docs",
+		subOption: &ecspresso.DocsOption{Article: "readme", JSON: true},
+	},
+	{
+		args:      []string{"docs", "--index", "--json"},
+		sub:       "docs",
+		subOption: &ecspresso.DocsOption{Article: "readme", Index: true, JSON: true},
+	},
+	{
 		args: []string{"diff"},
 		sub:  "diff",
 		subOption: &ecspresso.DiffOption{

--- a/docs.go
+++ b/docs.go
@@ -10,7 +10,7 @@ import (
 
 // DocsOption defines CLI options for the docs subcommand.
 type DocsOption struct {
-	Article string `help:"article name to display" default:"readme" enum:"readme"`
+	Article string `help:"article name to display" default:"readme" enum:"readme,skill"`
 	Index   bool   `help:"show table of contents" default:"false"`
 	Search  string `help:"search keyword in documents" default:""`
 	JSON    bool   `help:"output in JSON format" default:"false" name:"json"`
@@ -53,6 +53,8 @@ func getArticle(name string) (string, error) {
 	switch name {
 	case "readme":
 		return readmeContent, nil
+	case "skill":
+		return skillContent, nil
 	default:
 		return "", fmt.Errorf("unknown article: %s", name)
 	}

--- a/docs.go
+++ b/docs.go
@@ -1,0 +1,205 @@
+package ecspresso
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// DocsOption defines CLI options for the docs subcommand.
+type DocsOption struct {
+	Article string `help:"article name to display" default:"readme" enum:"readme"`
+	Index   bool   `help:"show table of contents" default:"false"`
+	Search  string `help:"search keyword in documents" default:""`
+	JSON    bool   `help:"output in JSON format" default:"false" name:"json"`
+}
+
+type docsSection struct {
+	Level   int    `json:"level"`
+	Title   string `json:"title"`
+	Content string `json:"content,omitempty"`
+	Line    int    `json:"line"`
+}
+
+type docsOutput struct {
+	Article  string        `json:"article"`
+	Mode     string        `json:"mode"`
+	Query    string        `json:"query,omitempty"`
+	Sections []docsSection `json:"sections"`
+}
+
+// Docs shows embedded documentation.
+func Docs(opt DocsOption) error {
+	content, err := getArticle(opt.Article)
+	if err != nil {
+		return err
+	}
+
+	jsonOutput := opt.JSON || logFormat == logFormatJSON
+
+	switch {
+	case opt.Index:
+		return docsIndex(opt.Article, content, jsonOutput)
+	case opt.Search != "":
+		return docsSearch(opt.Article, content, opt.Search, jsonOutput)
+	default:
+		return docsFull(opt.Article, content, jsonOutput)
+	}
+}
+
+func getArticle(name string) (string, error) {
+	switch name {
+	case "readme":
+		return readmeContent, nil
+	default:
+		return "", fmt.Errorf("unknown article: %s", name)
+	}
+}
+
+func docsFull(article, content string, jsonOutput bool) error {
+	if !jsonOutput {
+		_, err := io.WriteString(os.Stdout, content)
+		return err
+	}
+	sections := parseSections(content)
+	out := docsOutput{
+		Article:  article,
+		Mode:     "full",
+		Sections: sections,
+	}
+	return writeJSON(out)
+}
+
+func docsIndex(article, content string, jsonOutput bool) error {
+	sections := parseSections(content)
+
+	if !jsonOutput {
+		var buf strings.Builder
+		for _, s := range sections {
+			indent := strings.Repeat("  ", s.Level-1)
+			prefix := strings.Repeat("#", s.Level)
+			fmt.Fprintf(&buf, "%s%s %s (L%d)\n", indent, prefix, s.Title, s.Line)
+		}
+		_, err := io.WriteString(os.Stdout, buf.String())
+		return err
+	}
+
+	indexSections := make([]docsSection, len(sections))
+	for i, s := range sections {
+		indexSections[i] = docsSection{
+			Level: s.Level,
+			Title: s.Title,
+			Line:  s.Line,
+		}
+	}
+	out := docsOutput{
+		Article:  article,
+		Mode:     "index",
+		Sections: indexSections,
+	}
+	return writeJSON(out)
+}
+
+func docsSearch(article, content, query string, jsonOutput bool) error {
+	sections := parseSections(content)
+	lowerQuery := strings.ToLower(query)
+
+	var matched []docsSection
+	for _, s := range sections {
+		if strings.Contains(strings.ToLower(s.Content), lowerQuery) {
+			matched = append(matched, s)
+		}
+	}
+
+	if len(matched) == 0 {
+		return fmt.Errorf("no sections found matching %q in article %q", query, article)
+	}
+
+	if !jsonOutput {
+		var buf strings.Builder
+		for i, s := range matched {
+			if i > 0 {
+				buf.WriteString("\n---\n\n")
+			}
+			buf.WriteString(strings.TrimRight(s.Content, "\n"))
+			buf.WriteString("\n")
+		}
+		_, err := io.WriteString(os.Stdout, buf.String())
+		return err
+	}
+
+	out := docsOutput{
+		Article:  article,
+		Mode:     "search",
+		Query:    query,
+		Sections: matched,
+	}
+	return writeJSON(out)
+}
+
+func writeJSON(v any) error {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal json: %w", err)
+	}
+	b = append(b, '\n')
+	_, err = os.Stdout.Write(b)
+	return err
+}
+
+// parseSections parses markdown content into leaf sections.
+// Each section starts at a heading (line beginning with #) and extends
+// until the next heading of any level. Lines inside fenced code blocks
+// are not treated as headings.
+func parseSections(content string) []docsSection {
+	lines := strings.Split(content, "\n")
+	var sections []docsSection
+	var current *docsSection
+	var body strings.Builder
+	inCodeBlock := false
+
+	for i, line := range lines {
+		if strings.HasPrefix(line, "```") {
+			inCodeBlock = !inCodeBlock
+		}
+
+		if !inCodeBlock && strings.HasPrefix(line, "#") {
+			// flush previous section
+			if current != nil {
+				current.Content = body.String()
+				sections = append(sections, *current)
+			}
+
+			level := 0
+			for _, c := range line {
+				if c == '#' {
+					level++
+				} else {
+					break
+				}
+			}
+			title := strings.TrimSpace(line[level:])
+
+			current = &docsSection{
+				Level: level,
+				Title: title,
+				Line:  i + 1, // 1-based
+			}
+			body.Reset()
+			body.WriteString(line)
+			body.WriteString("\n")
+		} else if current != nil {
+			body.WriteString(line)
+			body.WriteString("\n")
+		}
+	}
+	// flush last section
+	if current != nil {
+		current.Content = body.String()
+		sections = append(sections, *current)
+	}
+
+	return sections
+}

--- a/docs_embed.go
+++ b/docs_embed.go
@@ -4,3 +4,6 @@ import _ "embed"
 
 //go:embed README.md
 var readmeContent string
+
+//go:embed skills/SKILL.md
+var skillContent string

--- a/docs_embed.go
+++ b/docs_embed.go
@@ -1,0 +1,6 @@
+package ecspresso
+
+import _ "embed"
+
+//go:embed README.md
+var readmeContent string

--- a/docs_test.go
+++ b/docs_test.go
@@ -153,6 +153,26 @@ func TestDocsSearchNoMatch(t *testing.T) {
 	}
 }
 
+func TestParseSectionsSkill(t *testing.T) {
+	content := ecspresso.SkillContent
+	sections := ecspresso.ParseSections(content)
+
+	if len(sections) == 0 {
+		t.Fatal("expected non-zero sections from SKILL.md")
+	}
+
+	titles := make(map[string]bool)
+	for _, s := range sections {
+		titles[s.Title] = true
+	}
+
+	for _, expected := range []string{"ecspresso Skill for LLM Agents", "Common workflows", "Configuration structure"} {
+		if !titles[expected] {
+			t.Errorf("expected heading %q not found in SKILL.md sections", expected)
+		}
+	}
+}
+
 func TestDocsOptionDefault(t *testing.T) {
 	want := &ecspresso.DocsOption{
 		Article: "readme",

--- a/docs_test.go
+++ b/docs_test.go
@@ -1,0 +1,172 @@
+package ecspresso_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/kayac/ecspresso/v2"
+)
+
+func TestParseSections(t *testing.T) {
+	content := "# Title\n\nIntro text.\n\n## Section A\n\nBody A.\n\n### Subsection A1\n\nBody A1.\n\n## Section B\n\nBody B.\n"
+	sections := ecspresso.ParseSections(content)
+
+	if len(sections) != 4 {
+		t.Fatalf("expected 4 sections, got %d", len(sections))
+	}
+
+	want := []struct {
+		level int
+		title string
+		line  int
+	}{
+		{1, "Title", 1},
+		{2, "Section A", 5},
+		{3, "Subsection A1", 9},
+		{2, "Section B", 13},
+	}
+
+	for i, w := range want {
+		s := sections[i]
+		if s.Level != w.level {
+			t.Errorf("section[%d] level: want %d, got %d", i, w.level, s.Level)
+		}
+		if s.Title != w.title {
+			t.Errorf("section[%d] title: want %q, got %q", i, w.title, s.Title)
+		}
+		if s.Line != w.line {
+			t.Errorf("section[%d] line: want %d, got %d", i, w.line, s.Line)
+		}
+	}
+
+	// verify content of first section includes intro text
+	if !strings.Contains(sections[0].Content, "Intro text.") {
+		t.Errorf("section[0] content should contain 'Intro text.', got %q", sections[0].Content)
+	}
+
+	// verify section A does not contain subsection A1 content
+	if strings.Contains(sections[1].Content, "Body A1.") {
+		t.Errorf("section[1] should not contain 'Body A1.' (leaf section)")
+	}
+}
+
+func TestParseSectionsCodeBlock(t *testing.T) {
+	content := "## Real Section\n\n```yaml\n# this is a comment not a heading\nfoo: bar\n```\n\n## Next Section\n\nBody.\n"
+	sections := ecspresso.ParseSections(content)
+
+	if len(sections) != 2 {
+		t.Fatalf("expected 2 sections (code block # should be ignored), got %d", len(sections))
+	}
+
+	if sections[0].Title != "Real Section" {
+		t.Errorf("section[0] title: want %q, got %q", "Real Section", sections[0].Title)
+	}
+	if sections[1].Title != "Next Section" {
+		t.Errorf("section[1] title: want %q, got %q", "Next Section", sections[1].Title)
+	}
+
+	// verify the code block content is in the first section
+	if !strings.Contains(sections[0].Content, "# this is a comment not a heading") {
+		t.Errorf("section[0] should contain code block content")
+	}
+}
+
+func TestParseSectionsEmpty(t *testing.T) {
+	sections := ecspresso.ParseSections("")
+	if len(sections) != 0 {
+		t.Errorf("expected 0 sections for empty content, got %d", len(sections))
+	}
+}
+
+func TestParseSectionsReadme(t *testing.T) {
+	content := ecspresso.ReadmeContent
+	sections := ecspresso.ParseSections(content)
+
+	if len(sections) == 0 {
+		t.Fatal("expected non-zero sections from README.md")
+	}
+
+	// verify well-known headings exist
+	titles := make(map[string]bool)
+	for _, s := range sections {
+		titles[s.Title] = true
+	}
+
+	for _, expected := range []string{"ecspresso", "Install", "Usage", "Plugins"} {
+		if !titles[expected] {
+			t.Errorf("expected heading %q not found in README.md sections", expected)
+		}
+	}
+
+	// verify first section is the top-level heading
+	if sections[0].Level != 1 || sections[0].Title != "ecspresso" {
+		t.Errorf("first section should be '# ecspresso', got level=%d title=%q", sections[0].Level, sections[0].Title)
+	}
+}
+
+func TestDocsSearch(t *testing.T) {
+	content := ecspresso.ReadmeContent
+	sections := ecspresso.ParseSections(content)
+
+	query := "fargate"
+	lowerQuery := strings.ToLower(query)
+	var matched []string
+	for _, s := range sections {
+		if strings.Contains(strings.ToLower(s.Content), lowerQuery) {
+			matched = append(matched, s.Title)
+		}
+	}
+
+	if len(matched) == 0 {
+		t.Fatal("expected at least one section matching 'fargate'")
+	}
+
+	// verify well-known fargate sections
+	found := false
+	for _, title := range matched {
+		if strings.Contains(strings.ToLower(title), "fargate") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected a section with 'fargate' in the title among matched sections: %v", matched)
+	}
+}
+
+func TestDocsSearchNoMatch(t *testing.T) {
+	content := "# Title\n\nSome content.\n"
+	sections := ecspresso.ParseSections(content)
+
+	query := "zzz_nonexistent_keyword_zzz"
+	lowerQuery := strings.ToLower(query)
+	var matched int
+	for _, s := range sections {
+		if strings.Contains(strings.ToLower(s.Content), lowerQuery) {
+			matched++
+		}
+	}
+
+	if matched != 0 {
+		t.Errorf("expected 0 matches for non-existent keyword, got %d", matched)
+	}
+}
+
+func TestDocsOptionDefault(t *testing.T) {
+	want := &ecspresso.DocsOption{
+		Article: "readme",
+		Index:   false,
+		Search:  "",
+		JSON:    false,
+	}
+	args := []string{"docs"}
+	_, opts, _, err := ecspresso.ParseCLIv2(args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := opts.ForSubCommand("docs")
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("DocsOption mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/export_test.go
+++ b/export_test.go
@@ -33,6 +33,8 @@ var (
 	IsPermissionError      = isPermissionError
 	WrapPermissionError    = wrapPermissionError
 	ParseIAMPolicyDocument = parseIAMPolicyDocument
+	ParseSections          = parseSections
+	ReadmeContent          = readmeContent
 )
 
 type ModifyAutoScalingParams = modifyAutoScalingParams

--- a/export_test.go
+++ b/export_test.go
@@ -35,6 +35,7 @@ var (
 	ParseIAMPolicyDocument = parseIAMPolicyDocument
 	ParseSections          = parseSections
 	ReadmeContent          = readmeContent
+	SkillContent           = skillContent
 )
 
 type ModifyAutoScalingParams = modifyAutoScalingParams

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -1,0 +1,174 @@
+# ecspresso Skill for LLM Agents
+
+## Overview
+
+ecspresso is a deployment tool for Amazon ECS. You can use it to deploy, manage, and troubleshoot ECS services through configuration files.
+
+## Learning about ecspresso
+
+Use the `docs` subcommand to look up how ecspresso works. This command requires no AWS credentials or config file.
+
+```bash
+# Browse the table of contents to find relevant sections
+ecspresso docs --index --json
+
+# Search for a topic by keyword
+ecspresso docs --search "fargate" --json
+
+# Read the full documentation
+ecspresso docs --json
+```
+
+Always use `--json` for structured output that is easier to parse.
+
+## Common workflows
+
+### Check current state before making changes
+
+```bash
+# Show service status (running tasks, deployments, events)
+ecspresso status --config ecspresso.yml
+
+# Show differences between local definitions and running service
+ecspresso diff --config ecspresso.yml
+
+# Verify that resources referenced in definitions exist and are valid
+ecspresso verify --config ecspresso.yml
+```
+
+### Deploy
+
+```bash
+# Preview what will change (dry-run)
+ecspresso deploy --config ecspresso.yml --dry-run
+
+# Deploy the service
+ecspresso deploy --config ecspresso.yml
+
+# Deploy and wait until stable
+ecspresso deploy --config ecspresso.yml --wait-until stable
+```
+
+### Rollback
+
+```bash
+# Rollback to the previous task definition
+ecspresso rollback --config ecspresso.yml
+
+# Rollback with dry-run
+ecspresso rollback --config ecspresso.yml --dry-run
+```
+
+### Scale
+
+```bash
+# Scale to a specific number of tasks
+ecspresso scale --config ecspresso.yml --tasks 5
+```
+
+### Run a one-off task
+
+```bash
+# Run a standalone task using the service's task definition
+ecspresso run --config ecspresso.yml
+
+# Run and watch logs
+ecspresso run --config ecspresso.yml --watch-container app
+```
+
+### Inspect tasks
+
+```bash
+# List running tasks as JSON
+ecspresso tasks --config ecspresso.yml --output json
+```
+
+### Render configuration for inspection
+
+```bash
+# Render resolved task definition (with template variables expanded)
+ecspresso render --config ecspresso.yml taskdef
+
+# Render resolved service definition
+ecspresso render --config ecspresso.yml servicedef
+```
+
+## Configuration structure
+
+ecspresso uses a config file (default: `ecspresso.yml`) that references a task definition file and optionally a service definition file.
+
+```
+ecspresso.yml          # Main config: region, cluster, service, file paths
+ecs-task-def.json      # ECS task definition (JSON, YAML, or Jsonnet)
+ecs-service-def.json   # ECS service definition (JSON, YAML, or Jsonnet)
+```
+
+Definition files support template syntax: `{{ env "VAR" "default" }}`, `{{ must_env "VAR" }}`, and plugin functions like `{{ tfstate "resource.attr" }}`.
+
+### Jsonnet is recommended over JSON/YAML
+
+When creating or modifying definition files, prefer the Jsonnet (`.jsonnet`) format over JSON or YAML. Jsonnet has several advantages:
+
+- **Comments**: Jsonnet supports `//` and `/* */` comments. JSON does not allow comments at all.
+- **Trailing commas**: No need to worry about trailing comma errors.
+- **Variables and functions**: You can define local variables, reuse values, and compute derived values with `std.parseInt()`, `std.parseJson()`, etc.
+- **No template syntax conflicts**: In JSON/YAML, Go template syntax `{{ }}` can cause readability issues. In Jsonnet, use native functions like `std.native('env')('VAR', 'default')` instead, which are cleaner and can return non-string types.
+- **No separate install needed**: ecspresso bundles the Jsonnet library.
+
+Example Jsonnet config:
+
+```jsonnet
+// ecspresso.jsonnet
+{
+  region: 'ap-northeast-1',
+  cluster: 'default',
+  service: 'myservice',
+  service_definition: 'ecs-service-def.jsonnet',
+  task_definition: 'ecs-task-def.jsonnet',
+}
+```
+
+Example Jsonnet task definition:
+
+```jsonnet
+// ecs-task-def.jsonnet
+local env = std.native('env');
+local must_env = std.native('must_env');
+local tfstate = std.native('tfstate');
+{
+  family: 'myservice',
+  cpu: '256',
+  memory: '512',
+  networkMode: 'awsvpc',
+  requiresCompatibilities: ['FARGATE'],
+  executionRoleArn: tfstate('aws_iam_role.ecs_execution.arn'),
+  containerDefinitions: [
+    {
+      name: 'app',
+      image: must_env('APP_IMAGE'),
+      cpu: 0,
+      portMappings: [{ containerPort: 8080 }],
+      environment: [
+        { name: 'ENV', value: env('ENV', 'production') },
+      ],
+      logConfiguration: {
+        logDriver: 'awslogs',
+        options: {
+          'awslogs-group': '/ecs/myservice',
+          'awslogs-region': 'ap-northeast-1',
+          'awslogs-stream-prefix': 'app',
+        },
+      },
+    },
+  ],
+}
+```
+
+Use `ecspresso init --jsonnet` to generate Jsonnet files from an existing service. For more details, run `ecspresso docs --search "jsonnet" --json`.
+
+## Tips
+
+- Always run `ecspresso diff` before `ecspresso deploy` to understand what will change.
+- Use `--dry-run` on destructive operations (`deploy`, `rollback`, `delete`, `scale`) to preview the action.
+- The `verify` command checks IAM roles, container images, secrets, and log groups referenced in definitions.
+- When you need to learn more about a specific feature, use `ecspresso docs --search "<keyword>" --json` to find the relevant documentation section.


### PR DESCRIPTION
## Summary

- Add `docs` subcommand that shows embedded documentation directly from the binary (no AWS credentials or config file required)
- Embed `README.md` and `skills/SKILL.md` into the binary via `//go:embed`
- Add `skills/SKILL.md` as a guide for LLM agents covering common workflows, command patterns, and Jsonnet best practices

## Usage

```bash
ecspresso docs                            # show full README
ecspresso docs --index                    # show table of contents
ecspresso docs --search "fargate"         # search by keyword
ecspresso docs --search "deploy" --json   # JSON output for LLM agents
ecspresso docs --article skill            # show LLM agent skill guide
```

LLM agents can self-bootstrap by adding one line to their instructions:
```
Run `ecspresso docs --article skill` to learn how to use ecspresso.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)