### PR TITLE
Use structured slog attributes for log messages

### DIFF
--- a/.github/workflows/tagpr-release.yml
+++ b/.github/workflows/tagpr-release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         with:
-          go-version: "1.24"
+          go-version: "1.25"
         if: ${{ steps.tagpr.outputs.tag != '' || github.event_name == 'workflow_dispatch' }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,8 @@ jobs:
     strategy:
       matrix:
         go:
-          - "1.24"
           - "1.25"
+          - "1.26"
     name: Build
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Flags:
       --timeout=TIMEOUT           timeout. Override in a configuration file ($ECSPRESSO_TIMEOUT).
       --filter-command=STRING     filter command ($ECSPRESSO_FILTER_COMMAND)
       --[no-]color                enable colorized output ($ECSPRESSO_COLOR)
+      --log-format="text"         log format (text, json) ($ECSPRESSO_LOG_FORMAT)
 
 Commands:
   appspec
@@ -265,6 +266,22 @@ Commands:
 
 For more options for sub-commands, See `ecspresso sub-command --help`.
 
+### Log format
+
+`--log-format` option controls the log output format. The default is `text`.
+
+**text** format outputs human-readable logs. Attributes from `slog.With` (e.g. service/cluster) appear before the message, and per-call attributes appear after the message in `[key:value]` format.
+
+```
+2024-01-01T00:00:00.000+09:00 [INFO] [myService/default] deployment created on CodeDeploy [deployment_id:d-XXXXXXXXX] [url:https://...]
+```
+
+**json** format outputs structured JSON logs suitable for machine parsing. All attributes are output as individual JSON fields.
+
+```json
+{"time":"2024-01-01T00:00:00.000+09:00","level":"INFO","msg":"deployment created on CodeDeploy","cluster":"default","service":"myService","deployment_id":"d-XXXXXXXXX","url":"https://..."}
+```
+
 ## Quick Start
 
 ecspresso allows you to easily manage your existing/running ECS services by code.
@@ -273,9 +290,9 @@ Try `ecspresso init` for your ECS service with option `--region`, `--cluster` an
 
 ```console
 $ ecspresso init --region ap-northeast-1 --cluster default --service myservice --config ecspresso.yml
-2019/10/12 01:31:48 myservice/default save service definition to ecs-service-def.json
-2019/10/12 01:31:48 myservice/default save task definition to ecs-task-def.json
-2019/10/12 01:31:48 myservice/default save config to ecspresso.yml
+2024-01-01T00:00:00.000+09:00 [INFO] [myservice/default] saving service definition [path:ecs-service-def.json]
+2024-01-01T00:00:00.000+09:00 [INFO] [myservice/default] saving task definition [path:ecs-task-def.json]
+2024-01-01T00:00:00.000+09:00 [INFO] [myservice/default] saving config [path:ecspresso.yml]
 ```
 
 Review the generated files: `ecspresso.yml`, `ecs-service-def.json`, and `ecs-task-def.json`.
@@ -378,20 +395,20 @@ ecspresso also adds some template functions via plugins. See the [Plugins](#plug
 
 ```console
 $ ecspresso deploy --config ecspresso.yml
-2017/11/09 23:20:13 myService/default Starting deploy
+2024-01-01T00:00:00.000+09:00 [INFO] [myService/default] Starting deploy
 Service: myService
 Cluster: default
 TaskDefinition: myService:3
 Deployments:
     PRIMARY myService:3 desired:1 pending:0 running:1
 Events:
-2017/11/09 23:20:13 myService/default Creating a new task definition by myTask.json
-2017/11/09 23:20:13 myService/default Registering a new task definition...
-2017/11/09 23:20:13 myService/default Task definition is registered myService:4
-2017/11/09 23:20:13 myService/default Updating service...
-2017/11/09 23:20:13 myService/default Waiting for service stable...(it will take a few minutes)
-2017/11/09 23:23:23 myService/default  PRIMARY myService:4 desired:1 pending:0 running:1
-2017/11/09 23:23:29 myService/default Service is stable now. Completed!
+2024-01-01T00:00:00.000+09:00 [INFO] [myService/default] creating a new task definition [path:myTask.json]
+2024-01-01T00:00:00.000+09:00 [INFO] [myService/default] registering a new task definition
+2024-01-01T00:00:00.000+09:00 [INFO] [myService/default] task definition is registered [task_definition:myService:4]
+2024-01-01T00:00:00.000+09:00 [INFO] [myService/default] updating service
+2024-01-01T00:00:00.000+09:00 [INFO] [myService/default] Waiting for service stable...(it will take a few minutes)
+2024-01-01T00:03:10.000+09:00 [INFO] [myService/default]  PRIMARY myService:4 desired:1 pending:0 running:1
+2024-01-01T00:03:16.000+09:00 [INFO] [myService/default] Service is stable now. Completed!
 ```
 
 `deploy` commands has many options to customize the deployment behavior. See `ecspresso deploy --help` for more details.
@@ -514,19 +531,18 @@ codedeploy:
 
 ```console
 $ ecspresso deploy --config ecspresso.yml --rollback-events DEPLOYMENT_FAILURE
-2019/10/15 22:47:07 myService/default Starting deploy
+2024-01-01T00:00:00.000+09:00 [INFO] [myService/default] Starting deploy
 Service: myService
 Cluster: default
 TaskDefinition: myService:5
 TaskSets:
    PRIMARY myService:5 desired:1 pending:0 running:1
 Events:
-2019/10/15 22:47:08 myService/default Creating a new task definition by ecs-task-def.json
-2019/10/15 22:47:08 myService/default Registering a new task definition...
-2019/10/15 22:47:08 myService/default Task definition is registered myService:6
-2019/10/15 22:47:08 myService/default desired count: 1
-2019/10/15 22:47:09 myService/default Deployment d-XXXXXXXXX is created on CodeDeploy
-2019/10/15 22:47:09 myService/default https://ap-northeast-1.console.aws.amazon.com/codesuite/codedeploy/deployments/d-XXXXXXXXX?region=ap-northeast-1
+2024-01-01T00:00:01.000+09:00 [INFO] [myService/default] creating a new task definition [path:ecs-task-def.json]
+2024-01-01T00:00:01.000+09:00 [INFO] [myService/default] registering a new task definition
+2024-01-01T00:00:01.000+09:00 [INFO] [myService/default] task definition is registered [task_definition:myService:6]
+2024-01-01T00:00:01.000+09:00 [INFO] [myService/default] desired count [count:1]
+2024-01-01T00:00:02.000+09:00 [INFO] [myService/default] deployment created on CodeDeploy [deployment_id:d-XXXXXXXXX] [url:https://ap-northeast-1.console.aws.amazon.com/codesuite/codedeploy/deployments/d-XXXXXXXXX?region=ap-northeast-1]
 ```
 
 CodeDeploy appspec hooks can be defined in a config file. ecspresso automatically creates `Resources` and `version` elements in appspec on deployment:
@@ -1054,7 +1070,7 @@ ecspresso verify tries to assume the task execution role defined in task definit
 
 ```console
 $ ecspresso verify
-2020/12/08 11:43:10 nginx-local/ecspresso-test Starting verify
+2024-01-01T00:00:00.000+09:00 [INFO] [nginx-local/ecspresso-test] Starting verify
   TaskDefinition
     ExecutionRole[arn:aws:iam::123456789012:role/ecsTaskRole]
     --> [OK]
@@ -1071,7 +1087,7 @@ $ ecspresso verify
   --> [OK]
   Cluster
   --> [OK]
-2020/12/08 11:43:14 nginx-local/ecspresso-test Verify OK!
+2024-01-01T00:00:04.000+09:00 [INFO] [nginx-local/ecspresso-test] Verify OK!
 ```
 
 ### Manipulate ECS tasks

--- a/autoscaling.go
+++ b/autoscaling.go
@@ -48,7 +48,7 @@ func (d *App) modifyAutoScaling(ctx context.Context, opt DeployOption) error {
 	if p.isEmpty() {
 		return nil
 	}
-	d.LogInfo("Modify auto scaling settings %s", p.String())
+	d.LogInfo("modifying auto scaling settings", "params", p.String())
 
 	resourceId := fmt.Sprintf("service/%s/%s", d.Cluster, d.Service)
 	out, err := d.autoScaling.DescribeScalableTargets(
@@ -63,7 +63,7 @@ func (d *App) modifyAutoScaling(ctx context.Context, opt DeployOption) error {
 		return fmt.Errorf("failed to describe scalable targets: %w", err)
 	}
 	if len(out.ScalableTargets) == 0 {
-		d.LogWarn("No scalable target for %s", resourceId)
+		d.LogWarn("no scalable target", "resource_id", resourceId)
 		d.LogInfo("Skip modifying auto scaling settings")
 		return nil
 	}
@@ -72,7 +72,7 @@ func (d *App) modifyAutoScaling(ctx context.Context, opt DeployOption) error {
 		return nil
 	}
 	for _, target := range out.ScalableTargets {
-		d.LogInfo("Register scalable target %s %s", *target.ResourceId, p.String())
+		d.LogInfo("registering scalable target", "resource_id", *target.ResourceId, "params", p.String())
 		_, err := d.autoScaling.RegisterScalableTarget(
 			ctx,
 			&applicationautoscaling.RegisterScalableTargetInput{

--- a/config.go
+++ b/config.go
@@ -183,7 +183,7 @@ func (c *Config) Restrict(ctx context.Context) error {
 		return fmt.Errorf("failed to setup plugins: %w", err)
 	}
 	if c.FilterCommand != "" {
-		LogWarn("filter_command is deprecated. Use environment variable or CLI flag instead.")
+		LogWarn("filter_command is deprecated, use environment variable or CLI flag instead")
 	}
 	return nil
 }
@@ -192,7 +192,7 @@ func (c *Config) AssumeRole(assumeRoleARN string) {
 	if assumeRoleARN == "" {
 		return
 	}
-	LogInfo("assume role: %s", assumeRoleARN)
+	LogInfo("assuming role", "role", assumeRoleARN)
 	stsClient := sts.NewFromConfig(c.awsv2Config)
 	assumeRoleProvider := stscreds.NewAssumeRoleProvider(stsClient, assumeRoleARN)
 	c.awsv2Config.Credentials = aws.NewCredentialsCache(assumeRoleProvider)
@@ -219,7 +219,7 @@ func (c *Config) ValidateVersion(version string) error {
 	}
 	v, err := goVersion.NewVersion(version)
 	if err != nil {
-		LogWarn("Invalid version format \"%s\". Skip checking required_version.", version)
+		LogWarn("invalid version format, skipping required_version check", "version", version)
 		// invalid version string (e.g. "current") always allowed
 		return nil
 	}

--- a/create.go
+++ b/create.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (d *App) createService(ctx context.Context, opt DeployOption) error {
-	d.LogInfo("Starting create service %s", opt.DryRunString())
+	d.LogInfo("Starting create service", withDryRun(opt.DryRun)...)
 	svd, err := d.LoadServiceDefinition(d.config.ServiceDefinitionPath)
 	if err != nil {
 		return err
@@ -43,7 +43,7 @@ func (d *App) createService(ctx context.Context, opt DeployOption) error {
 		if err != nil {
 			return err
 		}
-		d.LogInfo("Using latest task definition %s", tdArn)
+		d.LogInfo("using latest task definition", "task_definition", tdArn)
 	} else {
 		newTd, err := d.RegisterTaskDefinition(ctx, td)
 		if err != nil {
@@ -101,7 +101,7 @@ func (d *App) createService(ctx context.Context, opt DeployOption) error {
 
 	if err := doWait(ctx, sv); err != nil {
 		if errors.As(err, &errNotFound) && sv.isCodeDeploy() {
-			d.LogInfo("%s", err)
+			d.LogInfo(err.Error())
 			return d.WaitTaskSetStable(ctx, sv)
 		}
 		return err

--- a/delete.go
+++ b/delete.go
@@ -25,7 +25,7 @@ func (d *App) Delete(ctx context.Context, opt DeleteOption) error {
 	ctx, cancel := d.Start(ctx)
 	defer cancel()
 
-	d.LogInfo("Deleting service %s", opt.DryRunString())
+	d.LogInfo("Deleting service", withDryRun(opt.DryRun)...)
 	sv, err := d.DescribeServiceStatus(ctx, 3)
 	if err != nil {
 		return err

--- a/deploy.go
+++ b/deploy.go
@@ -89,11 +89,11 @@ func (d *App) Deploy(ctx context.Context, opt DeployOption) error {
 	defer cancel()
 
 	var sv *Service
-	d.LogInfo("Starting deploy %s", opt.DryRunString())
+	d.LogInfo("Starting deploy", withDryRun(opt.DryRun)...)
 	sv, err := d.DescribeServiceStatus(ctx, 0)
 	if err != nil {
 		if errors.As(err, &errNotFound) {
-			d.LogInfo("Service %s not found. Creating a new service %s", d.Service, opt.DryRunString())
+			d.LogInfo("service not found, creating a new service", withDryRun(opt.DryRun)...)
 			if d.config.isExpressMode() {
 				return d.createExpressGatewayService(ctx, opt)
 			} else {
@@ -150,7 +150,7 @@ func (d *App) Deploy(ctx context.Context, opt DeployOption) error {
 		count = calcDesiredCount(sv, opt)
 	}
 	if count != nil {
-		d.LogInfo("desired count: %d", *count)
+		d.LogInfo("desired count", "desired_count", *count)
 	} else {
 		d.LogInfo("desired count: unchanged")
 	}
@@ -176,14 +176,14 @@ func (d *App) Deploy(ctx context.Context, opt DeployOption) error {
 
 	if err := doWait(ctx, sv); err != nil {
 		if errors.As(err, &errNotFound) {
-			d.LogInfo("%s", err)
+			d.LogInfo(err.Error())
 			// no need to wait
 			return nil
 		}
 		return err
 	}
 
-	d.LogInfo("Service is %s now. Completed!", opt.WaitUntil)
+	d.LogInfo("service completed", "status", opt.WaitUntil)
 	return nil
 }
 
@@ -199,7 +199,7 @@ func (d *App) UpdateServiceTasks(ctx context.Context, taskDefinitionArn string, 
 	if opt.ForceNewDeployment {
 		msg = msg + " with force new deployment"
 	}
-	d.LogInfo("%s...", msg)
+	d.LogInfo(msg)
 	d.LogJSON(in)
 
 	_, err := d.ecs.UpdateService(ctx, in)
@@ -275,7 +275,7 @@ func (d *App) UpdateServiceAttributes(ctx context.Context, sv *Service, taskDefi
 		in.CapacityProviderStrategy = nil
 	} else {
 		if dc := sv.DeploymentConfiguration; dc != nil {
-			d.LogInfo("deployment by ECS %s strategy", dc.Strategy)
+			d.LogInfo("deployment by ECS strategy", "strategy", string(dc.Strategy))
 		} else {
 			d.LogInfo("deployment by ECS rolling update")
 		}
@@ -286,7 +286,7 @@ func (d *App) UpdateServiceAttributes(ctx context.Context, sv *Service, taskDefi
 	in.Cluster = aws.String(d.Cluster)
 
 	if opt.DryRun {
-		d.LogInfo("update service input: %s", MustMarshalJSONStringForAPI(in))
+		d.LogInfo("update service input", "input", MustMarshalJSONStringForAPI(in))
 		return nil
 	}
 	d.LogInfo("Updating service attributes...")
@@ -302,7 +302,7 @@ func (d *App) UpdateServiceAttributes(ctx context.Context, sv *Service, taskDefi
 
 func (d *App) DeployByCodeDeploy(ctx context.Context, taskDefinitionArn string, count *int32, sv *Service, opt DeployOption) error {
 	if count != nil {
-		d.LogInfo("updating desired count to %d", *count)
+		d.LogInfo("updating desired count", "desired_count", *count)
 	}
 	_, err := d.ecs.UpdateService(
 		ctx,
@@ -496,12 +496,11 @@ func (d *App) createDeployment(ctx context.Context, sv *Service, taskDefinitionA
 		id,
 		d.config.Region,
 	)
-	d.LogInfo("Deployment %s is created on CodeDeploy:", id)
-	d.LogInfo("%s", u)
+	d.LogInfo("deployment created on CodeDeploy", "deployment_id", id, "url", u)
 
 	if isatty.IsTerminal(os.Stdout.Fd()) {
 		if err := exec.Command("open", u).Start(); err != nil {
-			d.LogInfo("Couldn't open URL %s", u)
+			d.LogInfo("couldn't open URL", "url", u)
 		}
 	}
 	return nil
@@ -543,11 +542,11 @@ func (d *App) UpdateServiceTags(ctx context.Context, sv *Service, added, updated
 
 	if len(tags) > 0 {
 		for _, t := range tags {
-			d.LogInfo("updating service tags: %s=%s %s", aws.ToString(t.Key), aws.ToString(t.Value), opt.DryRunString())
+			d.LogInfo("updating service tag", withDryRun(opt.DryRun, "tag_key", aws.ToString(t.Key), "tag_value", aws.ToString(t.Value))...)
 		}
 	}
 	if len(untagKeys) > 0 {
-		d.LogInfo("deleting service tags: %v %s", untagKeys, opt.DryRunString())
+		d.LogInfo("deleting service tags", withDryRun(opt.DryRun, "tag_keys", strings.Join(untagKeys, ","))...)
 	}
 	if opt.DryRun {
 		return nil

--- a/deregister.go
+++ b/deregister.go
@@ -33,7 +33,7 @@ func (opt DeregisterOption) DryRunString() string {
 func (d *App) Deregister(ctx context.Context, opt DeregisterOption) error {
 	ctx, cancel := d.Start(ctx)
 	defer cancel()
-	d.LogInfo("Starting deregister task definition %s", opt.DryRunString())
+	d.LogInfo("Starting deregister task definition", withDryRun(opt.DryRun)...)
 
 	inUse, err := d.inUseRevisions(ctx)
 	if err != nil {
@@ -79,7 +79,7 @@ func (d *App) deregiserRevision(ctx context.Context, opt DeregisterOption, inUse
 	}
 
 	if opt.DryRun {
-		d.LogInfo("task definition %s will be deregistered", name)
+		d.LogInfo("task definition will be deregistered", "task_definition", name)
 		d.LogInfo("DRY RUN OK")
 		return nil
 	}
@@ -89,21 +89,21 @@ func (d *App) deregiserRevision(ctx context.Context, opt DeregisterOption, inUse
 		return fmt.Errorf("confirmation failed")
 	}
 
-	d.LogInfo("Deregistering %s", name)
+	d.LogInfo("deregistering", "task_definition", name)
 	if _, err := d.ecs.DeregisterTaskDefinition(ctx, &ecs.DeregisterTaskDefinitionInput{
 		TaskDefinition: aws.String(name),
 	}); err != nil {
 		return fmt.Errorf("failed to deregister task definition: %w", err)
 	}
-	d.LogInfo("%s was deregistered successfully", name)
+	d.LogInfo("task definition deregistered", "task_definition", name)
 	if opt.Delete {
-		d.LogInfo("Deleting %s", name)
+		d.LogInfo("deleting task definition", "task_definition", name)
 		if _, err := d.ecs.DeleteTaskDefinitions(ctx, &ecs.DeleteTaskDefinitionsInput{
 			TaskDefinitions: []string{name},
 		}); err != nil {
 			return fmt.Errorf("failed to delete task definition: %w", err)
 		}
-		d.LogInfo("%s was deleted successfully", name)
+		d.LogInfo("task definition deleted", "task_definition", name)
 	}
 	return nil
 }
@@ -130,7 +130,7 @@ func (d *App) deregisterKeeps(ctx context.Context, opt DeregisterOption, inUse m
 				continue
 			}
 			if s := inUse[name]; s != "" {
-				d.LogInfo("%s is in use by %s. skip", name, s)
+				d.LogInfo("task definition in use, skipping", "task_definition", name, "used_by", s)
 			} else {
 				d.LogDebug("%s is marked to deregister", name)
 				names = append(names, name)
@@ -149,7 +149,7 @@ func (d *App) deregisterKeeps(ctx context.Context, opt DeregisterOption, inUse m
 	}
 	for i, name := range names {
 		if i < idx {
-			d.LogInfo("%s will be deregistered", name)
+			d.LogInfo("task definition will be deregistered", "task_definition", name)
 			deregs = append(deregs, name)
 		}
 	}
@@ -165,26 +165,26 @@ func (d *App) deregisterKeeps(ctx context.Context, opt DeregisterOption, inUse m
 		return fmt.Errorf("confirmation failed")
 	}
 	for _, name := range deregs {
-		d.LogInfo("Deregistring %s", name)
+		d.LogInfo("deregistering", "task_definition", name)
 		if _, err := d.ecs.DeregisterTaskDefinition(ctx, &ecs.DeregisterTaskDefinitionInput{
 			TaskDefinition: aws.String(name),
 		}); err != nil {
 			return fmt.Errorf("failed to deregister task definition: %w", err)
 		}
-		d.LogInfo("%s was deregistered successfully", name)
+		d.LogInfo("task definition deregistered", "task_definition", name)
 		sleepContext(ctx, time.Second)
 		deregistered++
 	}
-	d.LogInfo("%d task definitions were deregistered", deregistered)
+	d.LogInfo("task definitions deregistered", "count", deregistered)
 	if opt.Delete {
 		for _, names := range lo.Chunk(deregs, 10) { // 10 is max batch size
-			d.LogInfo("Deleting task definitions %s", strings.Join(names, ","))
+			d.LogInfo("deleting task definitions", "task_definitions", strings.Join(names, ","))
 			if _, err := d.ecs.DeleteTaskDefinitions(ctx, &ecs.DeleteTaskDefinitionsInput{
 				TaskDefinitions: names,
 			}); err != nil {
 				return fmt.Errorf("failed to delete task definition: %w", err)
 			}
-			d.LogInfo("%d task definitions were deleted successfully", len(names))
+			d.LogInfo("task definitions deleted", "count", len(names))
 		}
 	}
 	return nil

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -208,7 +208,7 @@ func New(ctx context.Context, opt *CLIOptions, newAppOptions ...AppOption) (*App
 		fn(&appOpts)
 	}
 
-	LogInfo("ecspresso version: %s", Version)
+	LogInfo("ecspresso version", "version", Version)
 
 	// load config file
 	if appOpts.config == nil {
@@ -303,7 +303,7 @@ func (d *App) DescribeService(ctx context.Context) (*Service, error) {
 	status := aws.ToString(out.Services[0].Status)
 	switch status {
 	case "DRAINING":
-		d.LogWarn("service %s is %s", d.Service, status)
+		d.LogWarn("service status warning", "status", status)
 	case "INACTIVE":
 		return nil, ErrNotFound(fmt.Sprintf("service %s is %s", d.Service, status))
 	default:
@@ -426,7 +426,7 @@ func (d *App) describeAutoScaling(ctx context.Context, s *Service) ([]aasTypes.S
 	if err != nil {
 		var oe *smithy.OperationError
 		if errors.As(err, &oe) {
-			d.LogWarn("failed to describe scalable targets: %s", oe)
+			d.LogWarn("failed to describe scalable targets", "error", oe.Error())
 			return nil, nil, nil
 		}
 		return nil, nil, fmt.Errorf("failed to describe scalable targets: %w", err)
@@ -446,7 +446,7 @@ func (d *App) describeAutoScaling(ctx context.Context, s *Service) ([]aasTypes.S
 	if err != nil {
 		var oe *smithy.OperationError
 		if errors.As(err, &oe) {
-			d.LogWarn("failed to describe scaling policies: %s", oe)
+			d.LogWarn("failed to describe scaling policies", "error", oe.Error())
 			return tout.ScalableTargets, nil, nil
 		}
 		return tout.ScalableTargets, nil, fmt.Errorf("failed to describe scaling policies: %w", err)
@@ -462,7 +462,7 @@ func (d *App) DescribeTaskStatus(ctx context.Context, task *types.Task, watchCon
 	}
 	if len(out.Failures) > 0 {
 		f := out.Failures[0]
-		d.LogInfo("Task ARN: %s", *f.Arn)
+		d.LogInfo("task failure", "task_arn", *f.Arn)
 		return errors.New(*f.Reason)
 	}
 
@@ -573,7 +573,7 @@ func (d *App) RegisterTaskDefinition(ctx context.Context, td *TaskDefinitionInpu
 		return nil, fmt.Errorf("failed to register task definition: %w", err)
 	}
 	otd := TaskDefinition(*out.TaskDefinition)
-	d.LogInfo("Task definition is registered %s", otd.Name())
+	d.LogInfo("task definition registered", "task_definition", otd.Name())
 	return &otd, nil
 }
 
@@ -621,7 +621,7 @@ func unmarshalJSON(src []byte, v any, path string) error {
 		if !strings.Contains(err.Error(), "unknown field") {
 			return err
 		}
-		LogWarn("%s in %s", err, path)
+		LogWarn("unknown field in definition", "error", err.Error(), "path", path)
 		// unknown field -> try lax decoder
 		lax := json.NewDecoder(bytes.NewReader(src))
 		return lax.Decode(&v)
@@ -665,8 +665,7 @@ func (d *App) GetLogInfo(task *types.Task, c *types.ContainerDefinition) (string
 	logStream := strings.Join([]string{logStreamPrefix, *c.Name, taskID}, "/")
 	logGroup := lc.Options["awslogs-group"]
 
-	d.LogInfo("logGroup: %s", logGroup)
-	d.LogInfo("logStream: %s", logStream)
+	d.LogInfo("log configuration", "log_group", logGroup, "log_stream", logStream)
 
 	return logGroup, logStream
 }

--- a/express.go
+++ b/express.go
@@ -31,7 +31,7 @@ func (e *ExpressGatewayService) GetTags() []types.Tag {
 
 func (d *App) initExpressGatewayService(ctx context.Context, sv *Service, opt InitOption) (*ExpressGatewayService, *Service, error) {
 	conf := d.config
-	d.LogInfo("Initializing express definition from the service %s...", aws.ToString(sv.ServiceName))
+	d.LogInfo("initializing express definition", "service", aws.ToString(sv.ServiceName))
 
 	ex, err := d.DescribeExpressGatewayService(ctx, sv)
 	if err != nil {
@@ -53,7 +53,7 @@ func (d *App) initExpressGatewayService(ctx context.Context, sv *Service, opt In
 		}
 		b = []byte(out)
 	}
-	d.LogInfo("save the express gateway service %s to %s", aws.ToString(ex.ServiceName), conf.ExpressDefinitionPath)
+	d.LogInfo("saving express gateway service", "service", aws.ToString(ex.ServiceName), "path", conf.ExpressDefinitionPath)
 	if err := d.saveFile(conf.ExpressDefinitionPath, b, CreateFileMode, opt.ForceOverwrite); err != nil {
 		return nil, nil, err
 	}
@@ -104,7 +104,7 @@ func (d *App) createExpressGatewayService(ctx context.Context, opt DeployOption)
 	if err != nil {
 		return err
 	}
-	d.LogInfo("Creating express gateway service %s...%s", aws.ToString(ex.ServiceName), opt.DryRunString())
+	d.LogInfo("creating express gateway service", withDryRun(opt.DryRun, "service", aws.ToString(ex.ServiceName))...)
 	if opt.DryRun {
 		OutputJSONForAPI(os.Stdout, ex)
 		return nil
@@ -228,7 +228,7 @@ func (d *App) DeployExpressGatewayService(ctx context.Context, sv *Service, opt 
 	if err != nil {
 		return err
 	}
-	d.LogInfo("Updating express gateway service %s...%s", aws.ToString(sv.ServiceName), opt.DryRunString())
+	d.LogInfo("updating express gateway service", withDryRun(opt.DryRun, "service", aws.ToString(sv.ServiceName))...)
 
 	in := exToUpdateExpressGatewayServiceInput(ex, sv)
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/kayac/ecspresso/v2
 
-go 1.24.0
-
-toolchain go1.24.7
+go 1.25
 
 require (
 	github.com/Songmu/prompter v0.5.1
@@ -28,7 +26,7 @@ require (
 	github.com/fatih/color v1.18.0
 	github.com/fujiwara/cfn-lookup v1.1.0
 	github.com/fujiwara/ecsta v0.4.5
-	github.com/fujiwara/sloghandler v0.0.3
+	github.com/fujiwara/sloghandler v0.1.0
 	github.com/fujiwara/ssm-lookup v0.1.1
 	github.com/fujiwara/tfstate-lookup v1.8.1
 	github.com/goccy/go-yaml v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -175,8 +175,8 @@ github.com/fujiwara/cfn-lookup v1.1.0 h1:wNjMituD/n8XAhBw+L3uqtDCnWr1nrAI7T/YATM
 github.com/fujiwara/cfn-lookup v1.1.0/go.mod h1:yQiC+G7sSTRTic6E8RKv1G36tp+y2Q/9BT6QMQT4yyw=
 github.com/fujiwara/ecsta v0.4.5 h1:82M3oL6n+eNd3JgPiFOOKkIYq46ggnts2HbuHOtX3rI=
 github.com/fujiwara/ecsta v0.4.5/go.mod h1:SwSlCJuhiVrWfpYSaaHUSZVrs6Ey6nJ9V3flWNX7ndk=
-github.com/fujiwara/sloghandler v0.0.3 h1:1YVGGNXIqPtXtzQMM5IMKLLvkNdgZy5M3nTiO5Rz6FQ=
-github.com/fujiwara/sloghandler v0.0.3/go.mod h1:I9ihlxE0IGAEUbN5ZuItuu9TWsBEGzHYmcQQX3YXSXs=
+github.com/fujiwara/sloghandler v0.1.0 h1:4uxE5z01fKv/qzUoIyYk/2H1D4xEb/wi2K/Wks9z5Tg=
+github.com/fujiwara/sloghandler v0.1.0/go.mod h1:9wl7zZ1fO53Gl83/M8KFYW+5iACiwXAltOL5REOUd24=
 github.com/fujiwara/ssm-lookup v0.1.1 h1:Cwx7Y6A0HbIKyAzS60DYcf/TZ5KZHY/vTlCtUoythfQ=
 github.com/fujiwara/ssm-lookup v0.1.1/go.mod h1:ssVwS1FrHAKouOMEmYC6j07XRKqBGdABRmv6gBKewVg=
 github.com/fujiwara/tfstate-lookup v1.8.1 h1:lCWRvhfmm+9PbgS9AhDRi9qQOTFXTIws+W+TC1DY77s=

--- a/init.go
+++ b/init.go
@@ -92,7 +92,7 @@ func (d *App) Init(ctx context.Context, opt InitOption) error {
 	}
 
 	if sv.isExpressMode() {
-		d.LogInfo("%s is an Express Gateway Service", aws.ToString(sv.ServiceName))
+		d.LogInfo("Express Gateway Service detected", "service", aws.ToString(sv.ServiceName))
 		if opt.Express == nil || *opt.Express {
 			ex, sv, err := d.initExpressGatewayService(ctx, sv, opt)
 			if err != nil {
@@ -118,7 +118,7 @@ func (d *App) Init(ctx context.Context, opt InitOption) error {
 
 func (d *App) initConfigurationFile(ctx context.Context, configFilePath string, opt InitOption, sv *Service, td *TaskDefinitionInput, ex *ExpressGatewayService) error {
 	conf := d.config
-	d.LogInfo("Initializing configuration file to %s...", configFilePath)
+	d.LogInfo("initializing configuration file", "path", configFilePath)
 	if ex != nil {
 		// express
 		conf.Service = aws.ToString(sv.ServiceName)
@@ -135,7 +135,7 @@ func (d *App) initConfigurationFile(ctx context.Context, configFilePath string, 
 		if sv.isCodeDeploy() {
 			info, err := d.findDeploymentInfo(ctx)
 			if err != nil {
-				LogWarn("failed to find CodeDeploy deployment info: %s", err)
+				LogWarn("failed to find CodeDeploy deployment info", "error", err.Error())
 				LogWarn("you need to set config.codedeploy section manually")
 			} else {
 				conf.CodeDeploy = &ConfigCodeDeploy{
@@ -170,7 +170,7 @@ func (d *App) initConfigurationFile(ctx context.Context, configFilePath string, 
 				return fmt.Errorf("unable to marshal config to YAML: %w", err)
 			}
 		}
-		d.LogInfo("save the config to %s", configFilePath)
+		d.LogInfo("saving config", "path", configFilePath)
 		if err := d.saveFile(configFilePath, b, CreateFileMode, opt.ForceOverwrite); err != nil {
 			return err
 		}
@@ -180,7 +180,7 @@ func (d *App) initConfigurationFile(ctx context.Context, configFilePath string, 
 
 func (d *App) initServiceDefinition(ctx context.Context, sv *Service, opt InitOption) (*Service, string, error) {
 	conf := d.config
-	d.LogInfo("Initializing service definition from the service %s...", aws.ToString(sv.ServiceName))
+	d.LogInfo("initializing service definition", "service", aws.ToString(sv.ServiceName))
 
 	svArn := aws.ToString(sv.ServiceArn)
 	if long, _ := isLongArnFormat(svArn); long {
@@ -209,7 +209,7 @@ func (d *App) initServiceDefinition(ctx context.Context, sv *Service, opt InitOp
 			}
 			b = []byte(out)
 		}
-		d.LogInfo("save the service definition %s to %s", svArn, conf.ServiceDefinitionPath)
+		d.LogInfo("saving service definition", "service_arn", svArn, "path", conf.ServiceDefinitionPath)
 		if err := d.saveFile(conf.ServiceDefinitionPath, b, CreateFileMode, opt.ForceOverwrite); err != nil {
 			return nil, "", err
 		}
@@ -219,7 +219,7 @@ func (d *App) initServiceDefinition(ctx context.Context, sv *Service, opt InitOp
 
 func (d *App) initTaskDefinition(ctx context.Context, opt InitOption, tdArn string) (*TaskDefinitionInput, error) {
 	conf := d.config
-	d.LogInfo("Initializing task definition from the task definition %s...", tdArn)
+	d.LogInfo("initializing task definition", "task_definition", tdArn)
 
 	td, err := d.DescribeTaskDefinition(ctx, tdArn)
 	if err != nil {
@@ -238,7 +238,7 @@ func (d *App) initTaskDefinition(ctx context.Context, opt InitOption, tdArn stri
 			}
 			b = []byte(out)
 		}
-		d.LogInfo("save the task definition %s to %s", tdArn, conf.TaskDefinitionPath)
+		d.LogInfo("saving task definition", "task_definition", tdArn, "path", conf.TaskDefinitionPath)
 		if err := d.saveFile(conf.TaskDefinitionPath, b, CreateFileMode, opt.ForceOverwrite); err != nil {
 			return nil, err
 		}
@@ -278,7 +278,7 @@ func (d *App) saveFile(path string, b []byte, mode os.FileMode, force bool) erro
 	if _, err := os.Stat(path); err == nil && !force {
 		ok := prompter.YN(fmt.Sprintf("Overwrite existing file %s?", path), false)
 		if !ok {
-			d.LogInfo("skip %s", path)
+			d.LogInfo("skipping file", "path", path)
 			return nil
 		}
 	}

--- a/logger.go
+++ b/logger.go
@@ -51,14 +51,12 @@ func LogDebug(f string, v ...any) {
 	commonLogger.Debug(msg)
 }
 
-func LogInfo(f string, v ...any) {
-	msg := fmt.Sprintf(f, v...)
-	commonLogger.Info(msg)
+func LogInfo(msg string, args ...any) {
+	commonLogger.Info(msg, args...)
 }
 
-func LogWarn(f string, v ...any) {
-	msg := fmt.Sprintf(f, v...)
-	commonLogger.Warn(msg)
+func LogWarn(msg string, args ...any) {
+	commonLogger.Warn(msg, args...)
 }
 
 func LogError(f string, v ...any) {
@@ -71,19 +69,26 @@ func (d *App) LogDebug(f string, v ...any) {
 	d.logger.Debug(msg)
 }
 
-func (d *App) LogInfo(f string, v ...any) {
-	msg := fmt.Sprintf(f, v...)
-	d.logger.Info(msg)
+func (d *App) LogInfo(msg string, args ...any) {
+	d.logger.Info(msg, args...)
 }
 
-func (d *App) LogWarn(f string, v ...any) {
-	msg := fmt.Sprintf(f, v...)
-	d.logger.Warn(msg)
+func (d *App) LogWarn(msg string, args ...any) {
+	d.logger.Warn(msg, args...)
 }
 
 func (d *App) LogError(f string, v ...any) {
 	msg := fmt.Sprintf(f, v...)
 	d.logger.Error(msg)
+}
+
+// withDryRun appends "dry_run":true to args only when dryRun is true.
+// Usage: d.LogInfo("msg", withDryRun(opt.DryRun, "key", val)...)
+func withDryRun(dryRun bool, args ...any) []any {
+	if dryRun {
+		return append(args, "dry_run", true)
+	}
+	return args
 }
 
 func (d *App) LogJSON(v any) {

--- a/logger_test.go
+++ b/logger_test.go
@@ -2,9 +2,12 @@ package ecspresso_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"log/slog"
+	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/kayac/ecspresso/v2"
 )
 
@@ -20,8 +23,8 @@ func TestCommonLogger(t *testing.T) {
 			ecspresso.SetLogger(logger)
 
 			ecspresso.LogDebug("test %s", level)
-			ecspresso.LogInfo("test %s", level)
-			ecspresso.LogWarn("test %s", level)
+			ecspresso.LogInfo("test message", "level", level.String())
+			ecspresso.LogWarn("test message", "level", level.String())
 			ecspresso.LogError("test %s", level)
 			t.Log(b.String())
 		}
@@ -39,10 +42,84 @@ func TestLogger(t *testing.T) {
 			app.SetLogger(logger)
 
 			app.LogDebug("test %s", "test")
-			app.LogInfo("test %s", "test")
-			app.LogWarn("test %s", "test")
+			app.LogInfo("test message", "key", "value")
+			app.LogWarn("test message", "key", "value")
 			app.LogError("test %s", "test")
 			t.Log(b.String())
 		}
 	}
+}
+
+func TestStructuredLogOutput(t *testing.T) {
+	t.Run("json format has structured fields", func(t *testing.T) {
+		b := new(bytes.Buffer)
+		ecspresso.SetLogFormat("json")
+		logger := ecspresso.NewLogger(b)
+		ecspresso.LogLevel.Set(slog.LevelInfo)
+
+		app := &ecspresso.App{}
+		app.SetLogger(logger.With("cluster", "test-cluster", "service", "test-svc"))
+
+		app.LogInfo("deployment created", "deployment_id", "d-ABC123", "url", "https://example.com")
+
+		var m map[string]any
+		if err := json.Unmarshal(b.Bytes(), &m); err != nil {
+			t.Fatalf("failed to parse JSON log: %s\noutput: %s", err, b.String())
+		}
+		if diff := cmp.Diff("deployment created", m["msg"]); diff != "" {
+			t.Errorf("msg mismatch (-want +got):\n%s", diff)
+		}
+		if diff := cmp.Diff("d-ABC123", m["deployment_id"]); diff != "" {
+			t.Errorf("deployment_id mismatch (-want +got):\n%s", diff)
+		}
+		if diff := cmp.Diff("https://example.com", m["url"]); diff != "" {
+			t.Errorf("url mismatch (-want +got):\n%s", diff)
+		}
+		if diff := cmp.Diff("test-cluster", m["cluster"]); diff != "" {
+			t.Errorf("cluster mismatch (-want +got):\n%s", diff)
+		}
+		if diff := cmp.Diff("test-svc", m["service"]); diff != "" {
+			t.Errorf("service mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("text format has key:value attrs", func(t *testing.T) {
+		b := new(bytes.Buffer)
+		ecspresso.SetLogFormat("text")
+		logger := ecspresso.NewLogger(b)
+		ecspresso.LogLevel.Set(slog.LevelInfo)
+
+		app := &ecspresso.App{}
+		app.SetLogger(logger)
+
+		app.LogInfo("starting deploy", "dry_run", true)
+
+		output := b.String()
+		if !strings.Contains(output, "[dry_run:true]") {
+			t.Errorf("expected [dry_run:true] in text output: %s", output)
+		}
+		if !strings.Contains(output, "starting deploy") {
+			t.Errorf("expected message in text output: %s", output)
+		}
+	})
+
+	t.Run("plain message without attrs", func(t *testing.T) {
+		b := new(bytes.Buffer)
+		ecspresso.SetLogFormat("json")
+		logger := ecspresso.NewLogger(b)
+		ecspresso.LogLevel.Set(slog.LevelInfo)
+
+		app := &ecspresso.App{}
+		app.SetLogger(logger)
+
+		app.LogInfo("DRY RUN OK")
+
+		var m map[string]any
+		if err := json.Unmarshal(b.Bytes(), &m); err != nil {
+			t.Fatalf("failed to parse JSON log: %s\noutput: %s", err, b.String())
+		}
+		if diff := cmp.Diff("DRY RUN OK", m["msg"]); diff != "" {
+			t.Errorf("msg mismatch (-want +got):\n%s", diff)
+		}
+	})
 }

--- a/register.go
+++ b/register.go
@@ -21,7 +21,7 @@ func (d *App) Register(ctx context.Context, opt RegisterOption) error {
 	ctx, cancel := d.Start(ctx)
 	defer cancel()
 
-	d.LogInfo("Starting register task definition %s", opt.DryRunString())
+	d.LogInfo("Starting register task definition", withDryRun(opt.DryRun)...)
 	td, err := d.LoadTaskDefinition(d.config.TaskDefinitionPath)
 	if err != nil {
 		return err

--- a/rollback.go
+++ b/rollback.go
@@ -40,13 +40,13 @@ func (d *App) Rollback(ctx context.Context, opt RollbackOption) error {
 		return fmt.Errorf("--deregister-task-definition not works with --no-wait together. Please use --no-deregister-task-definition with --no-wait")
 	}
 
-	d.LogInfo("Starting rollback %s", opt.DryRunString())
+	d.LogInfo("Starting rollback", withDryRun(opt.DryRun)...)
 	sv, err := d.DescribeServiceStatus(ctx, 0)
 	if err != nil {
 		return err
 	}
 
-	d.LogInfo("deployment controller: %s", sv.DeploymentController.Type)
+	d.LogInfo("deployment controller", "type", string(sv.DeploymentController.Type))
 	doRollback, err := d.RollbackFunc(sv)
 	if err != nil {
 		return err
@@ -82,13 +82,13 @@ func (d *App) Rollback(ctx context.Context, opt RollbackOption) error {
 	sleepContext(ctx, delayForServiceChanged) // wait for service updated
 	if err := doWait(ctx, sv); err != nil {
 		if errors.As(err, &errNotFound) {
-			d.LogInfo("%s", err)
+			d.LogInfo(err.Error())
 			return d.rollbackTaskDefinition(ctx, rollbackedTdArn, opt)
 		}
 		return err
 	}
 
-	d.LogInfo("Service is %s now. Completed!", opt.WaitUntil)
+	d.LogInfo("service completed", "status", opt.WaitUntil)
 
 	return d.rollbackTaskDefinition(ctx, rollbackedTdArn, opt)
 }
@@ -98,11 +98,11 @@ func (d *App) rollbackTaskDefinition(ctx context.Context, rollbackedTdArn string
 		return nil
 	}
 	if opt.DryRun {
-		d.LogInfo("task definition %s will be deregistered", arnToName(rollbackedTdArn))
+		d.LogInfo("task definition will be deregistered", "task_definition", arnToName(rollbackedTdArn))
 		return nil
 	}
 
-	d.LogInfo("Deregistering the rolled-back task definition %s", arnToName(rollbackedTdArn))
+	d.LogInfo("deregistering rolled-back task definition", "task_definition", arnToName(rollbackedTdArn))
 	_, err := d.ecs.DeregisterTaskDefinition(
 		ctx,
 		&ecs.DeregisterTaskDefinitionInput{
@@ -112,14 +112,14 @@ func (d *App) rollbackTaskDefinition(ctx context.Context, rollbackedTdArn string
 	if err != nil {
 		return fmt.Errorf("failed to deregister task definition: %w", err)
 	}
-	d.LogInfo("%s was deregistered successfully", arnToName(rollbackedTdArn))
+	d.LogInfo("task definition deregistered successfully", "task_definition", arnToName(rollbackedTdArn))
 	return nil
 }
 
 func (d *App) RollbackServiceTasks(ctx context.Context, sv *Service, targetArn string, opt RollbackOption) (string, error) {
 	currentArn := aws.ToString(sv.TaskDefinition)
 
-	d.LogInfo("Rolling back to %s %s", arnToName(targetArn), opt.DryRunString())
+	d.LogInfo("rolling back", withDryRun(opt.DryRun, "target", arnToName(targetArn))...)
 	if opt.DryRun {
 		return currentArn, nil
 	}
@@ -149,7 +149,7 @@ func (d *App) RollbackExpressService(ctx context.Context, sv *Service, _ string,
 		return "", err
 	}
 
-	d.LogInfo("Active deployment found, rolling back deployment %s %s", arnToName(deploymentArn), opt.DryRunString())
+	d.LogInfo("active deployment found, rolling back", withDryRun(opt.DryRun, "deployment", arnToName(deploymentArn))...)
 	return d.rollbackActiveECSDeployment(ctx, sv, deploymentArn, opt)
 }
 
@@ -159,13 +159,13 @@ func (d *App) RollbackECSService(ctx context.Context, sv *Service, targetArn str
 	if err != nil {
 		var errNotFound ErrNotFound
 		if errors.As(err, &errNotFound) {
-			d.LogInfo("No active service deployment found, rolling back service tasks to %s %s", arnToName(targetArn), opt.DryRunString())
+			d.LogInfo("no active deployment, rolling back service tasks", withDryRun(opt.DryRun, "target", arnToName(targetArn))...)
 			return d.RollbackServiceTasks(ctx, sv, targetArn, opt)
 		}
 		return "", err
 	}
 
-	d.LogInfo("Active deployment found, rolling back deployment %s %s", arnToName(deploymentArn), opt.DryRunString())
+	d.LogInfo("active deployment found, rolling back", withDryRun(opt.DryRun, "deployment", arnToName(deploymentArn))...)
 	return d.rollbackActiveECSDeployment(ctx, sv, deploymentArn, opt)
 }
 
@@ -194,12 +194,12 @@ func (d *App) RollbackByCodeDeploy(ctx context.Context, sv *Service, targetArn s
 	}
 	currentDeployment := out.DeploymentInfo
 
-	d.LogInfo("current deployment id: %s", *currentDeployment.DeploymentId)
+	d.LogInfo("current deployment", "deployment_id", *currentDeployment.DeploymentId)
 
 	switch currentDeployment.Status {
 	case cdTypes.DeploymentStatusSucceeded, cdTypes.DeploymentStatusFailed, cdTypes.DeploymentStatusStopped:
 		currentTdArn := aws.ToString(sv.TaskDefinition)
-		d.LogInfo("the deployment in progress is not found, creating a new deployment with %s %s", targetArn, opt.DryRunString())
+		d.LogInfo("deployment not in progress, creating new deployment", withDryRun(opt.DryRun, "target", targetArn)...)
 		if opt.DryRun {
 			return currentTdArn, nil
 		}
@@ -208,7 +208,7 @@ func (d *App) RollbackByCodeDeploy(ctx context.Context, sv *Service, targetArn s
 		}
 		return currentTdArn, nil
 	default: // If the deployment is not yet complete
-		d.LogInfo("the deployment in progress found, stopping the deployment %s %s", *currentDeployment.DeploymentId, opt.DryRunString())
+		d.LogInfo("deployment in progress, stopping", withDryRun(opt.DryRun, "deployment_id", *currentDeployment.DeploymentId)...)
 		tdArn, err := d.findTaskDefinitionOfDeployment(ctx, currentDeployment)
 		if err != nil {
 			return "", fmt.Errorf("failed to find task definition of deployment: %w", err)
@@ -318,8 +318,8 @@ func (d *App) waitForCodeDeployRollback(ctx context.Context, id string) error {
 		status := out.DeploymentInfo.Status
 		rbinfo := out.DeploymentInfo.RollbackInfo
 		if status == cdTypes.DeploymentStatusStopped && rbinfo != nil && rbinfo.RollbackDeploymentId != nil {
-			d.LogInfo("Deployment %s is stopped", id)
-			d.LogInfo("Rollback deployment created: %s", *rbinfo.RollbackDeploymentId)
+			d.LogInfo("deployment stopped", "deployment_id", id)
+			d.LogInfo("rollback deployment created", "deployment_id", *rbinfo.RollbackDeploymentId)
 			return nil
 		}
 		return fmt.Errorf("deployment %s is not stopped yet", id)
@@ -393,9 +393,9 @@ func (d *App) rollbackActiveECSDeployment(ctx context.Context, sv *Service, depl
 	currentTaskDefinition := aws.ToString(sv.TaskDefinition)
 
 	// Stop the deployment with rollback
-	d.LogInfo("Stopping deployment %s with rollback %s", arnToName(deploymentArn), opt.DryRunString())
+	d.LogInfo("stopping deployment with rollback", withDryRun(opt.DryRun, "deployment", arnToName(deploymentArn))...)
 	if opt.DryRun {
-		d.LogInfo("Rollback would be triggered for deployment %s", arnToName(deploymentArn))
+		d.LogInfo("rollback would be triggered", "deployment", arnToName(deploymentArn))
 		return currentTaskDefinition, nil
 	}
 

--- a/run.go
+++ b/run.go
@@ -45,7 +45,7 @@ func (d *App) Run(ctx context.Context, opt RunOption) error {
 	ctx, cancel := d.Start(ctx)
 	defer cancel()
 
-	d.LogInfo("Running task %s", opt.DryRunString())
+	d.LogInfo("Running task")
 	ov := types.TaskOverride{}
 	if opt.TaskOverrideStr != "" {
 		if err := json.Unmarshal([]byte(opt.TaskOverrideStr), &ov); err != nil {
@@ -68,9 +68,9 @@ func (d *App) Run(ctx context.Context, opt RunOption) error {
 		return err
 	}
 	if tdForRun.Arn == "" && tdForRun.TaskDefinitionInput != nil {
-		d.LogInfo("Task definition family %s will be registered", aws.ToString(tdForRun.TaskDefinitionInput.Family))
+		d.LogInfo("task definition will be registered", "family", aws.ToString(tdForRun.TaskDefinitionInput.Family))
 	} else {
-		d.LogInfo("Task definition ARN: %s", tdForRun.Arn)
+		d.LogInfo("task definition", "task_definition_arn", tdForRun.Arn)
 		var err error
 		td, err := d.DescribeTaskDefinition(ctx, tdForRun.Arn)
 		if err != nil {
@@ -82,7 +82,7 @@ func (d *App) Run(ctx context.Context, opt RunOption) error {
 	if watchContainer == nil {
 		return fmt.Errorf("container %s not found in the task definition", opt.WatchContainer)
 	}
-	d.LogInfo("Watch container: %s", aws.ToString(watchContainer.Name))
+	d.LogInfo("watch container", "container", aws.ToString(watchContainer.Name))
 
 	if opt.DryRun {
 		d.LogInfo("DRY RUN OK")
@@ -109,7 +109,7 @@ func (d *App) Run(ctx context.Context, opt RunOption) error {
 }
 
 func (d *App) RunTask(ctx context.Context, tdArn string, ov *types.TaskOverride, opt *RunOption) (*types.Task, error) {
-	d.LogInfo("Running task with %s", tdArn)
+	d.LogInfo("running task", "task_definition", tdArn)
 
 	sv, err := d.LoadServiceDefinition(d.config.ServiceDefinitionPath)
 	if err != nil {
@@ -150,7 +150,7 @@ func (d *App) RunTask(ctx context.Context, tdArn string, ov *types.TaskOverride,
 		if err != nil {
 			return nil, fmt.Errorf("failed to list tags for service: %w", err)
 		}
-		d.LogInfo("[DEBUG] propagate tags from service %s", *sv.ServiceArn)
+		d.LogInfo("[DEBUG] propagate tags from service", "service_arn", *sv.ServiceArn)
 		d.LogJSON(out)
 		in.Tags = append(in.Tags, out.Tags...)
 	case "", "NONE":
@@ -170,7 +170,7 @@ func (d *App) RunTask(ctx context.Context, tdArn string, ov *types.TaskOverride,
 	if len(out.Failures) > 0 {
 		f := out.Failures[0]
 		if f.Arn != nil {
-			d.LogInfo("Task ARN: %s", *f.Arn)
+			d.LogInfo("task failure", "task_arn", *f.Arn)
 		}
 		return nil, fmt.Errorf("failed to run task: %s %s", aws.ToString(f.Reason), aws.ToString(f.Detail))
 	}
@@ -179,7 +179,7 @@ func (d *App) RunTask(ctx context.Context, tdArn string, ov *types.TaskOverride,
 		return nil, fmt.Errorf("failed to run task: no tasks run")
 	}
 	task := out.Tasks[0]
-	d.LogInfo("Task ARN: %s", aws.ToString(task.TaskArn))
+	d.LogInfo("task started", "task_arn", aws.ToString(task.TaskArn))
 	return &task, nil
 }
 
@@ -197,7 +197,7 @@ func (d *App) WaitRunTask(ctx context.Context, task *types.Task, watchContainer 
 		return nil
 	}
 
-	d.LogInfo("Watching container: %s", *watchContainer.Name)
+	d.LogInfo("watching container", "container", *watchContainer.Name)
 	logGroup, logStream := d.GetLogInfo(task, watchContainer)
 	sleepContext(ctx, 3*time.Second) // wait for log stream
 
@@ -223,18 +223,18 @@ func (d *App) WaitRunTask(ctx context.Context, task *types.Task, watchContainer 
 func (d *App) waitTask(ctx context.Context, task *types.Task, untilRunning bool) error {
 	id := arnToName(*task.TaskArn)
 	if untilRunning {
-		d.LogInfo("Waiting for task ID %s until running", id)
+		d.LogInfo("waiting for task until running", "task_id", id)
 		waiter := ecs.NewTasksRunningWaiter(d.ecs, func(o *ecs.TasksRunningWaiterOptions) {
 			o.MaxDelay = waiterMaxDelay
 		})
 		if err := waiter.Wait(ctx, d.DescribeTasksInput(task), d.Timeout()); err != nil {
 			return err
 		}
-		d.LogInfo("Task ID %s is running", id)
+		d.LogInfo("task is running", "task_id", id)
 		return nil
 	}
 
-	d.LogInfo("Waiting for task ID %s until stopped", id)
+	d.LogInfo("waiting for task until stopped", "task_id", id)
 	waiter := ecs.NewTasksStoppedWaiter(d.ecs, func(o *ecs.TasksStoppedWaiterOptions) {
 		o.MaxDelay = waiterMaxDelay
 	})
@@ -265,7 +265,7 @@ func (d *App) resolveTaskDefinitionForRun(ctx context.Context, opt RunOption) (*
 		if err != nil {
 			return nil, err
 		}
-		d.LogInfo("Revision is not specified. Use latest task definition family %s", family)
+		d.LogInfo("revision not specified, using latest task definition", "family", family)
 		latestTdArn, err := d.findLatestTaskDefinitionArn(ctx, family)
 		if err != nil {
 			return nil, err
@@ -279,7 +279,7 @@ func (d *App) resolveTaskDefinitionForRun(ctx context.Context, opt RunOption) (*
 		if rev != "" {
 			return &taskDefinitionForRun{Arn: fmt.Sprintf("%s:%s", family, rev)}, nil
 		}
-		d.LogInfo("Revision is not specified. Use latest task definition family %s", family)
+		d.LogInfo("revision not specified, using latest task definition", "family", family)
 		latestTdArn, err := d.findLatestTaskDefinitionArn(ctx, family)
 		if err != nil {
 			return nil, err
@@ -296,7 +296,7 @@ func (d *App) resolveTaskDefinitionForRun(ctx context.Context, opt RunOption) (*
 		}
 		{
 			b, _ := MarshalJSONForAPI(in)
-			d.LogInfo("[DEBUG] task definition: %s", string(b))
+			d.LogInfo("[DEBUG] task definition", "definition", string(b))
 		}
 		if opt.DryRun {
 			return &taskDefinitionForRun{Arn: "", TaskDefinitionInput: in}, nil

--- a/verify.go
+++ b/verify.go
@@ -170,10 +170,10 @@ func (d *App) newAssumedVerifier(ctx context.Context, cfg aws.Config, executionR
 		RoleSessionName: aws.String("ecspresso-verifier"),
 	})
 	if err != nil {
-		d.LogInfo("failed to assume role to taskExecutionRole. Continue to verify with current session. %s", err.Error())
+		d.LogInfo("failed to assume role to taskExecutionRole, continuing with current session", "error", err.Error())
 		return newVerifier(&cfg, &cfg, opt), nil
 	}
-	d.LogInfo("success to assume role: %s", aws.ToString(executionRole))
+	d.LogInfo("assumed role successfully", "role", aws.ToString(executionRole))
 	ec := aws.Config{}
 	ec.Region = d.config.Region
 	ec.Credentials = credentials.NewStaticCredentialsProvider(
@@ -428,7 +428,7 @@ func (d *App) verifyServiceDefinition(ctx context.Context) error {
 		_, err := vs.VerifyResource(ctx, name, func(context.Context) error {
 			if ebs := vc.ManagedEBSVolume; ebs != nil {
 				if len(ebs.TagSpecifications) > 1 {
-					d.LogWarn("%s has more than one tag specifications. Only the first tag specification is used.", name)
+					d.LogWarn("more than one tag specification, using first only", "resource", name)
 				}
 				roleArn := aws.ToString(ebs.RoleArn)
 				if _, err := vs.VerifyResource(ctx, fmt.Sprintf("RoleArn[%s]", roleArn), func(ctx context.Context) error {
@@ -975,10 +975,10 @@ func (d *App) verifyLogConfiguration(ctx context.Context, c *types.ContainerDefi
 			} else if d.verifier.IsAssumed() {
 				return fmt.Errorf("failed to create log group %s: %w", group, err)
 			} else {
-				d.LogWarn("failed to create log group %s: %s", group, err)
+				d.LogWarn("failed to create log group", "log_group", group, "error", err.Error())
 			}
 		} else {
-			d.LogInfo("created log group %s", group)
+			d.LogInfo("created log group", "log_group", group)
 		}
 	}
 

--- a/wait.go
+++ b/wait.go
@@ -121,7 +121,7 @@ func (d *App) Wait(ctx context.Context, opt WaitOption) error {
 	defer cancel()
 
 	until := waitUntil(opt.WaitUntil)
-	d.LogInfo("Waiting for the service %s", until)
+	d.LogInfo("waiting for service", "until", string(until))
 
 	sv, err := d.DescribeServiceStatus(ctx, 0)
 	if err != nil {
@@ -134,13 +134,13 @@ func (d *App) Wait(ctx context.Context, opt WaitOption) error {
 	}
 	if err := doWait(ctx, sv); err != nil {
 		if errors.As(err, &errNotFound) && sv.isCodeDeploy() {
-			d.LogInfo("%s", err)
+			d.LogInfo(err.Error())
 			return d.WaitTaskSetStable(ctx, sv)
 		}
 		return err
 	}
 
-	d.LogInfo("Service is %s now. Completed!", until)
+	d.LogInfo("service completed", "status", string(until))
 	return nil
 }
 
@@ -159,7 +159,7 @@ func (d *App) WaitServiceStable(ctx context.Context, sv *Service) error {
 				return
 			case <-tick.C:
 				if err := d.showServiceStatus(waitCtx, st); err != nil {
-					d.LogWarn("%s", err.Error())
+					d.LogWarn(err.Error())
 					continue
 				}
 			}
@@ -177,7 +177,7 @@ func (d *App) WaitServiceStable(ctx context.Context, sv *Service) error {
 	<-time.After(delayForServiceChanged)
 	// show the service status once more (correct all logs)
 	if err := d.showServiceStatus(ctx, st); err != nil {
-		d.LogWarn("%s", err.Error())
+		d.LogWarn(err.Error())
 	}
 	return nil
 }
@@ -231,7 +231,7 @@ func (d *App) WaitServiceDeployCompleted(ctx context.Context, sv *Service) error
 		}
 		return err
 	}
-	d.LogInfo("Waiting for service deployment %s to complete...", arnToName(deploymentArn))
+	d.LogInfo("waiting for service deployment", "deployment", arnToName(deploymentArn))
 
 	tick := time.NewTicker(refreshInterval)
 	defer tick.Stop()
@@ -245,7 +245,7 @@ func (d *App) WaitServiceDeployCompleted(ctx context.Context, sv *Service) error
 		case <-tick.C:
 		}
 		if err := d.showServiceStatus(ctx, st); err != nil {
-			d.LogWarn("%s", err.Error())
+			d.LogWarn(err.Error())
 			continue
 		}
 
@@ -265,7 +265,7 @@ func (d *App) WaitServiceDeployCompleted(ctx context.Context, sv *Service) error
 		revisionSummaryOutput := strings.Join(lines, "\n")
 		if revisionSummaryOutput != prevRevisionSummaryOutput {
 			for _, line := range lines {
-				d.LogInfo("%s", line)
+				d.LogInfo(line)
 			}
 			prevRevisionSummaryOutput = revisionSummaryOutput
 		}
@@ -273,12 +273,12 @@ func (d *App) WaitServiceDeployCompleted(ctx context.Context, sv *Service) error
 		// check deployment status
 		status := dp.Status
 		if status != prevStatus {
-			d.LogInfo("Service deployment status: %s", status)
+			d.LogInfo("service deployment status", "status", string(status))
 			prevStatus = status
 		}
 		switch status {
 		case types.ServiceDeploymentStatusSuccessful, types.ServiceDeploymentStatusRollbackSuccessful:
-			d.LogInfo("Service deployment completed %s", status)
+			d.LogInfo("service deployment completed", "status", string(status))
 			return nil
 		case types.ServiceDeploymentStatusStopped, types.ServiceDeploymentStatusRollbackFailed, types.ServiceDeploymentStatusStopRequested:
 			return fmt.Errorf("Service deployment failed %s", status)
@@ -322,7 +322,7 @@ func (d *App) WaitForCodeDeploy(ctx context.Context, sv *Service) error {
 	if err != nil {
 		return err
 	}
-	d.LogInfo("Waiting for a deployment successful ID: %s", dpID)
+	d.LogInfo("waiting for deployment success", "deployment_id", dpID)
 	go d.codeDeployProgressBar(ctx, dpID)
 
 	waiter := codedeploy.NewDeploymentSuccessfulWaiter(d.codedeploy, func(o *codedeploy.DeploymentSuccessfulWaiterOptions) {
@@ -342,7 +342,7 @@ func (d *App) WaitForCodeDeployLifecycle(targetLifecycleEvent string) waitFunc {
 		if err != nil {
 			return err
 		}
-		d.LogInfo("Waiting for a deployment lifecycle event: %s (ID: %s)", targetLifecycleEvent, dpID)
+		d.LogInfo("waiting for deployment lifecycle event", "event", targetLifecycleEvent, "deployment_id", dpID)
 
 		t := time.NewTicker(refreshInterval)
 		defer t.Stop()
@@ -361,7 +361,7 @@ func (d *App) WaitForCodeDeployLifecycle(targetLifecycleEvent string) waitFunc {
 				TargetId:     aws.String(d.Cluster + ":" + d.Service),
 			})
 			if err != nil {
-				d.LogWarn("%s", err.Error())
+				d.LogWarn(err.Error())
 				continue
 			}
 
@@ -373,7 +373,7 @@ func (d *App) WaitForCodeDeployLifecycle(targetLifecycleEvent string) waitFunc {
 				lifecycleEvent := *ev.LifecycleEventName
 				if lifecycle2Status[lifecycleEvent] != ev.Status {
 					if ev.Status != cdTypes.LifecycleEventStatusPending {
-						d.LogInfo("%s: %s", lifecycleEvent, ev.Status)
+						d.LogInfo("lifecycle event status", "event", lifecycleEvent, "status", string(ev.Status))
 					}
 					lifecycle2Status[lifecycleEvent] = ev.Status
 				}
@@ -382,12 +382,12 @@ func (d *App) WaitForCodeDeployLifecycle(targetLifecycleEvent string) waitFunc {
 					targetEventFound = true
 					switch ev.Status {
 					case cdTypes.LifecycleEventStatusSucceeded:
-						d.LogInfo("Lifecycle event %s completed successfully", targetLifecycleEvent)
+						d.LogInfo("lifecycle event completed", "event", targetLifecycleEvent)
 						return nil
 					case cdTypes.LifecycleEventStatusFailed:
 						return fmt.Errorf("lifecycle event %s failed", targetLifecycleEvent)
 					case cdTypes.LifecycleEventStatusSkipped:
-						d.LogInfo("Lifecycle event %s was skipped", targetLifecycleEvent)
+						d.LogInfo("lifecycle event skipped", "event", targetLifecycleEvent)
 						return nil
 					default:
 						// NOP for "Pending", "InProgress", and "Unknown"
@@ -401,7 +401,7 @@ func (d *App) WaitForCodeDeployLifecycle(targetLifecycleEvent string) waitFunc {
 				if !targetEventFound {
 					return fmt.Errorf("lifecycle event %s not found in deployment", targetLifecycleEvent)
 				}
-				d.LogInfo("Deployment completed but lifecycle event %s did not complete as expected", targetLifecycleEvent)
+				d.LogInfo("deployment completed, lifecycle event incomplete", "event", targetLifecycleEvent)
 				return nil
 			}
 		}
@@ -446,7 +446,7 @@ func (d *App) showServiceStatus(ctx context.Context, st *showState) error {
 	// if the deployments are not changed, do not show the deployments.
 	if !bytes.Equal(st.deploymentsHash, hash) {
 		for _, line := range lines {
-			d.LogInfo("%s", line)
+			d.LogInfo(line)
 		}
 	}
 	st.deploymentsHash = hash
@@ -483,7 +483,7 @@ func (d *App) codeDeployProgressBar(ctx context.Context, dpID string) error {
 			TargetId:     aws.String(d.Cluster + ":" + d.Service),
 		})
 		if err != nil {
-			d.LogWarn("%s", err.Error())
+			d.LogWarn(err.Error())
 			continue
 		}
 		dep := out.DeploymentTarget
@@ -495,7 +495,7 @@ func (d *App) codeDeployProgressBar(ctx context.Context, dpID string) error {
 			name := *ev.LifecycleEventName
 			if lcEvents[name] != ev.Status {
 				if ev.Status != cdTypes.LifecycleEventStatusPending {
-					d.LogInfo("%s: %s", name, ev.Status)
+					d.LogInfo("lifecycle event status", "event", name, "status", string(ev.Status))
 				}
 				lcEvents[name] = ev.Status
 			}
@@ -523,7 +523,7 @@ func (d *App) WaitTaskSetStable(ctx context.Context, sv *Service) error {
 			ts := sv.TaskSets[0]
 			if aws.ToString(ts.Status) == "PRIMARY" {
 				if prev != ts.StabilityStatus {
-					d.LogInfo("Waiting a task set PRIMARY stable: %s", ts.StabilityStatus)
+					d.LogInfo("waiting for PRIMARY task set stable", "stability_status", string(ts.StabilityStatus))
 					if n > 1 {
 						d.LogInfo("Waiting a PRIMARY taskset available only")
 					}


### PR DESCRIPTION
## Summary
- Refactor `LogInfo`/`LogWarn` to use slog-native key-value attributes instead of `fmt.Sprintf`, so that `--log-format json` outputs structured JSON fields (e.g. `deployment_id`, `task_definition`, `dry_run`) instead of embedding them in the `msg` string
- Add `withDryRun` helper to conditionally append `dry_run:true` attribute only when dry-run is enabled
- Update `fujiwara/sloghandler` v0.0.3 → v0.1.0
- Update CI Go versions to 1.25/1.26
- Update README with new log format examples and `--log-format` documentation

Closes #938

🤖 Generated with [Claude Code](https://claude.com/claude-code)