### PR TITLE
Add --list flag to docs command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,10 @@ go test -race ./...
   }
   ```
 
+## Documentation
+
+- When adding or changing features, always check README.md for inconsistencies and update it if needed (e.g. command examples, flag lists, log output examples)
+
 ## Code Style
 
 - Use `go fmt ./...` before committing

--- a/README.md
+++ b/README.md
@@ -1177,6 +1177,7 @@ The `docs` command shows the embedded documentation (this README) directly from 
 ```
 Flags:
       --article="readme"          article name to display
+      --list                      list available articles
       --index                     show table of contents
       --search=""                 search keyword in documents
       --json                      output in JSON format
@@ -1208,7 +1209,13 @@ $ ecspresso docs --search "deploy" --json
 
 The JSON output contains structured sections with `level`, `title`, `content`, and `line` fields, making it easy for automated tools and LLM agents to consume ecspresso documentation programmatically.
 
-Available articles: `readme` (default), `skill`.
+List available articles:
+
+```console
+$ ecspresso docs --list
+readme	ecspresso README
+skill	LLM agent skill reference
+```
 
 Show the LLM agent skill guide:
 

--- a/docs.go
+++ b/docs.go
@@ -11,6 +11,7 @@ import (
 // DocsOption defines CLI options for the docs subcommand.
 type DocsOption struct {
 	Article string `help:"article name to display" default:"readme" enum:"readme,skill"`
+	List    bool   `help:"list available articles" default:"false"`
 	Index   bool   `help:"show table of contents" default:"false"`
 	Search  string `help:"search keyword in documents" default:""`
 	JSON    bool   `help:"output in JSON format" default:"false" name:"json"`
@@ -30,14 +31,28 @@ type docsOutput struct {
 	Sections []docsSection `json:"sections"`
 }
 
+type docsArticle struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+var articles = []docsArticle{
+	{Name: "readme", Description: "ecspresso README"},
+	{Name: "skill", Description: "LLM agent skill reference"},
+}
+
 // Docs shows embedded documentation.
 func Docs(opt DocsOption) error {
+	jsonOutput := opt.JSON || logFormat == logFormatJSON
+
+	if opt.List {
+		return docsList(jsonOutput)
+	}
+
 	content, err := getArticle(opt.Article)
 	if err != nil {
 		return err
 	}
-
-	jsonOutput := opt.JSON || logFormat == logFormatJSON
 
 	switch {
 	case opt.Index:
@@ -58,6 +73,18 @@ func getArticle(name string) (string, error) {
 	default:
 		return "", fmt.Errorf("unknown article: %s", name)
 	}
+}
+
+func docsList(jsonOutput bool) error {
+	if !jsonOutput {
+		var buf strings.Builder
+		for _, a := range articles {
+			fmt.Fprintf(&buf, "%s\t%s\n", a.Name, a.Description)
+		}
+		_, err := io.WriteString(os.Stdout, buf.String())
+		return err
+	}
+	return writeJSON(articles)
 }
 
 func docsFull(article, content string, jsonOutput bool) error {

--- a/docs_test.go
+++ b/docs_test.go
@@ -176,6 +176,7 @@ func TestParseSectionsSkill(t *testing.T) {
 func TestDocsOptionDefault(t *testing.T) {
 	want := &ecspresso.DocsOption{
 		Article: "readme",
+		List:    false,
 		Index:   false,
 		Search:  "",
 		JSON:    false,
@@ -188,5 +189,19 @@ func TestDocsOptionDefault(t *testing.T) {
 	got := opts.ForSubCommand("docs")
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("DocsOption mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestDocsListText(t *testing.T) {
+	err := ecspresso.Docs(ecspresso.DocsOption{List: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDocsListJSON(t *testing.T) {
+	err := ecspresso.Docs(ecspresso.DocsOption{List: true, JSON: true})
+	if err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
## Summary
- Add `--list` flag to `ecspresso docs` to show available articles
- Text output: tab-separated name and description
- JSON output: array of `{"name", "description"}` objects

🤖 Generated with [Claude Code](https://claude.com/claude-code)