### PR TITLE
Add --jsonnet flag to diff command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,7 @@ go test -race ./...
       t.Errorf("mismatch (-want +got):\n%s", diff)
   }
   ```
+- Use `t.Context()` instead of `context.Background()` in tests
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -1058,6 +1058,12 @@ $ ECSPRESSO_DIFF_COMMAND="difft --color=always" ecspresso diff
 
 The command should exit with status 0. If it exits with a non-zero status when two files differ (for example, `diff(1)`), you need to write a wrapper command.
 
+`ecspresso diff --jsonnet` renders the diff output in Jsonnet format instead of JSON. This is useful when you manage definitions in Jsonnet files.
+
+```console
+$ ecspresso diff --jsonnet
+```
+
 
 #### verify
 

--- a/config_test.go
+++ b/config_test.go
@@ -1,7 +1,6 @@
 package ecspresso_test
 
 import (
-	"context"
 	"strings"
 	"testing"
 	"time"
@@ -14,7 +13,7 @@ import (
 )
 
 func TestLoadServiceDefinition(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	app, err := ecspresso.New(ctx, &ecspresso.CLIOptions{ConfigFilePath: "tests/test.yaml"})
 	if err != nil {
 		t.Error(err)
@@ -64,7 +63,7 @@ func TestLoadConfigWithPluginMultiple(t *testing.T) {
 func TestLoadConfigWithPluginDuplicate(t *testing.T) {
 	t.Setenv("TAG", "testing")
 	t.Setenv("JSON", `{"foo":"bar"}`)
-	ctx := context.Background()
+	ctx := t.Context()
 	loader := ecspresso.NewConfigLoader(nil, nil)
 	_, err := loader.Load(ctx, "tests/config_duplicate_plugins.yaml", "")
 	if err == nil {
@@ -92,7 +91,7 @@ func testLoadConfigWithPlugin(t *testing.T, path string) {
 	t.Setenv("TAG", "testing")
 	t.Setenv("JSON", `{"foo":"bar"}`)
 	t.Setenv("AWS_REGION", "ap-northeast-1")
-	ctx := context.Background()
+	ctx := t.Context()
 	app, err := ecspresso.New(ctx, &ecspresso.CLIOptions{ConfigFilePath: path})
 	if err != nil {
 		t.Error(err)
@@ -226,7 +225,7 @@ func TestConfigWithRequiredVersionUnsatisfied(t *testing.T) {
 			ErrorMessage:    "does not satisfy constraints",
 		},
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	for _, c := range cases {
 		t.Run(c.CurrentVersion+":"+c.RequiredVersion, func(t *testing.T) {
 			conf := ecspresso.NewDefaultConfig()
@@ -259,7 +258,7 @@ func TestConfigWithInvalidRequiredVersion(t *testing.T) {
 			ErrorMessage:    "invalid format",
 		},
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	for _, c := range cases {
 		t.Run(c.CurrentVersion+":"+c.RequiredVersion, func(t *testing.T) {
 			conf := ecspresso.NewDefaultConfig()
@@ -279,7 +278,7 @@ func TestConfigWithInvalidRequiredVersion(t *testing.T) {
 func TestLoadConfigWithoutTimeout(t *testing.T) {
 	t.Setenv("AWS_REGION", "ap-northeast-2")
 
-	ctx := context.Background()
+	ctx := t.Context()
 	loader := ecspresso.NewConfigLoader(nil, nil)
 	conf, err := loader.Load(ctx, "tests/notimeout.yml", "")
 	if err != nil {
@@ -299,7 +298,7 @@ func TestLoadConfigWithoutTimeout(t *testing.T) {
 }
 
 func TestLoadConfigForCodeDeploy(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	loader := ecspresso.NewConfigLoader(nil, nil)
 	for _, ext := range []string{"yml", "json", "jsonnet"} {
 		name := "tests/config_codedeploy." + ext
@@ -328,7 +327,7 @@ var FilterCommandTests = []struct {
 }
 
 func TestFilterCommandDeprecated(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	for _, ts := range FilterCommandTests {
 		app, err := ecspresso.New(ctx, &ecspresso.CLIOptions{
 			ConfigFilePath: "tests/filter_command.yml",

--- a/diff.go
+++ b/diff.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/fatih/color"
+	"github.com/google/go-jsonnet/formatter"
 	"github.com/hexops/gotextdiff"
 	"github.com/hexops/gotextdiff/myers"
 	"github.com/hexops/gotextdiff/span"
@@ -27,6 +28,7 @@ import (
 
 type DiffOption struct {
 	Unified  bool   `help:"unified diff format" default:"true" negatable:""`
+	Jsonnet  bool   `help:"render as jsonnet format" default:"false"`
 	External string `help:"external command to format diff" env:"ECSPRESSO_DIFF_COMMAND"`
 
 	w io.Writer `kong:"-"`
@@ -156,6 +158,14 @@ func diffServices(ctx context.Context, local, remote *Service, localPath string,
 
 	remoteSv := toDiffString(remoteSvBytes)
 	newSv := toDiffString(newSvBytes)
+	if opt.Jsonnet {
+		if remoteSv, err = toJsonnetString(remoteSv, remoteArn); err != nil {
+			return false, fmt.Errorf("failed to format remote service definition as jsonnet: %w", err)
+		}
+		if newSv, err = toJsonnetString(newSv, localPath); err != nil {
+			return false, fmt.Errorf("failed to format local service definition as jsonnet: %w", err)
+		}
+	}
 	if remoteSv == newSv {
 		return false, nil
 	}
@@ -191,6 +201,14 @@ func diffTaskDefs(ctx context.Context, local, remote *TaskDefinitionInput, local
 
 	remoteTd := toDiffString(remoteTdBytes)
 	newTd := toDiffString(newTdBytes)
+	if opt.Jsonnet {
+		if remoteTd, err = toJsonnetString(remoteTd, remoteArn); err != nil {
+			return false, fmt.Errorf("failed to format remote task definition as jsonnet: %w", err)
+		}
+		if newTd, err = toJsonnetString(newTd, localPath); err != nil {
+			return false, fmt.Errorf("failed to format local task definition as jsonnet: %w", err)
+		}
+	}
 	if remoteTd == newTd {
 		return false, nil
 	}
@@ -487,4 +505,11 @@ func toDiffString(b []byte) string {
 		return ""
 	}
 	return string(b)
+}
+
+func toJsonnetString(jsonStr, filename string) (string, error) {
+	if jsonStr == "" {
+		return "", nil
+	}
+	return formatter.Format(filename, jsonStr, formatter.DefaultOptions())
 }

--- a/diff.go
+++ b/diff.go
@@ -253,9 +253,9 @@ func diffExternal(ctx context.Context, diffCmd string, target, remote, local str
 			return fmt.Errorf("failed to create temp dir: %w", err)
 		}
 	}
-	ext := ".json"
+	ext := jsonExt
 	if opt.Jsonnet {
-		ext = ".jsonnet"
+		ext = jsonnetExt
 	}
 	remoteFile := filepath.Join("remote", target+ext)
 	localFile := filepath.Join("local", target+ext)

--- a/diff.go
+++ b/diff.go
@@ -253,8 +253,12 @@ func diffExternal(ctx context.Context, diffCmd string, target, remote, local str
 			return fmt.Errorf("failed to create temp dir: %w", err)
 		}
 	}
-	remoteFile := filepath.Join("remote", target+".json")
-	localFile := filepath.Join("local", target+".json")
+	ext := ".json"
+	if opt.Jsonnet {
+		ext = ".jsonnet"
+	}
+	remoteFile := filepath.Join("remote", target+ext)
+	localFile := filepath.Join("local", target+ext)
 	if err := os.WriteFile(remoteFile, []byte(remote), 0644); err != nil {
 		return fmt.Errorf("failed to write remote file: %w", err)
 	}

--- a/diff_test.go
+++ b/diff_test.go
@@ -460,6 +460,68 @@ func TestDiffServicesCodeDeployTargetGroupArn(t *testing.T) {
 	})
 }
 
+func TestDiffJsonnet(t *testing.T) {
+	ctx := context.Background()
+	b := new(bytes.Buffer)
+	opt := &ecspresso.DiffOption{Unified: true, Jsonnet: true}
+	opt.SetWriter(b)
+	color.NoColor = true
+
+	t.Run("jsonnet diff for task defs with difference", func(t *testing.T) {
+		b.Reset()
+		local := &ecspresso.TaskDefinitionInput{
+			Cpu:    aws.String("256"),
+			Memory: aws.String("512"),
+			ContainerDefinitions: []types.ContainerDefinition{
+				{
+					Name:  aws.String("app"),
+					Image: aws.String("nginx:latest"),
+				},
+			},
+		}
+		remote := &ecspresso.TaskDefinitionInput{
+			Cpu:    aws.String("256"),
+			Memory: aws.String("1024"),
+			ContainerDefinitions: []types.ContainerDefinition{
+				{
+					Name:  aws.String("app"),
+					Image: aws.String("nginx:stable"),
+				},
+			},
+		}
+		diff, err := ecspresso.DiffTaskDefs(ctx, local, remote, "local.jsonnet", "remote", opt)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !diff {
+			t.Fatal("expected diff")
+		}
+		ds := b.String()
+		// jsonnet format uses unquoted keys
+		if strings.Contains(ds, `"memory"`) {
+			t.Errorf("expected jsonnet format (unquoted keys), got JSON: %s", ds)
+		}
+		if !strings.Contains(ds, "memory:") {
+			t.Errorf("expected jsonnet format with 'memory:' key: %s", ds)
+		}
+	})
+
+	t.Run("jsonnet diff for same task defs shows no diff", func(t *testing.T) {
+		b.Reset()
+		td := &ecspresso.TaskDefinitionInput{
+			Cpu:    aws.String("256"),
+			Memory: aws.String("512"),
+		}
+		diff, err := ecspresso.DiffTaskDefs(ctx, td, td, "local.jsonnet", "remote", opt)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if diff {
+			t.Fatalf("unexpected diff: %s", b.String())
+		}
+	})
+}
+
 func TestDiffTaskDefs(t *testing.T) {
 	ctx := context.Background()
 	b := new(bytes.Buffer)

--- a/diff_test.go
+++ b/diff_test.go
@@ -2,7 +2,6 @@ package ecspresso_test
 
 import (
 	"bytes"
-	"context"
 	"strings"
 	"testing"
 
@@ -232,7 +231,7 @@ var testServiceDefinitionHasDesiredCount = &ecspresso.Service{
 }
 
 func TestDiffServices(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	b := new(bytes.Buffer)
 	opt := &ecspresso.DiffOption{Unified: true}
 	opt.SetWriter(b)
@@ -372,7 +371,7 @@ func TestDiffServices(t *testing.T) {
 }
 
 func TestDiffServicesCodeDeployTargetGroupArn(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	b := new(bytes.Buffer)
 	opt := &ecspresso.DiffOption{Unified: true}
 	opt.SetWriter(b)
@@ -461,7 +460,7 @@ func TestDiffServicesCodeDeployTargetGroupArn(t *testing.T) {
 }
 
 func TestDiffJsonnet(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	b := new(bytes.Buffer)
 	opt := &ecspresso.DiffOption{Unified: true, Jsonnet: true}
 	opt.SetWriter(b)
@@ -523,7 +522,7 @@ func TestDiffJsonnet(t *testing.T) {
 }
 
 func TestDiffTaskDefs(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	b := new(bytes.Buffer)
 	opt := &ecspresso.DiffOption{Unified: true}
 	opt.SetWriter(b)

--- a/ecspresso_test.go
+++ b/ecspresso_test.go
@@ -1,7 +1,6 @@
 package ecspresso_test
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
 
@@ -21,7 +20,7 @@ func str[T any](v T) string {
 }
 
 func TestLoadTaskDefinition(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	for _, path := range []string{
 		"tests/td.json",
 		"tests/td-plain.json",
@@ -55,7 +54,7 @@ func TestLoadTaskDefinition(t *testing.T) {
 }
 
 func TestLoadTaskDefinitionTags(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	for _, path := range []string{"tests/td.json", "tests/td-plain.json", "tests/td.jsonnet"} {
 		app, err := ecspresso.New(ctx, &ecspresso.CLIOptions{
 			ConfigFilePath: "tests/td-config.yml",

--- a/express.go
+++ b/express.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
-	"github.com/google/go-jsonnet/formatter"
 	"github.com/hexops/gotextdiff"
 	"github.com/hexops/gotextdiff/myers"
 	"github.com/hexops/gotextdiff/span"
@@ -47,7 +46,7 @@ func (d *App) initExpressGatewayService(ctx context.Context, sv *Service, opt In
 		return nil, nil, fmt.Errorf("unable to marshal express gateway service to JSON: %w", err)
 	}
 	if opt.Jsonnet {
-		out, err := formatter.Format(conf.ExpressDefinitionPath, string(b), formatter.DefaultOptions())
+		out, err := toJsonnetString(string(b), conf.ExpressDefinitionPath)
 		if err != nil {
 			return nil, nil, fmt.Errorf("unable to format express gateway service as Jsonnet: %w", err)
 		}

--- a/external/external_test.go
+++ b/external/external_test.go
@@ -1,7 +1,6 @@
 package external_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -9,7 +8,7 @@ import (
 )
 
 func TestExternalPlugin(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	config := external.Config{
 		Name:    "test",
 		Command: []string{"jq", "-n"},
@@ -47,7 +46,7 @@ func TestExternalPlugin(t *testing.T) {
 }
 
 func TestExternalPluginTimeout(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	config := external.Config{
 		Name:    "test",
 		Command: []string{"sh", "-c", "sleep 2; echo 123"},
@@ -65,7 +64,7 @@ func TestExternalPluginTimeout(t *testing.T) {
 }
 
 func TestExternalPluginString(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	config := external.Config{
 		Name:    "echo",
 		Command: []string{"echo", "-n"},

--- a/init.go
+++ b/init.go
@@ -46,7 +46,7 @@ func (opt *InitOption) NewConfig(ctx context.Context, configFilePath string) (*C
 	return conf, nil
 }
 
-var (
+const (
 	jsonnetExt = ".jsonnet"
 	jsonExt    = ".json"
 	ymlExt     = ".yml"

--- a/init.go
+++ b/init.go
@@ -13,7 +13,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/goccy/go-yaml"
-	"github.com/google/go-jsonnet/formatter"
 )
 
 var CreateFileMode = os.FileMode(0644)
@@ -159,7 +158,7 @@ func (d *App) initConfigurationFile(ctx context.Context, configFilePath string, 
 			if err != nil {
 				return fmt.Errorf("unable to marshal config to JSON: %w", err)
 			}
-			out, err := formatter.Format(configFilePath, string(b), formatter.DefaultOptions())
+			out, err := toJsonnetString(string(b), configFilePath)
 			if err != nil {
 				return fmt.Errorf("unable to format config as Jsonnet: %w", err)
 			}
@@ -203,7 +202,7 @@ func (d *App) initServiceDefinition(ctx context.Context, sv *Service, opt InitOp
 		return nil, "", fmt.Errorf("unable to marshal service definition to JSON: %w", err)
 	} else {
 		if opt.Jsonnet {
-			out, err := formatter.Format(conf.ServiceDefinitionPath, string(b), formatter.DefaultOptions())
+			out, err := toJsonnetString(string(b), conf.ServiceDefinitionPath)
 			if err != nil {
 				return nil, "", fmt.Errorf("unable to format service definition as Jsonnet: %w", err)
 			}
@@ -232,7 +231,7 @@ func (d *App) initTaskDefinition(ctx context.Context, opt InitOption, tdArn stri
 		return nil, fmt.Errorf("unable to marshal task definition to JSON: %w", err)
 	} else {
 		if opt.Jsonnet {
-			out, err := formatter.Format(conf.TaskDefinitionPath, string(b), formatter.DefaultOptions())
+			out, err := toJsonnetString(string(b), conf.TaskDefinitionPath)
 			if err != nil {
 				return nil, fmt.Errorf("unable to format task definition as Jsonnet: %w", err)
 			}

--- a/registry/client_test.go
+++ b/registry/client_test.go
@@ -57,7 +57,7 @@ func TestImages(t *testing.T) {
 		}
 		t.Logf("testing %s", fullImage)
 		client := registry.New(c.image, "", "")
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 		defer cancel()
 		if ok, err := client.HasImage(ctx, c.tagOrDigest); err != nil {
 			if isTemporary(err) {
@@ -90,7 +90,7 @@ func TestFailImages(t *testing.T) {
 		}
 		t.Logf("testing (will be fail) %s", fullImage)
 		client := registry.New(c.image, "", "")
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 		defer cancel()
 		if ok, err := client.HasImage(ctx, c.tagOrDigest); err == nil {
 			t.Errorf("HasImage %s error %s", fullImage, err)

--- a/render.go
+++ b/render.go
@@ -8,7 +8,6 @@ import (
 	"os"
 
 	"github.com/goccy/go-yaml"
-	"github.com/google/go-jsonnet/formatter"
 )
 
 type RenderOption struct {
@@ -28,7 +27,7 @@ func (d *App) Render(ctx context.Context, opt RenderOption) error {
 				if err != nil {
 					return fmt.Errorf("unable to marshal config to JSON: %w", err)
 				}
-				s, err := formatter.Format("", string(b), formatter.DefaultOptions())
+				s, err := toJsonnetString(string(b), "")
 				if err != nil {
 					return fmt.Errorf("unable to format config as Jsonnet: %w", err)
 				}
@@ -47,7 +46,7 @@ func (d *App) Render(ctx context.Context, opt RenderOption) error {
 			}
 			s := MustMarshalJSONStringForAPI(sv)
 			if opt.Jsonnet {
-				s, err = formatter.Format(d.config.ServiceDefinitionPath, s, formatter.DefaultOptions())
+				s, err = toJsonnetString(s, d.config.ServiceDefinitionPath)
 				if err != nil {
 					return fmt.Errorf("unable to format service definition as Jsonnet: %w", err)
 				}
@@ -62,7 +61,7 @@ func (d *App) Render(ctx context.Context, opt RenderOption) error {
 			}
 			s := MustMarshalJSONStringForAPI(td)
 			if opt.Jsonnet {
-				s, err = formatter.Format(d.config.TaskDefinitionPath, s, formatter.DefaultOptions())
+				s, err = toJsonnetString(s, d.config.TaskDefinitionPath)
 				if err != nil {
 					return fmt.Errorf("unable to format task definition as Jsonnet: %w", err)
 				}
@@ -77,7 +76,7 @@ func (d *App) Render(ctx context.Context, opt RenderOption) error {
 			}
 			s := MustMarshalJSONStringForAPI(sv)
 			if opt.Jsonnet {
-				s, err = formatter.Format(d.config.ExpressDefinitionPath, s, formatter.DefaultOptions())
+				s, err = toJsonnetString(s, d.config.ExpressDefinitionPath)
 				if err != nil {
 					return fmt.Errorf("unable to format express gateway service definition as Jsonnet: %w", err)
 				}

--- a/secretsmanager/funcs_test.go
+++ b/secretsmanager/funcs_test.go
@@ -25,7 +25,7 @@ func (m *mockSecretsManagerClient) DescribeSecret(ctx context.Context, input *se
 
 func TestJsonnetNativeFuncs(t *testing.T) {
 	app := sm.MockNewApp(&mockSecretsManagerClient{})
-	funcs := app.JsonnetNativeFuncs(context.Background())
+	funcs := app.JsonnetNativeFuncs(t.Context())
 	vm := jsonnet.MakeVM()
 	for _, f := range funcs {
 		vm.NativeFunction(f)

--- a/util_test.go
+++ b/util_test.go
@@ -194,7 +194,7 @@ func TestCompareTags(t *testing.T) {
 
 func TestSleepContext(t *testing.T) {
 	t.Run("normal sleep", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 		start := time.Now()
 		duration := 100 * time.Millisecond
 
@@ -207,7 +207,7 @@ func TestSleepContext(t *testing.T) {
 	})
 
 	t.Run("context canceled", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		start := time.Now()
 		duration := 1 * time.Second
 


### PR DESCRIPTION
## Summary
- Add `--jsonnet` option to `ecspresso diff` to render output in Jsonnet format instead of JSON
- Extract `toJsonnetString` helper function and consolidate all `formatter.Format()` calls across `diff.go`, `render.go`, `init.go`, and `express.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)