### PR TITLE
Fix waiting for stale deployment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ecspresso is a deployment tool for Amazon ECS written in Go. It manages ECS services through configuration files (YAML, JSON, or Jsonnet) that define task definitions and service definitions.
 
+## Git Workflow
+
+- Default branch: `v2`
+- Do not commit directly to `v2`. Always create a feature branch first.
+
 ## Build Commands
 
 ```bash

--- a/rollback.go
+++ b/rollback.go
@@ -328,16 +328,6 @@ func (d *App) waitForCodeDeployRollback(ctx context.Context, id string) error {
 
 func (d *App) findActiveECSDeploymentArn(ctx context.Context, timeout time.Duration) (string, error) {
 	d.LogDebug("finding active ECS service deployment...")
-	sv, err := d.DescribeService(ctx)
-	if err != nil {
-		return "", fmt.Errorf("failed to describe service: %w", err)
-	}
-	if dpArn := sv.CurrentServiceDeployment; dpArn != nil {
-		d.LogDebug("current service deployment found: %s", aws.ToString(dpArn))
-		return aws.ToString(dpArn), nil
-	}
-	d.LogDebug("no current service deployment, searching active deployments...")
-
 	tm := time.NewTimer(timeout)
 	defer tm.Stop()
 	activeDeployments := make([]types.ServiceDeploymentBrief, 0)
@@ -347,7 +337,6 @@ func (d *App) findActiveECSDeploymentArn(ctx context.Context, timeout time.Durat
 			Service: &d.Service,
 			Status: []types.ServiceDeploymentStatus{
 				types.ServiceDeploymentStatusInProgress,
-				types.ServiceDeploymentStatusPending,
 			},
 		})
 		if err != nil {
@@ -355,7 +344,11 @@ func (d *App) findActiveECSDeploymentArn(ctx context.Context, timeout time.Durat
 		}
 		d.LogDebug("found %d active service deployments", len(resp.ServiceDeployments))
 		for _, sd := range resp.ServiceDeployments {
-			d.LogDebug(" service deployment: %s created at %s", aws.ToString(sd.ServiceDeploymentArn), sd.CreatedAt)
+			d.LogInfo("service deployment found",
+				"arn", arnToName(aws.ToString(sd.ServiceDeploymentArn)),
+				"created_at", sd.CreatedAt,
+				"status", sd.Status,
+			)
 		}
 		// found active deployments started after the application started
 		activeDeployments = append(activeDeployments,
@@ -373,19 +366,20 @@ func (d *App) findActiveECSDeploymentArn(ctx context.Context, timeout time.Durat
 		case <-tm.C: // Timeout reached
 			return "", ErrNotFound("no active service deployments found")
 		default:
-			d.LogDebug("no active service deployments found, retrying...")
+			d.LogInfo("no active service deployments found, waiting...")
 			sleepContext(ctx, delayForServiceChanged)
 		}
-	}
-
-	for _, sd := range activeDeployments {
-		d.LogDebug(" active service deployment: %s created at %s", aws.ToString(sd.ServiceDeploymentArn), sd.CreatedAt)
 	}
 
 	// Find the most recent active deployment
 	deployment := lo.MaxBy(activeDeployments, func(item types.ServiceDeploymentBrief, max types.ServiceDeploymentBrief) bool {
 		return item.CreatedAt.After(*max.CreatedAt)
 	})
+	d.LogInfo("wait deployment",
+		"arn", arnToName(aws.ToString(deployment.ServiceDeploymentArn)),
+		"created_at", deployment.CreatedAt,
+		"status", deployment.Status,
+	)
 	return aws.ToString(deployment.ServiceDeploymentArn), nil
 }
 

--- a/rollback.go
+++ b/rollback.go
@@ -342,9 +342,9 @@ func (d *App) findActiveECSDeploymentArn(ctx context.Context, timeout time.Durat
 		if err != nil {
 			return "", fmt.Errorf("failed to list service deployments: %w", err)
 		}
-		d.LogDebug("found %d active service deployments", len(resp.ServiceDeployments))
+		d.LogDebug("found %d service deployments", len(resp.ServiceDeployments))
 		for _, sd := range resp.ServiceDeployments {
-			d.LogInfo("service deployment found",
+			d.LogInfo("service deployment",
 				"arn", arnToName(aws.ToString(sd.ServiceDeploymentArn)),
 				"created_at", sd.CreatedAt,
 				"status", sd.Status,
@@ -366,7 +366,7 @@ func (d *App) findActiveECSDeploymentArn(ctx context.Context, timeout time.Durat
 		case <-tm.C: // Timeout reached
 			return "", ErrNotFound("no active service deployments found")
 		default:
-			d.LogInfo("no active service deployments found, waiting...")
+			d.LogInfo("no service deployments found, waiting...")
 			sleepContext(ctx, delayForServiceChanged)
 		}
 	}
@@ -375,7 +375,7 @@ func (d *App) findActiveECSDeploymentArn(ctx context.Context, timeout time.Durat
 	deployment := lo.MaxBy(activeDeployments, func(item types.ServiceDeploymentBrief, max types.ServiceDeploymentBrief) bool {
 		return item.CreatedAt.After(*max.CreatedAt)
 	})
-	d.LogInfo("wait deployment",
+	d.LogInfo("found deployment",
 		"arn", arnToName(aws.ToString(deployment.ServiceDeploymentArn)),
 		"created_at", deployment.CreatedAt,
 		"status", deployment.Status,


### PR DESCRIPTION
## Summary
- `CurrentServiceDeployment` may return an outdated value, causing rollback to wait on a previous deployment instead of the newly started one and exit immediately
- Always use `ListServiceDeployments` with `InProgress` status to find the correct active deployment
- Improve logging visibility for deployment discovery (Debug → Info, structured format)

refs
- #929 

🤖 Generated with [Claude Code](https://claude.com/claude-code)