### PR TITLE
Refactor tasks and exec to use subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1114,24 +1114,60 @@ Consider using ecsta as a CLI command.
 The `tasks` command lists tasks run by a service or having the same family to a task definition.
 
 ```
-Flags:
+Usage: ecspresso tasks <command> [flags]
+
+Common flags:
       --id=                       task ID
-      --output=table              output format
-      --find=false                find a task from tasks list and dump it as JSON
-      --stop=false                stop the task
-      --force=false               stop the task without confirmation
-      --trace=false               trace the task
+      --output=table              output format (table, json, tsv)
+
+Commands:
+  tasks list          list tasks (default)
+  tasks find          find a task from tasks list and dump it as JSON
+  tasks stop          stop a task
+  tasks trace         trace a task
+  tasks logs          show logs of a task
 ```
 
-The `--find` option enables task selection rom a list and displays it as JSON.
+##### tasks find
+
+The `find` subcommand enables task selection from a list and displays it as JSON.
 
 The `ECSPRESSO_FILTER_COMMAND` environment variable can be set to specify a command for filtering tasks, such as [peco](https://github.com/peco/peco), [fzf](https://github.com/junegunn/fzf), etc.
 
 ```console
-$ ECSPRESSO_FILTER_COMMAND=peco ecspresso tasks --find
+$ ECSPRESSO_FILTER_COMMAND=peco ecspresso tasks find
 ```
 
-The `--stop` option allows for task selecttion and stopping from a list.
+##### tasks stop
+
+The `stop` subcommand allows for task selection and stopping from a list.
+
+```console
+$ ecspresso tasks stop --force
+```
+
+```
+Flags:
+      --force=false               stop the task without confirmation
+```
+
+##### tasks logs
+
+The `logs` subcommand shows CloudWatch Logs of the task.
+
+```console
+$ ecspresso tasks logs -f -d 5m --container app
+```
+
+```
+Flags:
+  -f, --follow=false              follow logs
+  -d, --duration=1m               duration of logs
+  -s, --start-time=               start time of logs
+      --container=                container name
+```
+
+Use `--follow` to follow logs in real time, `--duration` to specify the time range, and `--start-time` to specify an absolute start time. When `--output json` is set, logs are output as JSON lines.
 
 #### exec
 
@@ -1140,15 +1176,16 @@ The `exec` command executes a command on a task.
 [session-manager-plugin](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html) is required in PATH.
 
 ```
-Flags:
+Usage: ecspresso exec <command> [flags]
+
+Common flags:
       --id=                       task ID
-      --command=sh                command to execute
       --container=                container name
-      --port-forward=false        enable port forward
-      --local-port=0              local port number
-      --port=0                    remote port number (required for --port-forward)
-      --host=                     remote host (required for --port-forward)
-      -L                          short expression of local-port:host:port
+
+Commands:
+  exec run              execute command on task (default)
+  exec portforward      port forwarding to a task
+  exec cp <src> <dest>  copy files between local and task
 ```
 
 If `--id` is not set, the command shows a list of tasks to select a task to execute.
@@ -1157,13 +1194,33 @@ The `ECSPRESSO_FILTER_COMMAND` environment variable works the same as with the `
 
 See also the official documentation [Using Amazon ECS Exec for debugging](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html).
 
-#### port forwarding
+##### exec run
 
-The `--port-forward` option enables port forwarding from a local port to an ECS task's port.
+The `run` subcommand (default) executes a command on a task interactively.
+
+```console
+$ ecspresso exec run --command "ls -la"
+```
 
 ```
-$ ecspresso exec --port-forward --port 80 --local-port 8080
-...
+Flags:
+      --command=sh                command to execute
+```
+
+##### exec portforward
+
+The `portforward` subcommand enables port forwarding from a local port to an ECS task's port.
+
+```console
+$ ecspresso exec portforward --port 80 --local-port 8080
+```
+
+```
+Flags:
+      --local-port=0              local port number
+      --port=0                    remote port number
+      --host=                     remote host
+  -L                              short expression of local-port:host:port
 ```
 
 If `--id` is not set, the command shows a list of tasks to select for port forwarding.
@@ -1172,8 +1229,31 @@ When `--local-port` is not specified, an ephemeral port is used as the local por
 
 The `-L` option is a short expression for `local-port:host:port`. For example, `-L 8080:example.com:80` is equivalent to `--local-port 8080 --host example.com --port 80`.
 
+```console
+$ ecspresso exec portforward -L 8080:example.com:80
 ```
-$ ecspresso exec --port-forward -L 8080:example.com:80
+
+##### exec cp
+
+The `cp` subcommand copies files between local and a running ECS task.
+
+The source and destination arguments use `taskID:/path` format for the remote side. Use `_` as the task ID to select a task interactively.
+
+```console
+# Copy a local file to the task
+$ ecspresso exec cp /local/file.txt _:/remote/file.txt
+
+# Copy a file from the task to local
+$ ecspresso exec cp _:/remote/file.txt /local/file.txt
+
+# Specify a task ID directly
+$ ecspresso exec cp /local/file.txt abcdef1234567890:/remote/file.txt
+```
+
+```
+Flags:
+      --port=12345                port number for file transfer
+      --[no-]progress             show progress bar (default true)
 ```
 
 ### Show documentation

--- a/README.md
+++ b/README.md
@@ -1167,7 +1167,7 @@ Flags:
       --container=                container name
 ```
 
-Use `--follow` to follow logs in real time, `--duration` to specify the time range, and `--start-time` to specify an absolute start time. When `--output json` is set, logs are output as JSON lines.
+Use `--follow` to follow logs in real time, `--duration` to specify the time range, and `--start-time` to specify an absolute start time. When `--log-format json` is set, logs are output as JSON lines.
 
 #### exec
 

--- a/cli_test.go
+++ b/cli_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/fatih/color"
 	"github.com/google/go-cmp/cmp"
@@ -893,18 +894,18 @@ var cliTests = []struct {
 			Jsonnet: false,
 		},
 	},
+	// tasks: default (list)
 	{
 		args: []string{"tasks"},
 		sub:  "tasks",
 		subOption: &ecspresso.TasksOption{
-			ID:     "",
 			Output: "table",
-			Find:   false,
-			Stop:   false,
-			Force:  false,
-			Trace:  false,
+			List: &ecspresso.TasksListOption{
+				Duration: time.Minute,
+			},
 		},
 	},
+	// tasks: deprecated flags (backward compat)
 	{
 		args: []string{"tasks", "--id", "abcdefff", "--output", "json",
 			"--find", "--stop", "--force", "--trace",
@@ -913,25 +914,68 @@ var cliTests = []struct {
 		subOption: &ecspresso.TasksOption{
 			ID:     "abcdefff",
 			Output: "json",
-			Find:   true,
-			Stop:   true,
-			Force:  true,
-			Trace:  true,
+			List: &ecspresso.TasksListOption{
+				DeprecatedFind:  true,
+				DeprecatedStop:  true,
+				DeprecatedForce: true,
+				DeprecatedTrace: true,
+				Duration:        time.Minute,
+			},
 		},
 	},
+	// tasks: find subcommand
+	{
+		args: []string{"tasks", "find"},
+		sub:  "tasks",
+		subOption: &ecspresso.TasksOption{
+			Output: "table",
+			Find:   &ecspresso.TasksFindOption{},
+		},
+	},
+	// tasks: stop subcommand with --force
+	{
+		args: []string{"tasks", "stop", "--force"},
+		sub:  "tasks",
+		subOption: &ecspresso.TasksOption{
+			Output: "table",
+			Stop:   &ecspresso.TasksStopOption{Force: true},
+		},
+	},
+	// tasks: trace subcommand
+	{
+		args: []string{"tasks", "trace"},
+		sub:  "tasks",
+		subOption: &ecspresso.TasksOption{
+			Output: "table",
+			Trace:  &ecspresso.TasksTraceOption{},
+		},
+	},
+	// tasks: logs subcommand
+	{
+		args: []string{"tasks", "logs", "-f", "-d", "5m", "--container", "app"},
+		sub:  "tasks",
+		subOption: &ecspresso.TasksOption{
+			Output: "table",
+			Logs: &ecspresso.TasksLogsOption{
+				Follow:    true,
+				Duration:  5 * time.Minute,
+				Container: "app",
+			},
+		},
+	},
+	// exec: default (run)
 	{
 		args: []string{"exec"},
 		sub:  "exec",
 		subOption: &ecspresso.ExecOption{
-			ID:          "",
-			Command:     "sh",
-			Container:   "",
-			LocalPort:   0,
-			Port:        0,
-			PortForward: false,
-			Host:        "",
+			Run: &ecspresso.ExecRunOption{
+				Command:  "sh",
+				CpPort:   12345,
+				Progress: true,
+			},
 		},
 	},
+	// exec: deprecated --port-forward (backward compat)
 	{
 		args: []string{"exec",
 			"--id", "abcdefff",
@@ -944,13 +988,73 @@ var cliTests = []struct {
 		},
 		sub: "exec",
 		subOption: &ecspresso.ExecOption{
-			ID:          "abcdefff",
-			Command:     "ls -la",
-			Container:   "mycontainer",
-			LocalPort:   8080,
-			Port:        80,
-			PortForward: true,
-			Host:        "example.com",
+			ID:        "abcdefff",
+			Container: "mycontainer",
+			Run: &ecspresso.ExecRunOption{
+				Command:     "ls -la",
+				PortForward: true,
+				LocalPort:   8080,
+				Port:        80,
+				Host:        "example.com",
+				CpPort:      12345,
+				Progress:    true,
+			},
+		},
+	},
+	// exec: portforward subcommand
+	{
+		args: []string{"exec", "--id", "abcdefff", "portforward",
+			"--local-port", "8080", "--port", "80", "--host", "example.com",
+		},
+		sub: "exec",
+		subOption: &ecspresso.ExecOption{
+			ID: "abcdefff",
+			Portforward: &ecspresso.ExecPortforwardOption{
+				LocalPort: 8080,
+				Port:      80,
+				Host:      "example.com",
+			},
+		},
+	},
+	// exec: cp subcommand
+	{
+		args: []string{"exec", "cp", "/local/file.txt", "_:/remote/file.txt"},
+		sub:  "exec",
+		subOption: &ecspresso.ExecOption{
+			Cp: &ecspresso.ExecCpOption{
+				Src:      "/local/file.txt",
+				Dest:     "_:/remote/file.txt",
+				Port:     12345,
+				Progress: true,
+			},
+		},
+	},
+	// exec: cp subcommand with --no-progress
+	{
+		args: []string{"exec", "cp", "--no-progress", "/local/file.txt", "_:/remote/file.txt"},
+		sub:  "exec",
+		subOption: &ecspresso.ExecOption{
+			Cp: &ecspresso.ExecCpOption{
+				Src:      "/local/file.txt",
+				Dest:     "_:/remote/file.txt",
+				Port:     12345,
+				Progress: false,
+			},
+		},
+	},
+	// exec: deprecated --cp (backward compat)
+	{
+		args: []string{"exec", "--cp", "/local/file.txt", "_:/remote/file.txt"},
+		sub:  "exec",
+		subOption: &ecspresso.ExecOption{
+			Run: &ecspresso.ExecRunOption{
+				Command:      "sh",
+				DeprecatedCp: true,
+				Src:          "/local/file.txt",
+				Dest:         "_:/remote/file.txt",
+				CpPort:       12345,
+				Progress:     true,
+			},
 		},
 	},
 }

--- a/cli_test.go
+++ b/cli_test.go
@@ -900,9 +900,7 @@ var cliTests = []struct {
 		sub:  "tasks",
 		subOption: &ecspresso.TasksOption{
 			Output: "table",
-			List: &ecspresso.TasksListOption{
-				Duration: time.Minute,
-			},
+			List:   &ecspresso.TasksListOption{},
 		},
 	},
 	// tasks: deprecated flags (backward compat)
@@ -919,7 +917,6 @@ var cliTests = []struct {
 				DeprecatedStop:  true,
 				DeprecatedForce: true,
 				DeprecatedTrace: true,
-				Duration:        time.Minute,
 			},
 		},
 	},
@@ -969,9 +966,7 @@ var cliTests = []struct {
 		sub:  "exec",
 		subOption: &ecspresso.ExecOption{
 			Run: &ecspresso.ExecRunOption{
-				Command:  "sh",
-				CpPort:   12345,
-				Progress: true,
+				Command: "sh",
 			},
 		},
 	},
@@ -996,8 +991,6 @@ var cliTests = []struct {
 				LocalPort:   8080,
 				Port:        80,
 				Host:        "example.com",
-				CpPort:      12345,
-				Progress:    true,
 			},
 		},
 	},
@@ -1039,21 +1032,6 @@ var cliTests = []struct {
 				Dest:     "_:/remote/file.txt",
 				Port:     12345,
 				Progress: false,
-			},
-		},
-	},
-	// exec: deprecated --cp (backward compat)
-	{
-		args: []string{"exec", "--cp", "/local/file.txt", "_:/remote/file.txt"},
-		sub:  "exec",
-		subOption: &ecspresso.ExecOption{
-			Run: &ecspresso.ExecRunOption{
-				Command:      "sh",
-				DeprecatedCp: true,
-				Src:          "/local/file.txt",
-				Dest:         "_:/remote/file.txt",
-				CpPort:       12345,
-				Progress:     true,
 			},
 		},
 	},

--- a/cliv2.go
+++ b/cliv2.go
@@ -25,6 +25,10 @@ func ParseCLIv2(args []string) (string, *CLIOptions, func(), error) {
 	}
 	sub := strings.Fields(c.Command())[0]
 
+	// Kong allocates all cmd:"" pointer fields during parsing.
+	// Clear inactive subcommand pointers so nil checks work for dispatch.
+	clearInactiveSubcommands(&opts, c.Command())
+
 	for _, envFile := range opts.Envfile {
 		if err := ExportEnvFile(envFile); err != nil {
 			return sub, &opts, nil, fmt.Errorf("failed to load envfile: %w", err)
@@ -39,4 +43,49 @@ func ParseCLIv2(args []string) (string, *CLIOptions, func(), error) {
 	}
 	color.NoColor = !opts.Color
 	return sub, &opts, func() { c.PrintUsage(true) }, nil
+}
+
+func clearInactiveSubcommands(opts *CLIOptions, cmd string) {
+	fields := strings.Fields(cmd)
+	if len(fields) < 2 {
+		return
+	}
+	primary, subcmd := fields[0], fields[1]
+
+	switch primary {
+	case "tasks":
+		t := opts.Tasks
+		if t == nil {
+			return
+		}
+		if subcmd != "list" {
+			t.List = nil
+		}
+		if subcmd != "find" {
+			t.Find = nil
+		}
+		if subcmd != "stop" {
+			t.Stop = nil
+		}
+		if subcmd != "trace" {
+			t.Trace = nil
+		}
+		if subcmd != "logs" {
+			t.Logs = nil
+		}
+	case "exec":
+		e := opts.Exec
+		if e == nil {
+			return
+		}
+		if subcmd != "run" {
+			e.Run = nil
+		}
+		if subcmd != "portforward" {
+			e.Portforward = nil
+		}
+		if subcmd != "cp" {
+			e.Cp = nil
+		}
+	}
 }

--- a/exec.go
+++ b/exec.go
@@ -9,14 +9,43 @@ import (
 
 type ExecOption struct {
 	ID        string `help:"task ID" default:""`
-	Command   string `help:"command to execute" default:"sh"`
 	Container string `help:"container name" default:""`
 
-	PortForward bool   `help:"enable port forward" default:"false"`
-	LocalPort   int    `help:"local port number" default:"0"`
-	Port        int    `help:"remote port number (required for --port-forward)" default:"0"`
-	Host        string `help:"remote host (required for --port-forward)" default:""`
-	L           string `name:"L" short:"L" help:"short expression of local-port:host:port" default:""`
+	Run         *ExecRunOption         `cmd:"" default:"withargs" help:"execute command on task"`
+	Portforward *ExecPortforwardOption `cmd:"" help:"port forwarding to a task"`
+	Cp          *ExecCpOption          `cmd:"" help:"copy files between local and task"`
+}
+
+// ExecRunOption is the default subcommand for exec.
+// Deprecated flags are kept as hidden for backward compatibility.
+type ExecRunOption struct {
+	Command string `help:"command to execute" default:"sh"`
+
+	PortForward bool   `name:"port-forward" hidden:"" default:"false"`
+	LocalPort   int    `name:"local-port" hidden:"" default:"0"`
+	Port        int    `name:"port" hidden:"" default:"0"`
+	Host        string `name:"host" hidden:"" default:""`
+	L           string `name:"L" short:"L" hidden:"" default:""`
+
+	DeprecatedCp bool   `name:"cp" hidden:"" default:"false"`
+	Src          string `arg:"" optional:"" default:""`
+	Dest         string `arg:"" optional:"" default:""`
+	CpPort       int    `name:"cp-port" hidden:"" default:"12345"`
+	Progress     bool   `name:"progress" hidden:"" default:"true" negatable:""`
+}
+
+type ExecPortforwardOption struct {
+	LocalPort int    `help:"local port number" default:"0"`
+	Port      int    `help:"remote port number" default:"0"`
+	Host      string `help:"remote host" default:""`
+	L         string `name:"L" short:"L" help:"short expression of local-port:host:port" default:""`
+}
+
+type ExecCpOption struct {
+	Src      string `arg:"" help:"source"`
+	Dest     string `arg:"" help:"destination"`
+	Port     int    `help:"port number for file transfer" default:"12345"`
+	Progress bool   `help:"show progress bar" default:"true" negatable:""`
 }
 
 func (d *App) NewEcsta(ctx context.Context) (*ecsta.Ecsta, error) {
@@ -46,24 +75,65 @@ func (d *App) Exec(ctx context.Context, opt ExecOption) error {
 		service = &d.config.Service
 	}
 
-	if opt.PortForward {
-		return ecstaApp.RunPortforward(ctx, &ecsta.PortforwardOption{
-			ID:         opt.ID,
-			Container:  opt.Container,
-			LocalPort:  opt.LocalPort,
-			RemotePort: opt.Port,
-			RemoteHost: opt.Host,
-			L:          opt.L,
-			Family:     &family,
-			Service:    service,
-		})
-	} else {
-		return ecstaApp.RunExec(ctx, &ecsta.ExecOption{
+	switch {
+	case opt.Cp != nil:
+		return ecstaApp.RunCp(ctx, &ecsta.CpOption{
+			Src:       opt.Cp.Src,
+			Dest:      opt.Cp.Dest,
+			Port:      opt.Cp.Port,
+			Progress:  opt.Cp.Progress,
 			ID:        opt.ID,
-			Command:   opt.Command,
 			Container: opt.Container,
 			Family:    &family,
 			Service:   service,
 		})
+	case opt.Portforward != nil:
+		return ecstaApp.RunPortforward(ctx, &ecsta.PortforwardOption{
+			ID:         opt.ID,
+			Container:  opt.Container,
+			LocalPort:  opt.Portforward.LocalPort,
+			RemotePort: opt.Portforward.Port,
+			RemoteHost: opt.Portforward.Host,
+			L:          opt.Portforward.L,
+			Family:     &family,
+			Service:    service,
+		})
+	case opt.Run != nil:
+		run := opt.Run
+		switch {
+		case run.DeprecatedCp:
+			LogWarn("--cp flag is deprecated, use 'exec cp' subcommand instead")
+			return ecstaApp.RunCp(ctx, &ecsta.CpOption{
+				Src:       run.Src,
+				Dest:      run.Dest,
+				Port:      run.CpPort,
+				Progress:  run.Progress,
+				ID:        opt.ID,
+				Container: opt.Container,
+				Family:    &family,
+				Service:   service,
+			})
+		case run.PortForward:
+			LogWarn("--port-forward flag is deprecated, use 'exec portforward' subcommand instead")
+			return ecstaApp.RunPortforward(ctx, &ecsta.PortforwardOption{
+				ID:         opt.ID,
+				Container:  opt.Container,
+				LocalPort:  run.LocalPort,
+				RemotePort: run.Port,
+				RemoteHost: run.Host,
+				L:          run.L,
+				Family:     &family,
+				Service:    service,
+			})
+		default:
+			return ecstaApp.RunExec(ctx, &ecsta.ExecOption{
+				ID:        opt.ID,
+				Command:   run.Command,
+				Container: opt.Container,
+				Family:    &family,
+				Service:   service,
+			})
+		}
 	}
+	return nil
 }

--- a/exec.go
+++ b/exec.go
@@ -26,12 +26,6 @@ type ExecRunOption struct {
 	Port        int    `name:"port" hidden:"" default:"0"`
 	Host        string `name:"host" hidden:"" default:""`
 	L           string `name:"L" short:"L" hidden:"" default:""`
-
-	DeprecatedCp bool   `name:"cp" hidden:"" default:"false"`
-	Src          string `arg:"" optional:"" default:""`
-	Dest         string `arg:"" optional:"" default:""`
-	CpPort       int    `name:"cp-port" hidden:"" default:"12345"`
-	Progress     bool   `name:"progress" hidden:"" default:"true" negatable:""`
 }
 
 type ExecPortforwardOption struct {
@@ -101,18 +95,6 @@ func (d *App) Exec(ctx context.Context, opt ExecOption) error {
 	case opt.Run != nil:
 		run := opt.Run
 		switch {
-		case run.DeprecatedCp:
-			LogWarn("--cp flag is deprecated, use 'exec cp' subcommand instead")
-			return ecstaApp.RunCp(ctx, &ecsta.CpOption{
-				Src:       run.Src,
-				Dest:      run.Dest,
-				Port:      run.CpPort,
-				Progress:  run.Progress,
-				ID:        opt.ID,
-				Container: opt.Container,
-				Family:    &family,
-				Service:   service,
-			})
 		case run.PortForward:
 			LogWarn("--port-forward flag is deprecated, use 'exec portforward' subcommand instead")
 			return ecstaApp.RunPortforward(ctx, &ecsta.PortforwardOption{

--- a/tasks.go
+++ b/tasks.go
@@ -24,15 +24,10 @@ type TasksOption struct {
 // TasksListOption is the default subcommand for tasks.
 // Deprecated flags are kept as hidden for backward compatibility.
 type TasksListOption struct {
-	DeprecatedFind  bool          `name:"find" hidden:"" default:"false"`
-	DeprecatedStop  bool          `name:"stop" hidden:"" default:"false"`
-	DeprecatedForce bool          `name:"force" hidden:"" default:"false"`
-	DeprecatedTrace bool          `name:"trace" hidden:"" default:"false"`
-	DeprecatedLogs  bool          `name:"logs" hidden:"" default:"false"`
-	Follow          bool          `name:"follow" short:"f" hidden:"" default:"false"`
-	Duration        time.Duration `name:"duration" short:"d" hidden:"" default:"1m"`
-	StartTime       string        `name:"start-time" short:"s" hidden:"" default:""`
-	Container       string        `name:"container" hidden:"" default:""`
+	DeprecatedFind  bool `name:"find" hidden:"" default:"false"`
+	DeprecatedStop  bool `name:"stop" hidden:"" default:"false"`
+	DeprecatedForce bool `name:"force" hidden:"" default:"false"`
+	DeprecatedTrace bool `name:"trace" hidden:"" default:"false"`
 }
 
 type TasksFindOption struct{}
@@ -130,18 +125,6 @@ func (d *App) Tasks(ctx context.Context, opt TasksOption) error {
 				Duration: time.Minute,
 				Family:   &family,
 				Service:  service,
-			})
-		case list.DeprecatedLogs:
-			LogWarn("--logs flag is deprecated, use 'tasks logs' subcommand instead")
-			return ecstaApp.RunLogs(ctx, &ecsta.LogsOption{
-				ID:        opt.taskID(),
-				Follow:    list.Follow,
-				Duration:  list.Duration,
-				StartTime: list.StartTime,
-				Container: list.Container,
-				Family:    &family,
-				Service:   service,
-				JSON:      logFormat == logFormatJSON,
 			})
 		default:
 			return ecstaApp.RunList(ctx, &ecsta.ListOption{

--- a/tasks.go
+++ b/tasks.go
@@ -103,7 +103,7 @@ func (d *App) Tasks(ctx context.Context, opt TasksOption) error {
 			Container: opt.Logs.Container,
 			Family:    &family,
 			Service:   service,
-			JSON:      opt.Output == "json",
+			JSON:      logFormat == logFormatJSON,
 		})
 	case opt.List != nil:
 		list := opt.List
@@ -141,7 +141,7 @@ func (d *App) Tasks(ctx context.Context, opt TasksOption) error {
 				Container: list.Container,
 				Family:    &family,
 				Service:   service,
-				JSON:      opt.Output == "json",
+				JSON:      logFormat == logFormatJSON,
 			})
 		default:
 			return ecstaApp.RunList(ctx, &ecsta.ListOption{

--- a/tasks.go
+++ b/tasks.go
@@ -13,10 +13,41 @@ import (
 type TasksOption struct {
 	ID     string `help:"task ID" default:""`
 	Output string `help:"output format" enum:"table,json,tsv" default:"table"`
-	Find   bool   `help:"find a task from tasks list and dump it as JSON" default:"false"`
-	Stop   bool   `help:"stop the task" default:"false"`
-	Force  bool   `help:"stop the task without confirmation" default:"false"`
-	Trace  bool   `help:"trace the task" default:"false"`
+
+	List  *TasksListOption  `cmd:"" default:"withargs" help:"list tasks"`
+	Find  *TasksFindOption  `cmd:"" help:"find a task from tasks list and dump it as JSON"`
+	Stop  *TasksStopOption  `cmd:"" help:"stop a task"`
+	Trace *TasksTraceOption `cmd:"" help:"trace a task"`
+	Logs  *TasksLogsOption  `cmd:"" help:"show logs of a task"`
+}
+
+// TasksListOption is the default subcommand for tasks.
+// Deprecated flags are kept as hidden for backward compatibility.
+type TasksListOption struct {
+	DeprecatedFind  bool          `name:"find" hidden:"" default:"false"`
+	DeprecatedStop  bool          `name:"stop" hidden:"" default:"false"`
+	DeprecatedForce bool          `name:"force" hidden:"" default:"false"`
+	DeprecatedTrace bool          `name:"trace" hidden:"" default:"false"`
+	DeprecatedLogs  bool          `name:"logs" hidden:"" default:"false"`
+	Follow          bool          `name:"follow" short:"f" hidden:"" default:"false"`
+	Duration        time.Duration `name:"duration" short:"d" hidden:"" default:"1m"`
+	StartTime       string        `name:"start-time" short:"s" hidden:"" default:""`
+	Container       string        `name:"container" hidden:"" default:""`
+}
+
+type TasksFindOption struct{}
+
+type TasksStopOption struct {
+	Force bool `help:"stop the task without confirmation" default:"false"`
+}
+
+type TasksTraceOption struct{}
+
+type TasksLogsOption struct {
+	Follow    bool          `help:"follow logs" short:"f" default:"false"`
+	Duration  time.Duration `help:"duration of logs" short:"d" default:"1m"`
+	StartTime string        `help:"start time of logs" short:"s" default:""`
+	Container string        `help:"container name" default:""`
 }
 
 func (o TasksOption) taskID() string {
@@ -42,32 +73,84 @@ func (d *App) Tasks(ctx context.Context, opt TasksOption) error {
 		service = &d.config.Service
 	}
 
-	if opt.Find {
+	switch {
+	case opt.Find != nil:
 		return ecstaApp.RunDescribe(ctx, &ecsta.DescribeOption{
 			ID:      opt.taskID(),
 			Family:  &family,
 			Service: service,
 		})
-	} else if opt.Stop {
+	case opt.Stop != nil:
 		return ecstaApp.RunStop(ctx, &ecsta.StopOption{
 			ID:      opt.taskID(),
-			Force:   opt.Force,
+			Force:   opt.Stop.Force,
 			Family:  &family,
 			Service: service,
 		})
-	} else if opt.Trace {
+	case opt.Trace != nil:
 		return ecstaApp.RunTrace(ctx, &ecsta.TraceOption{
 			ID:       opt.taskID(),
 			Duration: time.Minute,
 			Family:   &family,
 			Service:  service,
 		})
-	} else {
-		return ecstaApp.RunList(ctx, &ecsta.ListOption{
-			Family:  &family,
-			Service: service,
+	case opt.Logs != nil:
+		return ecstaApp.RunLogs(ctx, &ecsta.LogsOption{
+			ID:        opt.taskID(),
+			Follow:    opt.Logs.Follow,
+			Duration:  opt.Logs.Duration,
+			StartTime: opt.Logs.StartTime,
+			Container: opt.Logs.Container,
+			Family:    &family,
+			Service:   service,
+			JSON:      opt.Output == "json",
 		})
+	case opt.List != nil:
+		list := opt.List
+		switch {
+		case list.DeprecatedFind:
+			LogWarn("--find flag is deprecated, use 'tasks find' subcommand instead")
+			return ecstaApp.RunDescribe(ctx, &ecsta.DescribeOption{
+				ID:      opt.taskID(),
+				Family:  &family,
+				Service: service,
+			})
+		case list.DeprecatedStop:
+			LogWarn("--stop flag is deprecated, use 'tasks stop' subcommand instead")
+			return ecstaApp.RunStop(ctx, &ecsta.StopOption{
+				ID:      opt.taskID(),
+				Force:   list.DeprecatedForce,
+				Family:  &family,
+				Service: service,
+			})
+		case list.DeprecatedTrace:
+			LogWarn("--trace flag is deprecated, use 'tasks trace' subcommand instead")
+			return ecstaApp.RunTrace(ctx, &ecsta.TraceOption{
+				ID:       opt.taskID(),
+				Duration: time.Minute,
+				Family:   &family,
+				Service:  service,
+			})
+		case list.DeprecatedLogs:
+			LogWarn("--logs flag is deprecated, use 'tasks logs' subcommand instead")
+			return ecstaApp.RunLogs(ctx, &ecsta.LogsOption{
+				ID:        opt.taskID(),
+				Follow:    list.Follow,
+				Duration:  list.Duration,
+				StartTime: list.StartTime,
+				Container: list.Container,
+				Family:    &family,
+				Service:   service,
+				JSON:      opt.Output == "json",
+			})
+		default:
+			return ecstaApp.RunList(ctx, &ecsta.ListOption{
+				Family:  &family,
+				Service: service,
+			})
+		}
 	}
+	return nil
 }
 
 func (d *App) taskDefinitionFamily(ctx context.Context) (string, error) {


### PR DESCRIPTION
## Summary

- Replace mutually exclusive boolean flags (`--find`, `--stop`, `--trace`, `--port-forward`) with proper Kong subcommands
  - `tasks`: `list` (default), `find`, `stop`, `trace`, `logs`
  - `exec`: `run` (default), `portforward`, `cp`
- Old flag syntax for existing commands is preserved via hidden flags on the default subcommand with deprecation warnings
- `tasks logs` and `exec cp` are new features, available only as subcommands
- Each subcommand has only its relevant flags in `--help` output

## New usage

```
ecspresso tasks find
ecspresso tasks stop --force
ecspresso tasks trace
ecspresso tasks logs -f -d 5m --container app
ecspresso exec portforward --port 80 --local-port 8080
ecspresso exec cp /local/file.txt _:/remote/file.txt
```

## Backward compatibility

Old syntax for pre-existing commands still works but emits a deprecation warning:

```
ecspresso tasks --find        # warns: use 'tasks find'
ecspresso tasks --stop        # warns: use 'tasks stop'
ecspresso tasks --trace       # warns: use 'tasks trace'
ecspresso exec --port-forward # warns: use 'exec portforward'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)