### PR TITLE
feat: support --with-service/--without-service flag for diff command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1064,10 +1064,10 @@ The command should exit with status 0. If it exits with a non-zero status when t
 $ ecspresso diff --jsonnet
 ```
 
-`ecspresso diff --no-update-service` skips the diff of the service definition and only shows the diff of the task definition.
+`ecspresso diff --without-service` skips the diff of the service definition and only shows the diff of the task definition.
 
 ```console
-$ ecspresso diff --no-update-service
+$ ecspresso diff --without-service
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -1064,6 +1064,12 @@ The command should exit with status 0. If it exits with a non-zero status when t
 $ ecspresso diff --jsonnet
 ```
 
+`ecspresso diff --no-update-service` skips the diff of the service definition and only shows the diff of the task definition.
+
+```console
+$ ecspresso diff --no-update-service
+```
+
 
 #### verify
 

--- a/cli_test.go
+++ b/cli_test.go
@@ -809,21 +809,24 @@ var cliTests = []struct {
 		args: []string{"diff"},
 		sub:  "diff",
 		subOption: &ecspresso.DiffOption{
-			Unified: true,
+			Unified:     true,
+			WithService: true,
 		},
 	},
 	{
 		args: []string{"diff", "--no-unified"},
 		sub:  "diff",
 		subOption: &ecspresso.DiffOption{
-			Unified: false,
+			Unified:     false,
+			WithService: true,
 		},
 	},
 	{
 		args: []string{"diff", "--no-color"},
 		sub:  "diff",
 		subOption: &ecspresso.DiffOption{
-			Unified: true,
+			Unified:     true,
+			WithService: true,
 		},
 		fn: func(t *testing.T, o any) {
 			if color.NoColor != true {
@@ -835,7 +838,8 @@ var cliTests = []struct {
 		args: []string{"diff", "--color"},
 		sub:  "diff",
 		subOption: &ecspresso.DiffOption{
-			Unified: true,
+			Unified:     true,
+			WithService: true,
 		},
 		fn: func(t *testing.T, o any) {
 			if color.NoColor == true {

--- a/cli_test.go
+++ b/cli_test.go
@@ -844,11 +844,11 @@ var cliTests = []struct {
 		},
 	},
 	{
-		args: []string{"diff", "--no-update-service"},
+		args: []string{"diff", "--without-service"},
 		sub:  "diff",
 		subOption: &ecspresso.DiffOption{
-			Unified:         true,
-			NoUpdateService: true,
+			Unified:     true,
+			WithService: false,
 		},
 	},
 	{

--- a/cli_test.go
+++ b/cli_test.go
@@ -844,6 +844,14 @@ var cliTests = []struct {
 		},
 	},
 	{
+		args: []string{"diff", "--no-update-service"},
+		sub:  "diff",
+		subOption: &ecspresso.DiffOption{
+			Unified:         true,
+			NoUpdateService: true,
+		},
+	},
+	{
 		args: []string{"appspec"},
 		sub:  "appspec",
 		subOption: &ecspresso.AppSpecOption{

--- a/diff.go
+++ b/diff.go
@@ -30,7 +30,7 @@ type DiffOption struct {
 	Unified         bool   `help:"unified diff format" default:"true" negatable:""`
 	Jsonnet         bool   `help:"render as jsonnet format" default:"false"`
 	External        string `help:"external command to format diff" env:"ECSPRESSO_DIFF_COMMAND"`
-	NoUpdateService bool   `help:"skip diff of service definition" default:"false"`
+	WithService     bool   `help:"with service definition" default:"true" negatable:"without-service"`
 
 	w io.Writer `kong:"-"`
 }
@@ -49,7 +49,7 @@ func (d *App) Diff(ctx context.Context, opt DiffOption) error {
 
 	var remoteTaskDefArn string
 	// diff for services only when service defined and not skipped
-	if d.config.Service != "" && !opt.NoUpdateService {
+	if d.config.Service != "" && opt.WithService {
 		d.LogDebug("diff service compare with %s", d.config.Service)
 		newSv, err := d.LoadServiceDefinition(d.config.ServiceDefinitionPath)
 		if err != nil {

--- a/diff.go
+++ b/diff.go
@@ -27,9 +27,10 @@ import (
 )
 
 type DiffOption struct {
-	Unified  bool   `help:"unified diff format" default:"true" negatable:""`
-	Jsonnet  bool   `help:"render as jsonnet format" default:"false"`
-	External string `help:"external command to format diff" env:"ECSPRESSO_DIFF_COMMAND"`
+	Unified         bool   `help:"unified diff format" default:"true" negatable:""`
+	Jsonnet         bool   `help:"render as jsonnet format" default:"false"`
+	External        string `help:"external command to format diff" env:"ECSPRESSO_DIFF_COMMAND"`
+	NoUpdateService bool   `help:"skip diff of service definition" default:"false"`
 
 	w io.Writer `kong:"-"`
 }
@@ -47,8 +48,8 @@ func (d *App) Diff(ctx context.Context, opt DiffOption) error {
 	}
 
 	var remoteTaskDefArn string
-	// diff for services only when service defined
-	if d.config.Service != "" {
+	// diff for services only when service defined and not skipped
+	if d.config.Service != "" && !opt.NoUpdateService {
 		d.LogDebug("diff service compare with %s", d.config.Service)
 		newSv, err := d.LoadServiceDefinition(d.config.ServiceDefinitionPath)
 		if err != nil {

--- a/diff_test.go
+++ b/diff_test.go
@@ -521,6 +521,142 @@ func TestDiffJsonnet(t *testing.T) {
 	})
 }
 
+func TestDiffNoUpdateService(t *testing.T) {
+	ctx := t.Context()
+	color.NoColor = true
+
+	localSv := &ecspresso.Service{
+		Service: types.Service{
+			LaunchType: types.LaunchTypeFargate,
+			NetworkConfiguration: &types.NetworkConfiguration{
+				AwsvpcConfiguration: &types.AwsVpcConfiguration{
+					Subnets:        []string{"subnet-111"},
+					SecurityGroups: []string{"sg-111"},
+				},
+			},
+		},
+	}
+	remoteSv := &ecspresso.Service{
+		Service: types.Service{
+			LaunchType: types.LaunchTypeFargate,
+			NetworkConfiguration: &types.NetworkConfiguration{
+				AwsvpcConfiguration: &types.AwsVpcConfiguration{
+					Subnets:        []string{"subnet-222"},
+					SecurityGroups: []string{"sg-222"},
+				},
+			},
+		},
+	}
+
+	t.Run("NoUpdateService=false shows service diff", func(t *testing.T) {
+		b := new(bytes.Buffer)
+		opt := &ecspresso.DiffOption{Unified: true, NoUpdateService: false}
+		opt.SetWriter(b)
+
+		diff, err := ecspresso.DiffServices(ctx, localSv, remoteSv, "file", opt)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !diff {
+			t.Fatal("expected diff when NoUpdateService is false")
+		}
+		if b.String() == "" {
+			t.Fatal("expected non-empty diff output")
+		}
+	})
+
+	t.Run("NoUpdateService=true produces only task def diff", func(t *testing.T) {
+		b := new(bytes.Buffer)
+		opt := &ecspresso.DiffOption{Unified: true, NoUpdateService: true}
+		opt.SetWriter(b)
+
+		localTd := &ecspresso.TaskDefinitionInput{
+			Cpu:    aws.String("256"),
+			Memory: aws.String("512"),
+			ContainerDefinitions: []types.ContainerDefinition{
+				{Name: aws.String("app"), Image: aws.String("nginx:latest")},
+			},
+		}
+		remoteTd := &ecspresso.TaskDefinitionInput{
+			Cpu:    aws.String("256"),
+			Memory: aws.String("1024"),
+			ContainerDefinitions: []types.ContainerDefinition{
+				{Name: aws.String("app"), Image: aws.String("nginx:stable")},
+			},
+		}
+
+		// Simulate Diff method: when NoUpdateService=true, skip service diff
+		serviceName := "my-service"
+		if serviceName != "" && !opt.NoUpdateService {
+			// This block should NOT execute
+			if _, err := ecspresso.DiffServices(ctx, localSv, remoteSv, "file", opt); err != nil {
+				t.Fatal(err)
+			}
+		}
+		// Task def diff always runs
+		diff, err := ecspresso.DiffTaskDefs(ctx, localTd, remoteTd, "local", "remote", opt)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !diff {
+			t.Fatal("expected task def diff")
+		}
+		output := b.String()
+		// Should contain task def changes but no service subnet/sg changes
+		if strings.Contains(output, "subnet") {
+			t.Errorf("expected no service diff in output, got: %s", output)
+		}
+		if !strings.Contains(output, "memory") {
+			t.Errorf("expected task def diff with memory change, got: %s", output)
+		}
+	})
+
+	t.Run("NoUpdateService=false produces both service and task def diff", func(t *testing.T) {
+		b := new(bytes.Buffer)
+		opt := &ecspresso.DiffOption{Unified: true, NoUpdateService: false}
+		opt.SetWriter(b)
+
+		localTd := &ecspresso.TaskDefinitionInput{
+			Cpu:    aws.String("256"),
+			Memory: aws.String("512"),
+			ContainerDefinitions: []types.ContainerDefinition{
+				{Name: aws.String("app"), Image: aws.String("nginx:latest")},
+			},
+		}
+		remoteTd := &ecspresso.TaskDefinitionInput{
+			Cpu:    aws.String("256"),
+			Memory: aws.String("1024"),
+			ContainerDefinitions: []types.ContainerDefinition{
+				{Name: aws.String("app"), Image: aws.String("nginx:stable")},
+			},
+		}
+
+		// Simulate Diff method: when NoUpdateService=false, run service diff
+		serviceName := "my-service"
+		if serviceName != "" && !opt.NoUpdateService {
+			if _, err := ecspresso.DiffServices(ctx, localSv, remoteSv, "file", opt); err != nil {
+				t.Fatal(err)
+			}
+		}
+		// Task def diff always runs
+		diff, err := ecspresso.DiffTaskDefs(ctx, localTd, remoteTd, "local", "remote", opt)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !diff {
+			t.Fatal("expected task def diff")
+		}
+		output := b.String()
+		// Should contain both service and task def changes
+		if !strings.Contains(output, "subnet") {
+			t.Errorf("expected service diff with subnet change, got: %s", output)
+		}
+		if !strings.Contains(output, "memory") {
+			t.Errorf("expected task def diff with memory change, got: %s", output)
+		}
+	})
+}
+
 func TestDiffTaskDefs(t *testing.T) {
 	ctx := t.Context()
 	b := new(bytes.Buffer)

--- a/diff_test.go
+++ b/diff_test.go
@@ -521,7 +521,7 @@ func TestDiffJsonnet(t *testing.T) {
 	})
 }
 
-func TestDiffNoUpdateService(t *testing.T) {
+func TestDiffWithoutService(t *testing.T) {
 	ctx := t.Context()
 	color.NoColor = true
 
@@ -548,9 +548,9 @@ func TestDiffNoUpdateService(t *testing.T) {
 		},
 	}
 
-	t.Run("NoUpdateService=false shows service diff", func(t *testing.T) {
+	t.Run("WithService=true shows service diff", func(t *testing.T) {
 		b := new(bytes.Buffer)
-		opt := &ecspresso.DiffOption{Unified: true, NoUpdateService: false}
+		opt := &ecspresso.DiffOption{Unified: true, WithService: true}
 		opt.SetWriter(b)
 
 		diff, err := ecspresso.DiffServices(ctx, localSv, remoteSv, "file", opt)
@@ -558,16 +558,16 @@ func TestDiffNoUpdateService(t *testing.T) {
 			t.Fatal(err)
 		}
 		if !diff {
-			t.Fatal("expected diff when NoUpdateService is false")
+			t.Fatal("expected diff when WithService is true")
 		}
 		if b.String() == "" {
 			t.Fatal("expected non-empty diff output")
 		}
 	})
 
-	t.Run("NoUpdateService=true produces only task def diff", func(t *testing.T) {
+	t.Run("WithService=false produces only task def diff", func(t *testing.T) {
 		b := new(bytes.Buffer)
-		opt := &ecspresso.DiffOption{Unified: true, NoUpdateService: true}
+		opt := &ecspresso.DiffOption{Unified: true, WithService: false}
 		opt.SetWriter(b)
 
 		localTd := &ecspresso.TaskDefinitionInput{
@@ -585,9 +585,9 @@ func TestDiffNoUpdateService(t *testing.T) {
 			},
 		}
 
-		// Simulate Diff method: when NoUpdateService=true, skip service diff
+		// Simulate Diff method: when WithService=false, skip service diff
 		serviceName := "my-service"
-		if serviceName != "" && !opt.NoUpdateService {
+		if serviceName != "" && opt.WithService {
 			// This block should NOT execute
 			if _, err := ecspresso.DiffServices(ctx, localSv, remoteSv, "file", opt); err != nil {
 				t.Fatal(err)
@@ -611,9 +611,9 @@ func TestDiffNoUpdateService(t *testing.T) {
 		}
 	})
 
-	t.Run("NoUpdateService=false produces both service and task def diff", func(t *testing.T) {
+	t.Run("WithService=true produces both service and task def diff", func(t *testing.T) {
 		b := new(bytes.Buffer)
-		opt := &ecspresso.DiffOption{Unified: true, NoUpdateService: false}
+		opt := &ecspresso.DiffOption{Unified: true, WithService: true}
 		opt.SetWriter(b)
 
 		localTd := &ecspresso.TaskDefinitionInput{
@@ -631,9 +631,9 @@ func TestDiffNoUpdateService(t *testing.T) {
 			},
 		}
 
-		// Simulate Diff method: when NoUpdateService=false, run service diff
+		// Simulate Diff method: when WithService=true, run service diff
 		serviceName := "my-service"
-		if serviceName != "" && !opt.NoUpdateService {
+		if serviceName != "" && opt.WithService {
 			if _, err := ecspresso.DiffServices(ctx, localSv, remoteSv, "file", opt); err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
## Summary

Add `--with-service` / `--without-service` flag to the `diff` command to control whether the service definition diff is included.

- `ecspresso diff` (default: `--with-service`) — shows both service and task definition diffs
- `ecspresso diff --without-service` — skips service definition diff, only shows task definition diff

This is useful when you only want to see task definition changes without the service definition noise.

## Changes

- Add `WithService` field to `DiffOption` struct with `default:"true"` and `negatable:"without-service"`
- Skip service definition diff when `--without-service` is specified
- Update tests and README accordingly

## Test plan

- [x] `go build ./...` passes
- [x] `TestDiffWithoutService` tests pass
- [x] CLI parsing test for `--without-service` flag passes