### PR TITLE
Add skills subcommand using skillsmith

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,16 +14,16 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go
-        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v5
-        with:
-          go-version: "1.25"
-
       - name: Check out code into the Go module directory
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
         with:
           ref: ${{ github.event.inputs.ref }}
           fetch-depth: 0 # it is required for the changelog to work correctly.
+
+      - name: Set up Go
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v5
+        with:
+          go-version: "1.25"
 
       - name: Set env
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,13 +10,13 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
+
       - name: Set up Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6
         with:
           go-version: ${{ matrix.go }}
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
 
       - name: Build & Test
         run: |

--- a/README.md
+++ b/README.md
@@ -1310,7 +1310,7 @@ readme	ecspresso README
 
 ### LLM agent integration
 
-ecspresso provides an [Agent Skill](https://agentskills.io/) for LLM agents (Claude Code, GitHub Copilot, OpenAI Codex, etc.) to use ecspresso effectively. The skill covers common workflows, command usage patterns, and best practices.
+ecspresso provides an [Agent Skill](https://agentskills.io/) for LLM agents (Claude Code, GitHub Copilot, OpenAI Codex, etc.) to use ecspresso effectively. The skill covers common workflows, command usage patterns, and best practices. Powered by [Songmu/skillsmith](https://github.com/Songmu/skillsmith).
 
 Install the skill for your user:
 

--- a/README.md
+++ b/README.md
@@ -1306,24 +1306,32 @@ List available articles:
 ```console
 $ ecspresso docs --list
 readme	ecspresso README
-skill	LLM agent skill reference
-```
-
-Show the LLM agent skill guide:
-
-```console
-$ ecspresso docs --article skill
 ```
 
 ### LLM agent integration
 
 ecspresso provides a skill guide for LLM agents (such as Claude Code, ChatGPT, etc.) to use ecspresso effectively. The skill guide covers common workflows, command usage patterns, and best practices including the recommendation to use Jsonnet over JSON/YAML for definition files.
 
-The skill guide is embedded in the binary and can be accessed via `ecspresso docs --article skill`. No separate file installation is needed.
+The skill is distributed via the `skills` subcommand using the [Agent Skills](https://agentskills.io/) specification. Install the skill with:
+
+```console
+$ ecspresso skills install
+```
+
+The `skills` subcommand provides the following operations:
+
+```console
+$ ecspresso skills list        # List available skills
+$ ecspresso skills install     # Install skills to ~/.agents/skills
+$ ecspresso skills update      # Update installed skills
+$ ecspresso skills uninstall   # Remove installed skills
+$ ecspresso skills status      # Show installation status
+$ ecspresso skills reinstall   # Reinstall all managed skills
+```
 
 To integrate ecspresso with an LLM agent:
 
-1. Add a line to the agent's instructions (e.g., CLAUDE.md): `Run ecspresso docs --article skill to learn how to use ecspresso.`
+1. Run `ecspresso skills install` to install the skill.
 2. The agent can then use `ecspresso docs --search "<keyword>" --json` to look up specific topics at runtime.
 
 This combination allows an LLM agent to deploy, manage, and troubleshoot ECS services through ecspresso with minimal human guidance.

--- a/README.md
+++ b/README.md
@@ -1310,31 +1310,33 @@ readme	ecspresso README
 
 ### LLM agent integration
 
-ecspresso provides a skill guide for LLM agents (such as Claude Code, ChatGPT, etc.) to use ecspresso effectively. The skill guide covers common workflows, command usage patterns, and best practices including the recommendation to use Jsonnet over JSON/YAML for definition files.
+ecspresso provides an [Agent Skill](https://agentskills.io/) for LLM agents (Claude Code, GitHub Copilot, OpenAI Codex, etc.) to use ecspresso effectively. The skill covers common workflows, command usage patterns, and best practices.
 
-The skill is distributed via the `skills` subcommand using the [Agent Skills](https://agentskills.io/) specification. Install the skill with:
+Install the skill for your user:
 
 ```console
 $ ecspresso skills install
 ```
 
-The `skills` subcommand provides the following operations:
+This installs the skill to `~/.agents/skills/ecspresso/SKILL.md`. Compatible LLM agents automatically discover skills in this directory — no additional configuration is needed.
+
+To share the skill with your team via the repository, use `--scope repo`:
+
+```console
+$ ecspresso skills install --scope repo
+```
+
+This installs to `.agents/skills/` in the repository root. Commit this directory so that team members' agents can use the skill without installing it individually.
+
+Other `skills` operations:
 
 ```console
 $ ecspresso skills list        # List available skills
-$ ecspresso skills install     # Install skills to ~/.agents/skills
+$ ecspresso skills status      # Show installation status
 $ ecspresso skills update      # Update installed skills
 $ ecspresso skills uninstall   # Remove installed skills
-$ ecspresso skills status      # Show installation status
 $ ecspresso skills reinstall   # Reinstall all managed skills
 ```
-
-To integrate ecspresso with an LLM agent:
-
-1. Run `ecspresso skills install` to install the skill.
-2. The agent can then use `ecspresso docs --search "<keyword>" --json` to look up specific topics at runtime.
-
-This combination allows an LLM agent to deploy, manage, and troubleshoot ECS services through ecspresso with minimal human guidance.
 
 ## Plugins
 

--- a/cli.go
+++ b/cli.go
@@ -39,7 +39,7 @@ type CLIOptions struct {
 	Tasks      *TasksOption      `cmd:"" help:"list tasks that are in a service or having the same family"`
 	Verify     *VerifyOption     `cmd:"" help:"verify resources in configurations"`
 	Wait       *WaitOption       `cmd:"" help:"wait until service stable"`
-	Skills     struct{}          `cmd:"" help:"manage agent skills"`
+	Skills     *SkillsOption     `cmd:"" help:"manage agent skills"`
 	Version    struct{}          `cmd:"" help:"show version"`
 }
 
@@ -101,6 +101,8 @@ func (opts *CLIOptions) ForSubCommand(sub string) any {
 		return opts.Verify
 	case "wait":
 		return opts.Wait
+	case "skills":
+		return opts.Skills
 	default:
 		return nil
 	}
@@ -113,6 +115,8 @@ func dispatchCLI(ctx context.Context, sub string, usage func(), opts *CLIOptions
 		return err
 	case "docs":
 		return Docs(*opts.Docs)
+	case "skills":
+		return dispatchSkills(ctx, opts.Skills)
 	}
 	var appOpts []AppOption
 	if sub == "init" {
@@ -175,17 +179,7 @@ func dispatchCLI(ctx context.Context, sub string, usage func(), opts *CLIOptions
 type CLIParseFunc func([]string) (string, *CLIOptions, func(), error)
 
 func CLI(ctx context.Context, parse CLIParseFunc) (int, error) {
-	// Handle "skills" subcommand before Kong parsing.
-	// skillsmith uses its own flag package for argument parsing.
-	args := os.Args[1:]
-	if len(args) > 0 && args[0] == "skills" {
-		if err := Skills(ctx, args[1:]); err != nil {
-			return 1, err
-		}
-		return 0, nil
-	}
-
-	sub, opts, usage, err := parse(args)
+	sub, opts, usage, err := parse(os.Args[1:])
 	if err != nil {
 		return 1, err
 	}

--- a/cli.go
+++ b/cli.go
@@ -110,6 +110,9 @@ func (opts *CLIOptions) ForSubCommand(sub string) any {
 	}
 }
 
+// dispatchCLI routes the subcommand to the appropriate handler.
+// Commands that do not require AWS credentials or config are handled
+// directly. All others are delegated to dispatchApp.
 func dispatchCLI(ctx context.Context, sub string, usage func(), opts *CLIOptions) error {
 	switch sub {
 	case "version", "":
@@ -119,7 +122,14 @@ func dispatchCLI(ctx context.Context, sub string, usage func(), opts *CLIOptions
 		return Docs(*opts.Docs)
 	case "skills":
 		return dispatchSkills(ctx, opts.Skills)
+	default:
+		return dispatchApp(ctx, sub, usage, opts)
 	}
+}
+
+// dispatchApp handles subcommands that require an App instance
+// (AWS credentials and config).
+func dispatchApp(ctx context.Context, sub string, usage func(), opts *CLIOptions) error {
 	var appOpts []AppOption
 	if sub == "init" {
 		config, err := opts.Init.NewConfig(ctx, opts.ConfigFilePath)
@@ -174,8 +184,8 @@ func dispatchCLI(ctx context.Context, sub string, usage func(), opts *CLIOptions
 		return app.Exec(ctx, *opts.Exec)
 	default:
 		usage()
+		return nil
 	}
-	return nil
 }
 
 type CLIParseFunc func([]string) (string, *CLIOptions, func(), error)

--- a/cli.go
+++ b/cli.go
@@ -6,6 +6,8 @@ import (
 	"log/slog"
 	"os"
 	"time"
+
+	"github.com/kayac/ecspresso/v2/skillscmd"
 )
 
 type CLIOptions struct {
@@ -39,7 +41,7 @@ type CLIOptions struct {
 	Tasks      *TasksOption      `cmd:"" help:"list tasks that are in a service or having the same family"`
 	Verify     *VerifyOption     `cmd:"" help:"verify resources in configurations"`
 	Wait       *WaitOption       `cmd:"" help:"wait until service stable"`
-	Skills     *SkillsOption     `cmd:"" help:"manage agent skills"`
+	Skills     *skillscmd.Commands `cmd:"" help:"manage agent skills"`
 	Version    struct{}          `cmd:"" help:"show version"`
 }
 

--- a/cli.go
+++ b/cli.go
@@ -118,7 +118,7 @@ func dispatchCLI(ctx context.Context, sub string, usage func(), opts *CLIOptions
 	case "version", "":
 		return showVersion()
 	case "docs":
-		return dispatchDocs(opts.Docs)
+		return dispatchDocs(ctx, opts.Docs)
 	case "skills":
 		return dispatchSkills(ctx, opts.Skills)
 	default:

--- a/cli.go
+++ b/cli.go
@@ -116,15 +116,19 @@ func (opts *CLIOptions) ForSubCommand(sub string) any {
 func dispatchCLI(ctx context.Context, sub string, usage func(), opts *CLIOptions) error {
 	switch sub {
 	case "version", "":
-		_, err := WriteOutput("ecspresso " + Version)
-		return err
+		return showVersion()
 	case "docs":
-		return Docs(*opts.Docs)
+		return dispatchDocs(opts.Docs)
 	case "skills":
 		return dispatchSkills(ctx, opts.Skills)
 	default:
 		return dispatchApp(ctx, sub, usage, opts)
 	}
+}
+
+func showVersion() error {
+	_, err := WriteOutput("ecspresso " + Version)
+	return err
 }
 
 // dispatchApp handles subcommands that require an App instance

--- a/cli.go
+++ b/cli.go
@@ -39,6 +39,7 @@ type CLIOptions struct {
 	Tasks      *TasksOption      `cmd:"" help:"list tasks that are in a service or having the same family"`
 	Verify     *VerifyOption     `cmd:"" help:"verify resources in configurations"`
 	Wait       *WaitOption       `cmd:"" help:"wait until service stable"`
+	Skills     struct{}          `cmd:"" help:"manage agent skills"`
 	Version    struct{}          `cmd:"" help:"show version"`
 }
 
@@ -174,7 +175,17 @@ func dispatchCLI(ctx context.Context, sub string, usage func(), opts *CLIOptions
 type CLIParseFunc func([]string) (string, *CLIOptions, func(), error)
 
 func CLI(ctx context.Context, parse CLIParseFunc) (int, error) {
-	sub, opts, usage, err := parse(os.Args[1:])
+	// Handle "skills" subcommand before Kong parsing.
+	// skillsmith uses its own flag package for argument parsing.
+	args := os.Args[1:]
+	if len(args) > 0 && args[0] == "skills" {
+		if err := Skills(ctx, args[1:]); err != nil {
+			return 1, err
+		}
+		return 0, nil
+	}
+
+	sub, opts, usage, err := parse(args)
 	if err != nil {
 		return 1, err
 	}

--- a/cli_test.go
+++ b/cli_test.go
@@ -801,11 +801,6 @@ var cliTests = []struct {
 		subOption: &ecspresso.DocsOption{Article: "readme", Index: true, JSON: true},
 	},
 	{
-		args:      []string{"docs", "--article", "skill"},
-		sub:       "docs",
-		subOption: &ecspresso.DocsOption{Article: "skill"},
-	},
-	{
 		args: []string{"diff"},
 		sub:  "diff",
 		subOption: &ecspresso.DiffOption{

--- a/cliv2.go
+++ b/cliv2.go
@@ -87,5 +87,28 @@ func clearInactiveSubcommands(opts *CLIOptions, cmd string) {
 		if subcmd != "cp" {
 			e.Cp = nil
 		}
+	case "skills":
+		s := opts.Skills
+		if s == nil {
+			return
+		}
+		if subcmd != "list" {
+			s.List = nil
+		}
+		if subcmd != "install" {
+			s.Install = nil
+		}
+		if subcmd != "update" {
+			s.Update = nil
+		}
+		if subcmd != "reinstall" {
+			s.Reinstall = nil
+		}
+		if subcmd != "uninstall" {
+			s.Uninstall = nil
+		}
+		if subcmd != "status" {
+			s.Status = nil
+		}
 	}
 }

--- a/diff.go
+++ b/diff.go
@@ -27,10 +27,10 @@ import (
 )
 
 type DiffOption struct {
-	Unified         bool   `help:"unified diff format" default:"true" negatable:""`
-	Jsonnet         bool   `help:"render as jsonnet format" default:"false"`
-	External        string `help:"external command to format diff" env:"ECSPRESSO_DIFF_COMMAND"`
-	WithService     bool   `help:"with service definition" default:"true" negatable:"without-service"`
+	Unified     bool   `help:"unified diff format" default:"true" negatable:""`
+	Jsonnet     bool   `help:"render as jsonnet format" default:"false"`
+	External    string `help:"external command to format diff" env:"ECSPRESSO_DIFF_COMMAND"`
+	WithService bool   `help:"with service definition" default:"true" negatable:"without-service"`
 
 	w io.Writer `kong:"-"`
 }

--- a/docs.go
+++ b/docs.go
@@ -10,7 +10,7 @@ import (
 
 // DocsOption defines CLI options for the docs subcommand.
 type DocsOption struct {
-	Article string `help:"article name to display" default:"readme" enum:"readme,skill"`
+	Article string `help:"article name to display" default:"readme" enum:"readme"`
 	List    bool   `help:"list available articles" default:"false"`
 	Index   bool   `help:"show table of contents" default:"false"`
 	Search  string `help:"search keyword in documents" default:""`
@@ -38,7 +38,6 @@ type docsArticle struct {
 
 var articles = []docsArticle{
 	{Name: "readme", Description: "ecspresso README"},
-	{Name: "skill", Description: "LLM agent skill reference"},
 }
 
 // Docs shows embedded documentation.
@@ -68,8 +67,6 @@ func getArticle(name string) (string, error) {
 	switch name {
 	case "readme":
 		return readmeContent, nil
-	case "skill":
-		return skillContent, nil
 	default:
 		return "", fmt.Errorf("unknown article: %s", name)
 	}

--- a/docs.go
+++ b/docs.go
@@ -1,6 +1,7 @@
 package ecspresso
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -40,12 +41,12 @@ var articles = []docsArticle{
 	{Name: "readme", Description: "ecspresso README"},
 }
 
-func dispatchDocs(opt *DocsOption) error {
-	return Docs(*opt)
+func dispatchDocs(ctx context.Context, opt *DocsOption) error {
+	return Docs(ctx, *opt)
 }
 
 // Docs shows embedded documentation.
-func Docs(opt DocsOption) error {
+func Docs(_ context.Context, opt DocsOption) error {
 	jsonOutput := opt.JSON || logFormat == logFormatJSON
 
 	if opt.List {

--- a/docs.go
+++ b/docs.go
@@ -40,6 +40,10 @@ var articles = []docsArticle{
 	{Name: "readme", Description: "ecspresso README"},
 }
 
+func dispatchDocs(opt *DocsOption) error {
+	return Docs(*opt)
+}
+
 // Docs shows embedded documentation.
 func Docs(opt DocsOption) error {
 	jsonOutput := opt.JSON || logFormat == logFormatJSON

--- a/docs_embed.go
+++ b/docs_embed.go
@@ -1,9 +1,12 @@
 package ecspresso
 
-import _ "embed"
+import (
+	"embed"
+	_ "embed"
+)
 
 //go:embed README.md
 var readmeContent string
 
-//go:embed skills/SKILL.md
-var skillContent string
+//go:embed skills
+var skillsFS embed.FS

--- a/docs_test.go
+++ b/docs_test.go
@@ -173,14 +173,14 @@ func TestDocsOptionDefault(t *testing.T) {
 }
 
 func TestDocsListText(t *testing.T) {
-	err := ecspresso.Docs(ecspresso.DocsOption{List: true})
+	err := ecspresso.Docs(t.Context(), ecspresso.DocsOption{List: true})
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestDocsListJSON(t *testing.T) {
-	err := ecspresso.Docs(ecspresso.DocsOption{List: true, JSON: true})
+	err := ecspresso.Docs(t.Context(), ecspresso.DocsOption{List: true, JSON: true})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/docs_test.go
+++ b/docs_test.go
@@ -153,26 +153,6 @@ func TestDocsSearchNoMatch(t *testing.T) {
 	}
 }
 
-func TestParseSectionsSkill(t *testing.T) {
-	content := ecspresso.SkillContent
-	sections := ecspresso.ParseSections(content)
-
-	if len(sections) == 0 {
-		t.Fatal("expected non-zero sections from SKILL.md")
-	}
-
-	titles := make(map[string]bool)
-	for _, s := range sections {
-		titles[s.Title] = true
-	}
-
-	for _, expected := range []string{"ecspresso Skill for LLM Agents", "Common workflows", "Configuration structure"} {
-		if !titles[expected] {
-			t.Errorf("expected heading %q not found in SKILL.md sections", expected)
-		}
-	}
-}
-
 func TestDocsOptionDefault(t *testing.T) {
 	want := &ecspresso.DocsOption{
 		Article: "readme",

--- a/export_test.go
+++ b/export_test.go
@@ -35,7 +35,6 @@ var (
 	ParseIAMPolicyDocument = parseIAMPolicyDocument
 	ParseSections          = parseSections
 	ReadmeContent          = readmeContent
-	SkillContent           = skillContent
 )
 
 type ModifyAutoScalingParams = modifyAutoScalingParams

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,10 @@
 module github.com/kayac/ecspresso/v2
 
-go 1.25
+go 1.25.0
 
 require (
 	github.com/Songmu/prompter v0.5.1
+	github.com/Songmu/skillsmith v0.0.2
 	github.com/alecthomas/kong v1.14.0
 	github.com/aws/aws-sdk-go-v2 v1.41.1
 	github.com/aws/aws-sdk-go-v2/config v1.32.7
@@ -144,6 +145,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.38.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	golang.org/x/crypto v0.47.0 // indirect
+	golang.org/x/mod v0.34.0 // indirect
 	golang.org/x/net v0.48.0 // indirect
 	golang.org/x/oauth2 v0.33.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/Songmu/prompter v0.5.1
-	github.com/Songmu/skillsmith v0.0.2
+	github.com/Songmu/skillsmith v0.1.0
 	github.com/alecthomas/kong v1.14.0
 	github.com/aws/aws-sdk-go-v2 v1.41.1
 	github.com/aws/aws-sdk-go-v2/config v1.32.7

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/Songmu/prompter v0.5.1 h1:IAsttKsOZWSDw7bV1mtGn9TAmLFAjXbp9I/eYmUUogo
 github.com/Songmu/prompter v0.5.1/go.mod h1:CS3jEPD6h9IaLaG6afrl1orTgII9+uDWuw95dr6xHSw=
 github.com/Songmu/skillsmith v0.0.2 h1:sF3wAc74Xi4BJ3D60njDoW33wzrZbdTMteKHpSIvkIk=
 github.com/Songmu/skillsmith v0.0.2/go.mod h1:agwErnb8lLH48nyoDqEZfoVJovtMGOgqUuTnR1M9ORI=
+github.com/Songmu/skillsmith v0.1.0 h1:R7tT94OrdsLuDGpdiBbLEjS+nDIRKjxGHeejwDpdf6w=
+github.com/Songmu/skillsmith v0.1.0/go.mod h1:agwErnb8lLH48nyoDqEZfoVJovtMGOgqUuTnR1M9ORI=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/kong v1.14.0 h1:gFgEUZWu2ZmZ+UhyZ1bDhuutbKN1nTtJTwh19Wsn21s=

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/Songmu/flextime v0.1.0 h1:sss5IALl84LbvU/cS5D1cKNd5ffT94N2BZwC+esgAJI
 github.com/Songmu/flextime v0.1.0/go.mod h1:ofUSZ/qj7f1BfQQ6rEH4ovewJ0SZmLOjBF1xa8iE87Q=
 github.com/Songmu/prompter v0.5.1 h1:IAsttKsOZWSDw7bV1mtGn9TAmLFAjXbp9I/eYmUUogo=
 github.com/Songmu/prompter v0.5.1/go.mod h1:CS3jEPD6h9IaLaG6afrl1orTgII9+uDWuw95dr6xHSw=
+github.com/Songmu/skillsmith v0.0.2 h1:sF3wAc74Xi4BJ3D60njDoW33wzrZbdTMteKHpSIvkIk=
+github.com/Songmu/skillsmith v0.0.2/go.mod h1:agwErnb8lLH48nyoDqEZfoVJovtMGOgqUuTnR1M9ORI=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/kong v1.14.0 h1:gFgEUZWu2ZmZ+UhyZ1bDhuutbKN1nTtJTwh19Wsn21s=
@@ -376,6 +378,8 @@ golang.org/x/crypto v0.47.0/go.mod h1:ff3Y9VzzKbwSSEzWqJsJVBnWmRwRSHt/6Op5n9bQc4
 golang.org/x/lint v0.0.0-20210508222113-6edffad5e616/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.34.0 h1:xIHgNUUnW6sYkcM5Jleh05DvLOtwc6RitGHbDk4akRI=
+golang.org/x/mod v0.34.0/go.mod h1:ykgH52iCZe79kzLLMhyCUzhMci+nQj+0XkbXpNYtVjY=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=

--- a/skills.go
+++ b/skills.go
@@ -1,0 +1,20 @@
+package ecspresso
+
+import (
+	"context"
+
+	"github.com/Songmu/skillsmith"
+)
+
+// Skills runs the skillsmith subcommand for managing agent skills.
+func Skills(ctx context.Context, args []string) error {
+	version := Version
+	if version == "" {
+		version = "v0.0.0-dev"
+	}
+	s, err := skillsmith.New("ecspresso", version, skillsFS)
+	if err != nil {
+		return err
+	}
+	return s.Run(ctx, args)
+}

--- a/skills.go
+++ b/skills.go
@@ -7,16 +7,12 @@ import (
 	"github.com/kayac/ecspresso/v2/skillscmd"
 )
 
-func newSmith() (*skillsmith.Smith, error) {
+func dispatchSkills(ctx context.Context, opts *skillscmd.Commands) error {
 	version := Version
 	if version == "" {
 		version = "v0.0.0-dev"
 	}
-	return skillsmith.New("ecspresso", version, skillsFS)
-}
-
-func dispatchSkills(ctx context.Context, opts *skillscmd.Commands) error {
-	s, err := newSmith()
+	s, err := skillsmith.New("ecspresso", version, skillsFS)
 	if err != nil {
 		return err
 	}

--- a/skills.go
+++ b/skills.go
@@ -2,19 +2,210 @@ package ecspresso
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/Songmu/skillsmith"
 )
 
-// Skills runs the skillsmith subcommand for managing agent skills.
-func Skills(ctx context.Context, args []string) error {
+// SkillsOption defines CLI options for the skills subcommand.
+type SkillsOption struct {
+	List      *SkillsListOption   `cmd:"" help:"list available skills"`
+	Install   *SkillsModifyOption `cmd:"" help:"install skills"`
+	Update    *SkillsModifyOption `cmd:"" help:"update installed skills"`
+	Reinstall *SkillsModifyOption `cmd:"" help:"reinstall all managed skills"`
+	Uninstall *SkillsModifyOption `cmd:"" help:"uninstall managed skills"`
+	Status    *SkillsStatusOption `cmd:"" help:"show installation status"`
+}
+
+// SkillsListOption defines CLI options for skills list.
+type SkillsListOption struct{}
+
+// SkillsModifyOption defines CLI options for skills install/update/reinstall/uninstall.
+type SkillsModifyOption struct {
+	Scope  string `help:"install scope (user or repo)" default:"" enum:",user,repo"`
+	Prefix string `help:"override install directory" default:""`
+	DryRun bool   `help:"preview changes without applying" name:"dry-run" default:"false"`
+	Force  bool   `help:"overwrite unmanaged skills or force downgrade" default:"false"`
+}
+
+func (o *SkillsModifyOption) options() skillsmith.Options {
+	return skillsmith.Options{
+		Scope:  o.Scope,
+		Prefix: o.Prefix,
+		DryRun: o.DryRun,
+		Force:  o.Force,
+	}
+}
+
+// SkillsStatusOption defines CLI options for skills status.
+type SkillsStatusOption struct {
+	Scope  string `help:"install scope (user or repo)" default:"" enum:",user,repo"`
+	Prefix string `help:"override install directory" default:""`
+}
+
+func (o *SkillsStatusOption) options() skillsmith.Options {
+	return skillsmith.Options{
+		Scope:  o.Scope,
+		Prefix: o.Prefix,
+	}
+}
+
+func dispatchSkills(ctx context.Context, opts *SkillsOption) error {
+	switch {
+	case opts.List != nil:
+		return skillsList(ctx)
+	case opts.Install != nil:
+		return skillsInstall(ctx, opts.Install.options())
+	case opts.Update != nil:
+		return skillsUpdate(ctx, opts.Update.options())
+	case opts.Reinstall != nil:
+		return skillsReinstall(ctx, opts.Reinstall.options())
+	case opts.Uninstall != nil:
+		return skillsUninstall(ctx, opts.Uninstall.options())
+	case opts.Status != nil:
+		return skillsStatus(ctx, opts.Status.options())
+	default:
+		return fmt.Errorf("unknown skills subcommand")
+	}
+}
+
+func newSmith() (*skillsmith.Smith, error) {
 	version := Version
 	if version == "" {
 		version = "v0.0.0-dev"
 	}
-	s, err := skillsmith.New("ecspresso", version, skillsFS)
+	return skillsmith.New("ecspresso", version, skillsFS)
+}
+
+func skillsList(ctx context.Context) error {
+	s, err := newSmith()
 	if err != nil {
 		return err
 	}
-	return s.Run(ctx, args)
+	skills, err := s.List(ctx)
+	if err != nil {
+		return err
+	}
+	if len(skills) == 0 {
+		_, err := WriteOutput("no skills found")
+		return err
+	}
+	for _, sk := range skills {
+		if sk.Description != "" {
+			fmt.Printf("%-30s %s\n", sk.Dir, sk.Description)
+		} else {
+			fmt.Println(sk.Dir)
+		}
+	}
+	return nil
+}
+
+func skillsInstall(ctx context.Context, opts skillsmith.Options) error {
+	s, err := newSmith()
+	if err != nil {
+		return err
+	}
+	result, err := s.Install(ctx, opts)
+	if err != nil {
+		return err
+	}
+	printCopyResult(result, "installed", opts.DryRun)
+	return nil
+}
+
+func skillsUpdate(ctx context.Context, opts skillsmith.Options) error {
+	s, err := newSmith()
+	if err != nil {
+		return err
+	}
+	result, err := s.Update(ctx, opts)
+	if err != nil {
+		return err
+	}
+	printCopyResult(result, "updated", opts.DryRun)
+	return nil
+}
+
+func skillsReinstall(ctx context.Context, opts skillsmith.Options) error {
+	s, err := newSmith()
+	if err != nil {
+		return err
+	}
+	result, err := s.Reinstall(ctx, opts)
+	if err != nil {
+		return err
+	}
+	printCopyResult(result, "reinstalled", opts.DryRun)
+	return nil
+}
+
+func skillsUninstall(ctx context.Context, opts skillsmith.Options) error {
+	s, err := newSmith()
+	if err != nil {
+		return err
+	}
+	result, err := s.Uninstall(ctx, opts)
+	if err != nil {
+		return err
+	}
+	for _, a := range result.Actions {
+		switch a.Action {
+		case "uninstalled":
+			if opts.DryRun {
+				fmt.Printf("uninstalled (dry-run): %s\n", a.Dir)
+			} else {
+				fmt.Printf("uninstalled: %s\n", a.Dir)
+			}
+		case "skipped":
+			fmt.Printf("skipped:     %s — %s\n", a.Dir, a.Message)
+		}
+	}
+	if opts.DryRun {
+		fmt.Println("[dry-run] no changes were made")
+	}
+	return nil
+}
+
+func skillsStatus(ctx context.Context, opts skillsmith.Options) error {
+	s, err := newSmith()
+	if err != nil {
+		return err
+	}
+	result, err := s.Status(ctx, opts)
+	if err != nil {
+		return err
+	}
+	for _, ss := range result.Skills {
+		switch {
+		case !ss.Installed:
+			fmt.Printf("%-30s not installed\n", ss.Dir)
+		case ss.MetadataError != nil:
+			fmt.Printf("%-30s installed (metadata unreadable: %v)\n", ss.Dir, ss.MetadataError)
+		case ss.UpToDate:
+			fmt.Printf("%-30s installed %s (up to date)\n", ss.Dir, ss.InstalledVersion)
+		default:
+			fmt.Printf("%-30s installed %s → available %s\n", ss.Dir, ss.InstalledVersion, ss.AvailableVersion)
+		}
+	}
+	return nil
+}
+
+func printCopyResult(result *skillsmith.CopyResult, verb string, dryRun bool) {
+	for _, a := range result.Actions {
+		switch a.Action {
+		case verb:
+			if dryRun {
+				fmt.Printf("%s (dry-run): %s\n", verb, a.Dir)
+			} else {
+				fmt.Printf("%s: %s\n", verb, a.Dir)
+			}
+		case "skipped":
+			fmt.Printf("skipped:   %s — %s\n", a.Dir, a.Message)
+		case "warned":
+			LogWarn("warning:   %s — %s", a.Dir, a.Message)
+		}
+	}
+	if dryRun {
+		fmt.Println("[dry-run] no changes were made")
+	}
 }

--- a/skills.go
+++ b/skills.go
@@ -2,72 +2,10 @@ package ecspresso
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/Songmu/skillsmith"
+	"github.com/kayac/ecspresso/v2/skillscmd"
 )
-
-// SkillsOption defines CLI options for the skills subcommand.
-type SkillsOption struct {
-	List      *SkillsListOption   `cmd:"" help:"list available skills"`
-	Install   *SkillsModifyOption `cmd:"" help:"install skills"`
-	Update    *SkillsModifyOption `cmd:"" help:"update installed skills"`
-	Reinstall *SkillsModifyOption `cmd:"" help:"reinstall all managed skills"`
-	Uninstall *SkillsModifyOption `cmd:"" help:"uninstall managed skills"`
-	Status    *SkillsStatusOption `cmd:"" help:"show installation status"`
-}
-
-// SkillsListOption defines CLI options for skills list.
-type SkillsListOption struct{}
-
-// SkillsModifyOption defines CLI options for skills install/update/reinstall/uninstall.
-type SkillsModifyOption struct {
-	Scope  string `help:"install scope (user or repo)" default:"" enum:",user,repo"`
-	Prefix string `help:"override install directory" default:""`
-	DryRun bool   `help:"preview changes without applying" name:"dry-run" default:"false"`
-	Force  bool   `help:"overwrite unmanaged skills or force downgrade" default:"false"`
-}
-
-func (o *SkillsModifyOption) options() skillsmith.Options {
-	return skillsmith.Options{
-		Scope:  o.Scope,
-		Prefix: o.Prefix,
-		DryRun: o.DryRun,
-		Force:  o.Force,
-	}
-}
-
-// SkillsStatusOption defines CLI options for skills status.
-type SkillsStatusOption struct {
-	Scope  string `help:"install scope (user or repo)" default:"" enum:",user,repo"`
-	Prefix string `help:"override install directory" default:""`
-}
-
-func (o *SkillsStatusOption) options() skillsmith.Options {
-	return skillsmith.Options{
-		Scope:  o.Scope,
-		Prefix: o.Prefix,
-	}
-}
-
-func dispatchSkills(ctx context.Context, opts *SkillsOption) error {
-	switch {
-	case opts.List != nil:
-		return skillsList(ctx)
-	case opts.Install != nil:
-		return skillsInstall(ctx, opts.Install.options())
-	case opts.Update != nil:
-		return skillsUpdate(ctx, opts.Update.options())
-	case opts.Reinstall != nil:
-		return skillsReinstall(ctx, opts.Reinstall.options())
-	case opts.Uninstall != nil:
-		return skillsUninstall(ctx, opts.Uninstall.options())
-	case opts.Status != nil:
-		return skillsStatus(ctx, opts.Status.options())
-	default:
-		return fmt.Errorf("unknown skills subcommand")
-	}
-}
 
 func newSmith() (*skillsmith.Smith, error) {
 	version := Version
@@ -77,135 +15,10 @@ func newSmith() (*skillsmith.Smith, error) {
 	return skillsmith.New("ecspresso", version, skillsFS)
 }
 
-func skillsList(ctx context.Context) error {
+func dispatchSkills(ctx context.Context, opts *skillscmd.Commands) error {
 	s, err := newSmith()
 	if err != nil {
 		return err
 	}
-	skills, err := s.List(ctx)
-	if err != nil {
-		return err
-	}
-	if len(skills) == 0 {
-		_, err := WriteOutput("no skills found")
-		return err
-	}
-	for _, sk := range skills {
-		if sk.Description != "" {
-			fmt.Printf("%-30s %s\n", sk.Dir, sk.Description)
-		} else {
-			fmt.Println(sk.Dir)
-		}
-	}
-	return nil
-}
-
-func skillsInstall(ctx context.Context, opts skillsmith.Options) error {
-	s, err := newSmith()
-	if err != nil {
-		return err
-	}
-	result, err := s.Install(ctx, opts)
-	if err != nil {
-		return err
-	}
-	printCopyResult(result, "installed", opts.DryRun)
-	return nil
-}
-
-func skillsUpdate(ctx context.Context, opts skillsmith.Options) error {
-	s, err := newSmith()
-	if err != nil {
-		return err
-	}
-	result, err := s.Update(ctx, opts)
-	if err != nil {
-		return err
-	}
-	printCopyResult(result, "updated", opts.DryRun)
-	return nil
-}
-
-func skillsReinstall(ctx context.Context, opts skillsmith.Options) error {
-	s, err := newSmith()
-	if err != nil {
-		return err
-	}
-	result, err := s.Reinstall(ctx, opts)
-	if err != nil {
-		return err
-	}
-	printCopyResult(result, "reinstalled", opts.DryRun)
-	return nil
-}
-
-func skillsUninstall(ctx context.Context, opts skillsmith.Options) error {
-	s, err := newSmith()
-	if err != nil {
-		return err
-	}
-	result, err := s.Uninstall(ctx, opts)
-	if err != nil {
-		return err
-	}
-	for _, a := range result.Actions {
-		switch a.Action {
-		case "uninstalled":
-			if opts.DryRun {
-				fmt.Printf("uninstalled (dry-run): %s\n", a.Dir)
-			} else {
-				fmt.Printf("uninstalled: %s\n", a.Dir)
-			}
-		case "skipped":
-			fmt.Printf("skipped:     %s — %s\n", a.Dir, a.Message)
-		}
-	}
-	if opts.DryRun {
-		fmt.Println("[dry-run] no changes were made")
-	}
-	return nil
-}
-
-func skillsStatus(ctx context.Context, opts skillsmith.Options) error {
-	s, err := newSmith()
-	if err != nil {
-		return err
-	}
-	result, err := s.Status(ctx, opts)
-	if err != nil {
-		return err
-	}
-	for _, ss := range result.Skills {
-		switch {
-		case !ss.Installed:
-			fmt.Printf("%-30s not installed\n", ss.Dir)
-		case ss.MetadataError != nil:
-			fmt.Printf("%-30s installed (metadata unreadable: %v)\n", ss.Dir, ss.MetadataError)
-		case ss.UpToDate:
-			fmt.Printf("%-30s installed %s (up to date)\n", ss.Dir, ss.InstalledVersion)
-		default:
-			fmt.Printf("%-30s installed %s → available %s\n", ss.Dir, ss.InstalledVersion, ss.AvailableVersion)
-		}
-	}
-	return nil
-}
-
-func printCopyResult(result *skillsmith.CopyResult, verb string, dryRun bool) {
-	for _, a := range result.Actions {
-		switch a.Action {
-		case verb:
-			if dryRun {
-				fmt.Printf("%s (dry-run): %s\n", verb, a.Dir)
-			} else {
-				fmt.Printf("%s: %s\n", verb, a.Dir)
-			}
-		case "skipped":
-			fmt.Printf("skipped:   %s — %s\n", a.Dir, a.Message)
-		case "warned":
-			LogWarn("warning:   %s — %s", a.Dir, a.Message)
-		}
-	}
-	if dryRun {
-		fmt.Println("[dry-run] no changes were made")
-	}
+	return opts.Run(ctx, s)
 }

--- a/skills/ecspresso/SKILL.md
+++ b/skills/ecspresso/SKILL.md
@@ -1,3 +1,16 @@
+---
+name: ecspresso
+description: ECS deployment tool - deploy, manage, and troubleshoot ECS services
+license: MIT
+compatibility:
+  - claude
+  - codex
+  - agents
+allowed_tools:
+  - Bash
+  - Read
+---
+
 # ecspresso Skill for LLM Agents
 
 ## Overview

--- a/skillscmd/skillscmd.go
+++ b/skillscmd/skillscmd.go
@@ -1,0 +1,195 @@
+// Package skillscmd provides Kong-compatible command structs for skillsmith
+// integration. Embed [Commands] in a Kong CLI options struct to add a
+// "skills" subcommand.
+//
+// Usage:
+//
+//	type CLIOptions struct {
+//	    Skills *skillscmd.Commands `cmd:"" help:"manage agent skills"`
+//	}
+//
+// After Kong parsing, dispatch with:
+//
+//	smith, _ := skillsmith.New("mytool", version, skillsFS)
+//	err := opts.Skills.Run(ctx, smith)
+package skillscmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/Songmu/skillsmith"
+)
+
+// Commands defines Kong subcommands for skills management.
+type Commands struct {
+	List      *ListOption   `cmd:"" help:"list available skills"`
+	Install   *ModifyOption `cmd:"" help:"install skills"`
+	Update    *ModifyOption `cmd:"" help:"update installed skills"`
+	Reinstall *ModifyOption `cmd:"" help:"reinstall all managed skills"`
+	Uninstall *ModifyOption `cmd:"" help:"uninstall managed skills"`
+	Status    *StatusOption `cmd:"" help:"show installation status"`
+}
+
+// ListOption defines CLI options for the list subcommand.
+type ListOption struct{}
+
+// ModifyOption defines CLI options for install/update/reinstall/uninstall subcommands.
+type ModifyOption struct {
+	Scope  string `help:"install scope (user or repo)" default:"" enum:",user,repo"`
+	Prefix string `help:"override install directory" default:""`
+	DryRun bool   `help:"preview changes without applying" name:"dry-run" default:"false"`
+	Force  bool   `help:"overwrite unmanaged skills or force downgrade" default:"false"`
+}
+
+func (o *ModifyOption) options() skillsmith.Options {
+	return skillsmith.Options{
+		Scope:  o.Scope,
+		Prefix: o.Prefix,
+		DryRun: o.DryRun,
+		Force:  o.Force,
+	}
+}
+
+// StatusOption defines CLI options for the status subcommand.
+type StatusOption struct {
+	Scope  string `help:"install scope (user or repo)" default:"" enum:",user,repo"`
+	Prefix string `help:"override install directory" default:""`
+}
+
+func (o *StatusOption) options() skillsmith.Options {
+	return skillsmith.Options{
+		Scope:  o.Scope,
+		Prefix: o.Prefix,
+	}
+}
+
+// Run dispatches to the active subcommand based on which option is non-nil.
+func (c *Commands) Run(ctx context.Context, s *skillsmith.Smith) error {
+	switch {
+	case c.List != nil:
+		return runList(ctx, s)
+	case c.Install != nil:
+		return runInstall(ctx, s, c.Install.options())
+	case c.Update != nil:
+		return runUpdate(ctx, s, c.Update.options())
+	case c.Reinstall != nil:
+		return runReinstall(ctx, s, c.Reinstall.options())
+	case c.Uninstall != nil:
+		return runUninstall(ctx, s, c.Uninstall.options())
+	case c.Status != nil:
+		return runStatus(ctx, s, c.Status.options())
+	default:
+		return fmt.Errorf("unknown skills subcommand")
+	}
+}
+
+func runList(ctx context.Context, s *skillsmith.Smith) error {
+	skills, err := s.List(ctx)
+	if err != nil {
+		return err
+	}
+	if len(skills) == 0 {
+		fmt.Println("no skills found")
+		return nil
+	}
+	for _, sk := range skills {
+		if sk.Description != "" {
+			fmt.Printf("%-30s %s\n", sk.Dir, sk.Description)
+		} else {
+			fmt.Println(sk.Dir)
+		}
+	}
+	return nil
+}
+
+func runInstall(ctx context.Context, s *skillsmith.Smith, opts skillsmith.Options) error {
+	result, err := s.Install(ctx, opts)
+	if err != nil {
+		return err
+	}
+	printCopyResult(result, "installed", opts.DryRun)
+	return nil
+}
+
+func runUpdate(ctx context.Context, s *skillsmith.Smith, opts skillsmith.Options) error {
+	result, err := s.Update(ctx, opts)
+	if err != nil {
+		return err
+	}
+	printCopyResult(result, "updated", opts.DryRun)
+	return nil
+}
+
+func runReinstall(ctx context.Context, s *skillsmith.Smith, opts skillsmith.Options) error {
+	result, err := s.Reinstall(ctx, opts)
+	if err != nil {
+		return err
+	}
+	printCopyResult(result, "reinstalled", opts.DryRun)
+	return nil
+}
+
+func runUninstall(ctx context.Context, s *skillsmith.Smith, opts skillsmith.Options) error {
+	result, err := s.Uninstall(ctx, opts)
+	if err != nil {
+		return err
+	}
+	for _, a := range result.Actions {
+		switch a.Action {
+		case "uninstalled":
+			if opts.DryRun {
+				fmt.Printf("uninstalled (dry-run): %s\n", a.Dir)
+			} else {
+				fmt.Printf("uninstalled: %s\n", a.Dir)
+			}
+		case "skipped":
+			fmt.Printf("skipped:     %s — %s\n", a.Dir, a.Message)
+		}
+	}
+	if opts.DryRun {
+		fmt.Println("[dry-run] no changes were made")
+	}
+	return nil
+}
+
+func runStatus(ctx context.Context, s *skillsmith.Smith, opts skillsmith.Options) error {
+	result, err := s.Status(ctx, opts)
+	if err != nil {
+		return err
+	}
+	for _, ss := range result.Skills {
+		switch {
+		case !ss.Installed:
+			fmt.Printf("%-30s not installed\n", ss.Dir)
+		case ss.MetadataError != nil:
+			fmt.Printf("%-30s installed (metadata unreadable: %v)\n", ss.Dir, ss.MetadataError)
+		case ss.UpToDate:
+			fmt.Printf("%-30s installed %s (up to date)\n", ss.Dir, ss.InstalledVersion)
+		default:
+			fmt.Printf("%-30s installed %s → available %s\n", ss.Dir, ss.InstalledVersion, ss.AvailableVersion)
+		}
+	}
+	return nil
+}
+
+func printCopyResult(result *skillsmith.CopyResult, verb string, dryRun bool) {
+	for _, a := range result.Actions {
+		switch a.Action {
+		case verb:
+			if dryRun {
+				fmt.Printf("%s (dry-run): %s\n", verb, a.Dir)
+			} else {
+				fmt.Printf("%s: %s\n", verb, a.Dir)
+			}
+		case "skipped":
+			fmt.Printf("skipped:   %s — %s\n", a.Dir, a.Message)
+		case "warned":
+			fmt.Fprintf(os.Stderr, "warning:   %s — %s\n", a.Dir, a.Message)
+		}
+	}
+	if dryRun {
+		fmt.Println("[dry-run] no changes were made")
+	}
+}


### PR DESCRIPTION
## Summary

- Add `ecspresso skills` subcommand using [github.com/Songmu/skillsmith](https://github.com/Songmu/skillsmith) v0.1.0 for [Agent Skills](https://agentskills.io/) distribution
- Remove `docs --article=skill` in favor of the skills subcommand
- Move `skills/SKILL.md` to `skills/ecspresso/SKILL.md` with skillsmith-compatible YAML frontmatter
- Kong-integrated option structs in `skillscmd` sub-package for proper help display and flag parsing

Available operations:

```
ecspresso skills list
ecspresso skills install [--scope user|repo] [--prefix DIR] [--dry-run] [--force]
ecspresso skills update [--scope user|repo] [--prefix DIR] [--dry-run] [--force]
ecspresso skills reinstall [--scope user|repo] [--prefix DIR] [--dry-run] [--force]
ecspresso skills uninstall [--scope user|repo] [--prefix DIR] [--dry-run] [--force]
ecspresso skills status [--scope user|repo] [--prefix DIR]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)