### PR TITLE
Reduce binary size by disabling unused tfstate backends

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Set env
         run: |

--- a/.github/workflows/tagpr-release.yml
+++ b/.github/workflows/tagpr-release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
-          go-version: "1.25"
+          go-version: "1.26"
         if: ${{ steps.tagpr.outputs.tag != '' || github.event_name == 'workflow_dispatch' }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,6 +9,9 @@ builds:
       - CGO_ENABLED=0
     main: ./cmd/ecspresso/
     binary: ecspresso
+    tags:
+      - no_gcs
+      - no_azurerm
     ldflags:
       - -s -w
       - -X main.Version=v{{.Version}}

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ DATE := $(shell date +%Y-%m-%dT%H:%M:%S%z)
 .PHONY: test binary install clean
 
 cmd/ecspresso/ecspresso: *.go cmd/ecspresso/*.go go.* */*.go
-	cd cmd/ecspresso && go build -ldflags "-s -w -X main.Version=${GIT_VER} -X main.buildDate=${DATE}" -trimpath
+	cd cmd/ecspresso && go build -tags "no_gcs,no_azurerm" -ldflags "-s -w -X main.Version=${GIT_VER} -X main.buildDate=${DATE}" -trimpath
 
 install: cmd/ecspresso/ecspresso
 	install cmd/ecspresso/ecspresso `go env GOPATH`/bin/ecspresso

--- a/cli.go
+++ b/cli.go
@@ -22,27 +22,27 @@ type CLIOptions struct {
 	Color          bool              `help:"enable colorized output" env:"ECSPRESSO_COLOR" default:"true" negatable:""`
 	LogFormat      string            `help:"log format" env:"ECSPRESSO_LOG_FORMAT" default:"text" enum:"text,json"`
 
-	Appspec    *AppSpecOption    `cmd:"" help:"output AppSpec YAML for CodeDeploy to STDOUT"`
-	Delete     *DeleteOption     `cmd:"" help:"delete service"`
-	Deploy     *DeployOption     `cmd:"" help:"deploy service"`
-	Deregister *DeregisterOption `cmd:"" help:"deregister task definition"`
-	Diff       *DiffOption       `cmd:"" help:"show diff between task definition, service definition with current running service and task definition"`
-	Docs       *DocsOption       `cmd:"" help:"show documentation for ecspresso"`
-	Exec       *ExecOption       `cmd:"" help:"execute command on task"`
-	Init       *InitOption       `cmd:"" help:"create configuration files from existing ECS service"`
-	Refresh    *RefreshOption    `cmd:"" help:"refresh service. equivalent to deploy --skip-task-definition --force-new-deployment --no-update-service"`
-	Register   *RegisterOption   `cmd:"" help:"register task definition"`
-	Render     *RenderOption     `cmd:"" help:"render config, service definition or task definition file to STDOUT"`
-	Revisions  *RevisionsOption  `cmd:"" help:"show revisions of task definitions"`
-	Rollback   *RollbackOption   `cmd:"" help:"rollback service"`
-	Run        *RunOption        `cmd:"" help:"run task"`
-	Scale      *ScaleOption      `cmd:"" help:"scale service. equivalent to deploy --skip-task-definition --no-update-service"`
-	Status     *StatusOption     `cmd:"" help:"show status of service"`
-	Tasks      *TasksOption      `cmd:"" help:"list tasks that are in a service or having the same family"`
-	Verify     *VerifyOption     `cmd:"" help:"verify resources in configurations"`
-	Wait       *WaitOption       `cmd:"" help:"wait until service stable"`
+	Appspec    *AppSpecOption      `cmd:"" help:"output AppSpec YAML for CodeDeploy to STDOUT"`
+	Delete     *DeleteOption       `cmd:"" help:"delete service"`
+	Deploy     *DeployOption       `cmd:"" help:"deploy service"`
+	Deregister *DeregisterOption   `cmd:"" help:"deregister task definition"`
+	Diff       *DiffOption         `cmd:"" help:"show diff between task definition, service definition with current running service and task definition"`
+	Docs       *DocsOption         `cmd:"" help:"show documentation for ecspresso"`
+	Exec       *ExecOption         `cmd:"" help:"execute command on task"`
+	Init       *InitOption         `cmd:"" help:"create configuration files from existing ECS service"`
+	Refresh    *RefreshOption      `cmd:"" help:"refresh service. equivalent to deploy --skip-task-definition --force-new-deployment --no-update-service"`
+	Register   *RegisterOption     `cmd:"" help:"register task definition"`
+	Render     *RenderOption       `cmd:"" help:"render config, service definition or task definition file to STDOUT"`
+	Revisions  *RevisionsOption    `cmd:"" help:"show revisions of task definitions"`
+	Rollback   *RollbackOption     `cmd:"" help:"rollback service"`
+	Run        *RunOption          `cmd:"" help:"run task"`
+	Scale      *ScaleOption        `cmd:"" help:"scale service. equivalent to deploy --skip-task-definition --no-update-service"`
+	Status     *StatusOption       `cmd:"" help:"show status of service"`
+	Tasks      *TasksOption        `cmd:"" help:"list tasks that are in a service or having the same family"`
+	Verify     *VerifyOption       `cmd:"" help:"verify resources in configurations"`
+	Wait       *WaitOption         `cmd:"" help:"wait until service stable"`
 	Skills     *skillscmd.Commands `cmd:"" help:"manage agent skills"`
-	Version    struct{}          `cmd:"" help:"show version"`
+	Version    struct{}            `cmd:"" help:"show version"`
 }
 
 func (opt *CLIOptions) resolveConfigFilePath() (path string) {


### PR DESCRIPTION
## Summary
- Add `no_gcs` and `no_azurerm` build tags to Makefile and `.goreleaser.yml` to exclude GCS and Azure Blob Storage backends from tfstate-lookup
- These backends pull in cloud.google.com/go, Azure SDK, gRPC, protobuf, OpenTelemetry (~9MB) that are unnecessary for most AWS-focused users
- Binary size: 69MB → 60MB
- Bump release/nightly workflow Go version from 1.25 to 1.26

🤖 Generated with [Claude Code](https://claude.com/claude-code)