### PR TITLE
Improve error handling for GetLogEvents in run-task

### DIFF
--- a/ecspresso.go
+++ b/ecspresso.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/applicationautoscaling"
 	aasTypes "github.com/aws/aws-sdk-go-v2/service/applicationautoscaling/types"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	cwlTypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 	"github.com/aws/aws-sdk-go-v2/service/codedeploy"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
@@ -514,7 +515,11 @@ func (d *App) GetLogEvents(ctx context.Context, logGroup string, logStream strin
 	ms := startedAt.UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond))
 	out, err := d.cwl.GetLogEvents(ctx, d.GetLogEventsInput(logGroup, logStream, ms, nextToken))
 	if err != nil {
-		return nextToken, err
+		var notfound *cwlTypes.ResourceNotFoundException
+		if errors.As(err, &notfound) {
+			return nextToken, ErrNotFound(err.Error())
+		}
+		return nextToken, wrapPermissionError(err)
 	}
 	if len(out.Events) == 0 {
 		return nextToken, nil

--- a/run.go
+++ b/run.go
@@ -3,6 +3,7 @@ package ecspresso
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -203,13 +204,28 @@ func (d *App) WaitRunTask(ctx context.Context, task *types.Task, watchContainer 
 
 	go func() {
 		ticker := time.NewTicker(5 * time.Second)
+		defer ticker.Stop()
 		var nextToken *string
 		for {
 			select {
 			case <-waitCtx.Done():
 				return
 			case <-ticker.C:
-				nextToken, _ = d.GetLogEvents(waitCtx, logGroup, logStream, startedAt, nextToken)
+				token, err := d.GetLogEvents(waitCtx, logGroup, logStream, startedAt, nextToken)
+				if err != nil {
+					if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+						return
+					}
+					if errors.As(err, &errPermissionDenied) {
+						d.LogWarn("failed to get log events: check logs:GetLogEvents permission", "error", err.Error())
+						return
+					}
+					if !errors.As(err, &errNotFound) {
+						d.LogWarn("failed to get log events", "error", err.Error())
+					}
+					continue
+				}
+				nextToken = token
 			}
 		}
 	}()


### PR DESCRIPTION
- Warn on log retrieval failures instead of silent discard.
- Exit goroutine on permission errors to avoid redundant retries.
- Keep tailing if the log stream is not yet found.


---
`logs:GetLogEvents` 漏れでrun-task時にコンテナのログが流れていないということに気づけなかったのでログがあると嬉しいと思いました。