### PR TITLE
fix: preserve remote ServiceArn when updating service tags

### DIFF
--- a/deploy.go
+++ b/deploy.go
@@ -143,7 +143,9 @@ func (d *App) Deploy(ctx context.Context, opt DeployOption) error {
 			if opt.DryRun {
 				d.LogInfo("update service input", "input", MustMarshalJSONStringForAPI(svInput))
 			}
+			remoteServiceArn := sv.ServiceArn
 			sv = newSv // updated
+			sv.ServiceArn = remoteServiceArn
 		} else {
 			d.LogInfo("service attributes will not change")
 		}


### PR DESCRIPTION
## Summary                                            
                                                        
- When deploying, if service attributes differ, `sv` was replaced with the locally loaded `newSv`                                        
- `newSv` is loaded from the local service definition file and does not contain `ServiceArn`                
- This caused `TagResource` / `UntagResource` to fail with `missing required field, TagResourceInput.ResourceArn`                         
- Fix: save the remote `ServiceArn` before replacing `sv`, then restore it afterward
-  This appears to be a regression introduced in #978 
  
## Repro                                              
   
  1. Configure tags in the local service definition that
   differ from the remote service
  2. Run `ecspresso deploy`
  3. → `2026-04-21T23:07:08.429+09:00 [ERROR] FAILED. failed to tag service: operation error ECS: TagResource, 1 validation error(s) found. - missing required field, TagResourceInput.ResourceArn. `                  