### PR TITLE
fix: exec/tasks surface tasks not belonging to the configured service

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -53,6 +53,20 @@ func (d *App) NewEcsta(ctx context.Context) (*ecsta.Ecsta, error) {
 	return app, nil
 }
 
+// resolveEcstaFilters returns Family/Service filters for ecsta. When service is set,
+// Family is left nil; passing both makes ecsta union ListTasks(Family) with
+// ListTasks(ServiceName), so the result includes tasks that do not belong to the service.
+func (d *App) resolveEcstaFilters(ctx context.Context) (*string, *string, error) {
+	if d.config.Service != "" {
+		return nil, &d.config.Service, nil
+	}
+	f, err := d.taskDefinitionFamily(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &f, nil, nil
+}
+
 func (d *App) Exec(ctx context.Context, opt ExecOption) error {
 	// Do not call d.Start() because timeout disabled for exec.
 
@@ -60,13 +74,9 @@ func (d *App) Exec(ctx context.Context, opt ExecOption) error {
 	if err != nil {
 		return err
 	}
-	family, err := d.taskDefinitionFamily(ctx)
+	family, service, err := d.resolveEcstaFilters(ctx)
 	if err != nil {
 		return err
-	}
-	var service *string
-	if d.config.Service != "" {
-		service = &d.config.Service
 	}
 
 	switch {
@@ -78,7 +88,7 @@ func (d *App) Exec(ctx context.Context, opt ExecOption) error {
 			Progress:  opt.Cp.Progress,
 			ID:        opt.ID,
 			Container: opt.Container,
-			Family:    &family,
+			Family:    family,
 			Service:   service,
 		})
 	case opt.Portforward != nil:
@@ -89,7 +99,7 @@ func (d *App) Exec(ctx context.Context, opt ExecOption) error {
 			RemotePort: opt.Portforward.Port,
 			RemoteHost: opt.Portforward.Host,
 			L:          opt.Portforward.L,
-			Family:     &family,
+			Family:     family,
 			Service:    service,
 		})
 	case opt.Run != nil:
@@ -104,7 +114,7 @@ func (d *App) Exec(ctx context.Context, opt ExecOption) error {
 				RemotePort: run.Port,
 				RemoteHost: run.Host,
 				L:          run.L,
-				Family:     &family,
+				Family:     family,
 				Service:    service,
 			})
 		default:
@@ -112,7 +122,7 @@ func (d *App) Exec(ctx context.Context, opt ExecOption) error {
 				ID:        opt.ID,
 				Command:   run.Command,
 				Container: opt.Container,
-				Family:    &family,
+				Family:    family,
 				Service:   service,
 			})
 		}

--- a/exec_test.go
+++ b/exec_test.go
@@ -1,0 +1,51 @@
+package ecspresso_test
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/google/go-cmp/cmp"
+	"github.com/kayac/ecspresso/v2"
+)
+
+func TestResolveEcstaFilters(t *testing.T) {
+	tests := []struct {
+		name            string
+		config          string
+		expectedFamily  *string
+		expectedService *string
+	}{
+		{
+			name:            "when service is configured, family is nil",
+			config:          "tests/run-with-sv.yaml",
+			expectedFamily:  nil,
+			expectedService: aws.String("test"),
+		},
+		{
+			name:            "when service is empty, family is loaded from task definition",
+			config:          "tests/run-without-sv.yaml",
+			expectedFamily:  aws.String("katsubushi"),
+			expectedService: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			app, err := ecspresso.New(ctx, &ecspresso.CLIOptions{ConfigFilePath: tt.config})
+			if err != nil {
+				t.Fatal(err)
+			}
+			family, service, err := app.ResolveEcstaFilters(ctx)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if diff := cmp.Diff(tt.expectedFamily, family); diff != "" {
+				t.Errorf("family mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tt.expectedService, service); diff != "" {
+				t.Errorf("service mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/export_test.go
+++ b/export_test.go
@@ -67,6 +67,10 @@ func (d *App) ResolveTaskDefinitionForRun(ctx context.Context, opt RunOption) (*
 	return d.resolveTaskDefinitionForRun(ctx, opt)
 }
 
+func (d *App) ResolveEcstaFilters(ctx context.Context) (*string, *string, error) {
+	return d.resolveEcstaFilters(ctx)
+}
+
 func (opt *DiffOption) SetWriter(w io.Writer) {
 	opt.w = w
 }

--- a/tasks.go
+++ b/tasks.go
@@ -59,34 +59,30 @@ func (d *App) Tasks(ctx context.Context, opt TasksOption) error {
 	}
 	ecstaApp.Config.Set("output", opt.Output)
 
-	family, err := d.taskDefinitionFamily(ctx)
+	family, service, err := d.resolveEcstaFilters(ctx)
 	if err != nil {
 		return err
-	}
-	var service *string
-	if d.config.Service != "" {
-		service = &d.config.Service
 	}
 
 	switch {
 	case opt.Find != nil:
 		return ecstaApp.RunDescribe(ctx, &ecsta.DescribeOption{
 			ID:      opt.taskID(),
-			Family:  &family,
+			Family:  family,
 			Service: service,
 		})
 	case opt.Stop != nil:
 		return ecstaApp.RunStop(ctx, &ecsta.StopOption{
 			ID:      opt.taskID(),
 			Force:   opt.Stop.Force,
-			Family:  &family,
+			Family:  family,
 			Service: service,
 		})
 	case opt.Trace != nil:
 		return ecstaApp.RunTrace(ctx, &ecsta.TraceOption{
 			ID:       opt.taskID(),
 			Duration: time.Minute,
-			Family:   &family,
+			Family:   family,
 			Service:  service,
 		})
 	case opt.Logs != nil:
@@ -96,7 +92,7 @@ func (d *App) Tasks(ctx context.Context, opt TasksOption) error {
 			Duration:  opt.Logs.Duration,
 			StartTime: opt.Logs.StartTime,
 			Container: opt.Logs.Container,
-			Family:    &family,
+			Family:    family,
 			Service:   service,
 			JSON:      logFormat == logFormatJSON,
 		})
@@ -107,7 +103,7 @@ func (d *App) Tasks(ctx context.Context, opt TasksOption) error {
 			LogWarn("--find flag is deprecated, use 'tasks find' subcommand instead")
 			return ecstaApp.RunDescribe(ctx, &ecsta.DescribeOption{
 				ID:      opt.taskID(),
-				Family:  &family,
+				Family:  family,
 				Service: service,
 			})
 		case list.DeprecatedStop:
@@ -115,7 +111,7 @@ func (d *App) Tasks(ctx context.Context, opt TasksOption) error {
 			return ecstaApp.RunStop(ctx, &ecsta.StopOption{
 				ID:      opt.taskID(),
 				Force:   list.DeprecatedForce,
-				Family:  &family,
+				Family:  family,
 				Service: service,
 			})
 		case list.DeprecatedTrace:
@@ -123,12 +119,12 @@ func (d *App) Tasks(ctx context.Context, opt TasksOption) error {
 			return ecstaApp.RunTrace(ctx, &ecsta.TraceOption{
 				ID:       opt.taskID(),
 				Duration: time.Minute,
-				Family:   &family,
+				Family:   family,
 				Service:  service,
 			})
 		default:
 			return ecstaApp.RunList(ctx, &ecsta.ListOption{
-				Family:  &family,
+				Family:  family,
 				Service: service,
 			})
 		}


### PR DESCRIPTION
close #1000

Skip the Family filter when `service` is set in config, so `ecspresso exec` and `ecspresso tasks <list|find|stop|trace|logs>` no longer return tasks belonging to other services that share the same task definition family.

## Test at my cluster

### Before

Included another service's task(service:b-railsc)

```console
[ec2-user@ip-xxx ~]$ cat config.yaml
region: ap-northeast-1
cluster: my-cluster
service: a-railsc
[ec2-user@ip-xxx ~]$ ecspresso tasks list --config config.yaml
2026-04-27T09:56:53.385Z [INFO] ecspresso version [version:v2.8.2]
|                ID                |    TASK DEFINITION    | INSTANCE | LAST STATUS | DESIRED STATUS |      CREATED AT      |            GROUP            |  TYPE   |
+----------------------------------+-----------------------+----------+-------------+----------------+----------------------+-----------------------------+---------+
| bf81...                          | railsc:104            |          | RUNNING     | RUNNING        | 2026-04-27T02:41:00Z | service:a-railsc            | FARGATE |
| efc4...                          | railsc:103            |          | RUNNING     | RUNNING        | 2026-04-24T07:11:42Z | service:b-railsc            | FARGATE |
```

### After

Only include service:a-railsc 's tasks.

```console
[ec2-user@ip-xxx ~]$ cat config.yaml
region: ap-northeast-1
cluster: my-cluster
service: a-railsc
[ec2-user@ip-xxx ~]$ ./ecspresso-patched tasks list --config config.yaml
2026-04-27T10:04:27.726Z [INFO] ecspresso version [version:]
|                ID                |    TASK DEFINITION    | INSTANCE | LAST STATUS | DESIRED STATUS |      CREATED AT      |            GROUP            |  TYPE   |
+----------------------------------+-----------------------+----------+-------------+----------------+----------------------+-----------------------------+---------+
| bf81...                          | railsc:104            |          | RUNNING     | RUNNING        | 2026-04-27T02:41:00Z | service:a-railsc            | FARGATE |
```
