### PR TITLE
fix: handle unexpected response from /releases API in install script

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,11 @@ runs:
         fi
         if [ "${VERSION}" = "latest" ]; then
           DOWNLOAD_URL=$(curl "${api_request_args[@]}" https://api.github.com/repos/kayac/ecspresso/releases \
-            | jq --arg matcher "linux.${GOARCH}." -r '[.[]|select(.tag_name > "v2.0")|select(.prerelease==false)][0].assets[].browser_download_url|select(match($matcher))')
+            | jq --arg matcher "linux.${GOARCH}." -r '[.[]?|select(.tag_name? > "v2.0")|select(.prerelease==false)][0].assets[]?.browser_download_url|select(match($matcher))')
+          if [ -z "${DOWNLOAD_URL}" ]; then
+            echo "Unexpected response from /releases API"
+            exit 1
+          fi
         else
           DOWNLOAD_URL=https://github.com/kayac/ecspresso/releases/download/${VERSION}/ecspresso_${VERSION:1}_linux_${GOARCH}.tar.gz
         fi


### PR DESCRIPTION
## Summary

- When [`version: latest`](https://github.com/kayac/ecspresso/blob/9a538ad129de7fe504808baf100707a8f3366c29/action.yml#L46-L48), if `/releases` API returns an unexpected response (e.g. an empty array `[\n\n]\n`, or a non-array shape), the `[...][0].assets[]` jq filter fails with `Cannot iterate over null`, which does not surface that the API response itself was the problem
- Validate the response shape explicitly and exit with `Unexpected response from /releases API` instead

```
BEFORE:

VERSION=latest GOARCH=arm64
jq: error (at <stdin>:3): Cannot iterate over null (null)
Process completed with exit code 5.
```
```
AFTER:

VERSION=latest GOARCH=arm64
Unexpected response from /releases API
Process completed with exit code 1.
```