### PR TITLE
Bump fujiwara/ecsta to v0.8.2 (fix #1000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1147,7 +1147,7 @@ Consider using ecsta as a CLI command.
 
 #### tasks
 
-The `tasks` command lists tasks run by a service or having the same family to a task definition.
+The `tasks` command lists tasks related to the ecspresso configuration. When `service` is configured, it lists tasks belonging to the service plus standalone tasks of the same family (typically launched by `ecspresso run`). Tasks of other services that share the task definition family are excluded. When `service` is not configured, it lists tasks of the task definition family.
 
 ```
 Usage: ecspresso tasks <command> [flags]

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/aws/smithy-go v1.25.0
 	github.com/fatih/color v1.19.0
 	github.com/fujiwara/cfn-lookup v1.1.0
-	github.com/fujiwara/ecsta v0.8.1
+	github.com/fujiwara/ecsta v0.8.2
 	github.com/fujiwara/sloghandler v0.1.0
 	github.com/fujiwara/ssm-lookup v0.1.1
 	github.com/fujiwara/tfstate-lookup v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -188,8 +188,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fujiwara/cfn-lookup v1.1.0 h1:wNjMituD/n8XAhBw+L3uqtDCnWr1nrAI7T/YATMwl9A=
 github.com/fujiwara/cfn-lookup v1.1.0/go.mod h1:yQiC+G7sSTRTic6E8RKv1G36tp+y2Q/9BT6QMQT4yyw=
-github.com/fujiwara/ecsta v0.8.1 h1:PsTM5Gnz/xBzJy5bJvlPOXbol/fItmA0ymDn+PVu69c=
-github.com/fujiwara/ecsta v0.8.1/go.mod h1:tSPr0SJhaB2gUbXlN6CAU8UVxFlp6tkSXPtp37hhdes=
+github.com/fujiwara/ecsta v0.8.2 h1:A4+7PYEv8pG6dbhucnOQDKwNi5OXNMtZYMNGFhSbZGc=
+github.com/fujiwara/ecsta v0.8.2/go.mod h1:tSPr0SJhaB2gUbXlN6CAU8UVxFlp6tkSXPtp37hhdes=
 github.com/fujiwara/sloghandler v0.1.0 h1:4uxE5z01fKv/qzUoIyYk/2H1D4xEb/wi2K/Wks9z5Tg=
 github.com/fujiwara/sloghandler v0.1.0/go.mod h1:9wl7zZ1fO53Gl83/M8KFYW+5iACiwXAltOL5REOUd24=
 github.com/fujiwara/ssm-lookup v0.1.1 h1:Cwx7Y6A0HbIKyAzS60DYcf/TZ5KZHY/vTlCtUoythfQ=


### PR DESCRIPTION
## Summary

Bumps `github.com/fujiwara/ecsta` from v0.8.1 to v0.8.2 to pick up [fujiwara/ecsta#119](https://github.com/fujiwara/ecsta/pull/119), which fixes the task list filter used by the `exec` and `tasks` commands.

When `service` is configured, ecspresso passes both `Family` and `Service` to ecsta. Previously ecsta unioned the two ListTasks calls, so tasks of sibling services sharing the task definition family were surfaced. ecsta v0.8.2 now lists by family and post-filters: tasks belonging to the configured service and standalone tasks (e.g. those launched by `ecspresso run`) of the same family are kept; tasks of other services are excluded.

Fixes #1000.

## Notes

This is a behavioral change for users who relied on the previous behavior where `exec` / `tasks` from one service's config could reach tasks of a sibling service that shared the task definition family. After this change, those sibling-service tasks are no longer listed; switch to that service's config to operate on them.

The README description of the `tasks` command is updated to match the new behavior.

## Test plan

- [ ] In a cluster with two services (`myapp-a`, `myapp-b`) sharing family `myapp`, run `ecspresso tasks list` with `service: myapp-a` and confirm only `myapp-a` tasks appear.
- [ ] Run `ecspresso run` against the same family, then `ecspresso tasks list` and confirm the standalone task is still listed.
- [ ] Run `ecspresso exec` and confirm the candidate list excludes `myapp-b` tasks.