### PR TITLE
fix: surface non-2xx errors from /releases API in install script

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ runs:
       env:
         github_token: ${{ inputs.github-token }}
       run: |
-        set -e
+        set -eo pipefail
         ARCH=$(uname -m)
         if [ "${ARCH}" = "x86_64" ]; then
           GOARCH="amd64"
@@ -39,7 +39,7 @@ runs:
 
         echo "VERSION=${VERSION} GOARCH=${GOARCH}"
 
-        api_request_args=("-sS")
+        api_request_args=("-sS" "--fail-with-body")
         if [[ -n "$github_token" ]]; then
           api_request_args=("${api_request_args[@]}" -H "authorization: token $github_token")
         fi
@@ -47,7 +47,7 @@ runs:
           DOWNLOAD_URL=$(curl "${api_request_args[@]}" https://api.github.com/repos/kayac/ecspresso/releases \
             | jq --arg matcher "linux.${GOARCH}." -r '[.[]?|select(.tag_name? > "v2.0")|select(.prerelease==false)][0].assets[]?.browser_download_url|select(match($matcher))')
           if [ -z "${DOWNLOAD_URL}" ]; then
-            echo "Unexpected response from /releases API"
+            echo "No matching release asset found for linux/${GOARCH}"
             exit 1
           fi
         else


### PR DESCRIPTION
## Summary

Follow-up to #1002. When the install script's `version: latest` path hits a non-2xx response from the GitHub `/releases` API (rate limit, auth failure, etc.), the error was previously masked because curl's stderr message gave no status and the empty body went through jq successfully, resulting in the generic `Unexpected response from /releases API`.

- Add `--fail-with-body` to curl so non-2xx responses fail the command while still printing the response body (so messages like `API rate limit exceeded for ...` are visible).
- Add `set -o pipefail` so curl's failure is not swallowed by the downstream `jq`.
- Reword the empty-`DOWNLOAD_URL` message to `No matching release asset found for linux/${GOARCH}`, which is now the only case that branch covers (API returned 2xx but no asset matched).

### Output examples

Rate limit:
```
curl: (22) The requested URL returned error: 403
{"message":"API rate limit exceeded for ...","documentation_url":"..."}
```

No matching asset (2xx but empty / unexpected shape):
```
No matching release asset found for linux/arm64
```