### PR TITLE
fix: skip draft releases when resolving latest in install script

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,7 @@ runs:
         fi
         if [ "${VERSION}" = "latest" ]; then
           DOWNLOAD_URL=$(curl "${api_request_args[@]}" https://api.github.com/repos/kayac/ecspresso/releases \
-            | jq --arg matcher "linux.${GOARCH}." -r '[.[]?|select(.tag_name? > "v2.0")|select(.prerelease==false)][0].assets[]?.browser_download_url|select(match($matcher))')
+            | jq --arg matcher "linux.${GOARCH}." -r '[.[]?|select(.tag_name? > "v2.0")|select(.draft==false)|select(.prerelease==false)][0].assets[]?.browser_download_url|select(match($matcher))')
           if [ -z "${DOWNLOAD_URL}" ]; then
             echo "No matching release asset found for linux/${GOARCH}"
             exit 1


### PR DESCRIPTION
## Summary

When a new draft release exists (e.g. just after `tagpr` creates one but before assets are uploaded), `version: latest` fails with `No matching release asset found for linux/...`.

The `/releases` API returns draft releases too, sorted by creation date, and the existing jq filter only excluded `prerelease`, not `draft`. The freshly-created draft (with a `tag_name` but an empty `assets` array) was therefore selected as the latest release.

Add `select(.draft==false)` to the filter so drafts are skipped.