### PR TITLE
Expose plugin runtime instances via App.PluginInstance

### DIFF
--- a/config.go
+++ b/config.go
@@ -71,6 +71,20 @@ type Config struct {
 	dir                string
 	versionConstraints goVersion.Constraints
 	awsv2Config        aws.Config
+
+	// pluginInstances records the runtime instance each plugin's Setup
+	// produces, when the plugin has something callers may want to access
+	// after setup. Currently only the tfstate plugin uses this (storing
+	// its *tfstate.TFState so callers can inject overrides via
+	// App.TFState). Other plugins resolve at template-render time and
+	// register nothing here.
+	pluginInstances []pluginInstance
+}
+
+type pluginInstance struct {
+	name       string
+	funcPrefix string
+	value      any
 }
 
 type ConfigCodeDeploy struct {

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -256,6 +256,24 @@ func (d *App) Config() *Config {
 	return d.config
 }
 
+// PluginInstance returns the runtime instance produced by the named
+// plugin during Setup, identified by funcPrefix (pass "" for the
+// default prefix). The concrete type depends on the plugin: for example
+// the "tfstate" plugin returns *tfstate.TFState, which callers can
+// type-assert to call SetOverrides on. Returns nil if no matching
+// plugin is configured.
+func (d *App) PluginInstance(name, funcPrefix string) any {
+	if d.config == nil {
+		return nil
+	}
+	for _, inst := range d.config.pluginInstances {
+		if inst.name == name && inst.funcPrefix == funcPrefix {
+			return inst.value
+		}
+	}
+	return nil
+}
+
 func (d *App) Timeout() time.Duration {
 	return d.config.Timeout.Duration
 }

--- a/plugin.go
+++ b/plugin.go
@@ -101,17 +101,20 @@ func setupPluginTFState(ctx context.Context, p ConfigPlugin, c *Config) error {
 		return errors.New("tfstate plugin requires path or url for tfstate location")
 	}
 
-	lookup, err := tfstate.ReadURL(ctx, loc)
+	state, err := tfstate.ReadURL(ctx, loc)
 	if err != nil {
 		return err
 	}
-	if err := p.AppendFuncMap(c, lookup.FuncMap(ctx)); err != nil {
+	c.pluginInstances = append(c.pluginInstances, pluginInstance{
+		name:       "tfstate",
+		funcPrefix: p.FuncPrefix,
+		value:      state,
+	})
+
+	if err := p.AppendFuncMap(c, state.FuncMap(ctx)); err != nil {
 		return err
 	}
-	if err := p.AppendJsonnetNativeFuncs(c, lookup.JsonnetNativeFuncs(ctx)); err != nil {
-		return err
-	}
-	return nil
+	return p.AppendJsonnetNativeFuncs(c, state.JsonnetNativeFuncs(ctx))
 }
 
 func setupPluginCFn(ctx context.Context, p ConfigPlugin, c *Config) error {


### PR DESCRIPTION
## Summary

Add a generic mechanism for callers to access the runtime objects that plugins produce during `Setup`, so external orchestrators can interact with them after `ecspresso.New` returns.

- `Config.pluginInstances` (`[]pluginInstance{name, funcPrefix, value any}`) — set during `Setup`, intended for plugins that produce something callers may want to touch later.
- `App.PluginInstance(name, funcPrefix string) any` — accessor. Returns `nil` if no matching plugin is configured. Caller type-asserts the result.
- `setupPluginTFState` is the only registrant today: it stores its `*tfstate.TFState` so callers can, for example, push value overrides via `SetOverrides` (added to `tfstate-lookup` in v1.12.0).

Generic on purpose — the same registry shape works if future plugins (ssm, cloudformation, …) need post-Setup access. Other plugins continue to resolve at template-render time and register nothing.

## Why

Used by [terraform-provider-ecspresso](https://github.com/fujiwara/terraform-provider-ecspresso) to inject Terraform-resolved values into tfstate lookups, bypassing the "tfstate file is one apply behind" problem on initial bootstrap. The provider needs a way to push fresh values into the tfstate plugin's lookup table after `ecspresso.New` returns; this PR exposes the minimal hook required.

Backward compatible: no public API removed or changed, no behavior change for existing CLI / library users.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` passes