### PR TITLE
Embed Version in source via tagpr versionFile

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,7 +14,7 @@ builds:
       - no_azurerm
     ldflags:
       - -s -w
-      - -X main.Version=v{{.Version}}
+      - -X github.com/kayac/ecspresso/v2.Version=v{{.Version}}
     goos:
       - darwin
       - linux

--- a/.tagpr
+++ b/.tagpr
@@ -45,5 +45,5 @@
 [tagpr]
 	vPrefix = true
 	releaseBranch = v2
-	versionFile = -
+	versionFile = version.go
 	release = draft

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ DATE := $(shell date +%Y-%m-%dT%H:%M:%S%z)
 .PHONY: test binary install clean
 
 cmd/ecspresso/ecspresso: *.go cmd/ecspresso/*.go go.* */*.go
-	cd cmd/ecspresso && go build -tags "no_gcs,no_azurerm" -ldflags "-s -w -X main.Version=${GIT_VER} -X main.buildDate=${DATE}" -trimpath
+	cd cmd/ecspresso && go build -tags "no_gcs,no_azurerm" -ldflags "-s -w -X github.com/kayac/ecspresso/v2.Version=${GIT_VER}" -trimpath
 
 install: cmd/ecspresso/ecspresso
 	install cmd/ecspresso/ecspresso `go env GOPATH`/bin/ecspresso

--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -9,10 +9,7 @@ import (
 	"github.com/kayac/ecspresso/v2"
 )
 
-var Version string
-
 func main() {
-	ecspresso.Version = Version
 	ctx, stop := signal.NotifyContext(context.Background(), trapSignals...)
 	defer stop()
 

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -35,7 +35,6 @@ const DefaultDesiredCount = -1
 const DefaultConfigFilePath = "ecspresso.yml"
 const dryRunStr = "DRY RUN"
 
-var Version string
 var delayForServiceChanged = 3 * time.Second
 var refreshInterval = 10 * time.Second
 var waiterMaxDelay = 15 * time.Second

--- a/version.go
+++ b/version.go
@@ -1,0 +1,4 @@
+package ecspresso
+
+// Version is the released version of ecspresso. Managed by tagpr.
+var Version = "v2.8.4"


### PR DESCRIPTION
## Summary
- Move `Version` from `cmd/ecspresso` (ldflags-only) into the `ecspresso` package as a tagpr-managed value in `version.go`, so library users see the released version instead of an empty string.
- Update `.tagpr` to point `versionFile` at `version.go`. The variable holds `vX.Y.Z` — tagpr's rewriter preserves the `v` prefix on bump.
- Adjust `Makefile` and `.goreleaser.yml` ldflags to target `github.com/kayac/ecspresso/v2.Version` so dev/release builds still embed git describe info.

## Test plan
- [x] `go test ./...`
- [x] CLI built via `make`: `ecspresso version` prints `ecspresso v2.8.4+nightly-...`
- [x] Library: `ecspresso.Version` returns `v2.8.4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)