### PR TITLE
Allow tfstate / cfn / ssm in top-level config fields across all formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ ecspresso also supports ECS Express mode for simplified deployments and provides
 - [Usage](#usage)
 - [Quick Start](#quick-start)
 - [Configuration file](#configuration-file)
+  - [Plugin functions in top-level fields](#plugin-functions-in-top-level-fields)
 - [Template syntax](#template-syntax)
 - [Deployment](#example-of-deployment)
   - [Rolling deployment](#rolling-deployment)
@@ -354,6 +355,61 @@ ignore:
 - Wait for the service to be stable.
 
 Configuration files and task/service definition files are read by [go-config](https://github.com/kayac/go-config) which provides template functions `env`, `must_env` and `json_escape`.
+
+### Plugin functions in top-level fields
+
+Plugin-provided functions (`tfstate`, `cfn` / `cloudformation`, `ssm`, `secretsmanager`) can be used in top-level configuration fields such as `cluster`, `service`, and `region`, not only inside task / service definitions. This is typically useful when ECS clusters are managed by Terraform:
+
+```yaml
+region: ap-northeast-1
+cluster: "{{ tfstate `aws_ecs_cluster.main.name` }}"
+service: myservice
+service_definition: ecs-service-def.json
+task_definition: ecs-task-def.json
+plugins:
+  - name: tfstate
+    config:
+      path: terraform.tfstate
+```
+
+```jsonnet
+local tfstate = std.native('tfstate');
+{
+  region: 'ap-northeast-1',
+  cluster: tfstate('aws_ecs_cluster.main.name'),
+  service: 'myservice',
+  service_definition: 'ecs-service-def.jsonnet',
+  task_definition: 'ecs-task-def.jsonnet',
+  plugins: [
+    { name: 'tfstate', config: { path: 'terraform.tfstate' } },
+  ],
+}
+```
+
+To make this work, ecspresso loads the configuration file in two passes:
+
+1. Extract only the `plugins` (and `region`) section, then run plugin setup.
+2. Re-read the whole file with plugin-provided template / Jsonnet functions registered.
+
+Notes and limitations:
+
+- The `plugins` block itself cannot reference plugin functions — that would be a chicken-and-egg loop. Use `env` / `must_env` there instead.
+- If `region` itself is resolved from a plugin function that needs AWS access (e.g. `ssm`, `cfn`), the AWS client for plugin setup falls back to the `AWS_REGION` environment variable.
+
+> [!IMPORTANT]
+> **Breaking change in v3 (not compatible with v2)**: the YAML configuration file must be valid YAML on its own — i.e. before template rendering. In particular, template literals that begin a scalar must be quoted, because YAML parses an unquoted leading `{` as a flow-mapping opener.
+>
+> v2 template-rendered the whole file first and parsed YAML afterwards, which silently tolerated unquoted `{{ ... }}` at the start of a scalar. v3 reads the raw file with a YAML parser in pass 1 to extract `plugins`, so this no longer works.
+>
+> ```yaml
+> # NG in v3 (worked in v2): YAML treats leading `{` as a flow-mapping opener
+> region: {{ must_env `AWS_REGION` }}
+>
+> # OK: quote the scalar
+> region: "{{ must_env `AWS_REGION` }}"
+> ```
+>
+> JSON and Jsonnet configurations are unaffected. Existing v2 YAML configs that already quote their template literals (the common case) continue to work without changes.
 
 ## Template syntax
 

--- a/config.go
+++ b/config.go
@@ -1,10 +1,13 @@
 package ecspresso
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"text/template"
 	"time"
 
@@ -13,6 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/goccy/go-yaml"
 	"github.com/google/go-jsonnet"
 	goVersion "github.com/hashicorp/go-version"
 	"github.com/kayac/ecspresso/v2/appspec"
@@ -79,6 +83,27 @@ type Config struct {
 	// App.TFState). Other plugins resolve at template-render time and
 	// register nothing here.
 	pluginInstances []pluginInstance
+
+	// pluginsConfigured is set once plugin Setup has run. The config
+	// loader runs a two-pass evaluation so that the tfstate / cfn / ssm
+	// jsonnet native functions and template funcs declared by plugins
+	// are available throughout the config (not just in task and service
+	// definitions): pass 1 extracts only the `plugins` field, plugin
+	// Setup runs, then pass 2 re-reads the whole file with plugin funcs
+	// available. This flag tells Restrict to skip a second setup.
+	pluginsConfigured bool
+}
+
+// pluginsOnly is used by extractPlugins to peel just the plugins
+// section (plus the region literal) off a YAML / JSON config. Other
+// fields are silently dropped — they may reference plugin-provided
+// functions that are not yet available on the first pass. Region is
+// pulled out so AWS-dependent plugins (ssm / secretsmanager / cfn)
+// are initialised against the region configured in the file, not the
+// AWS_REGION env fallback.
+type pluginsOnly struct {
+	Plugins []ConfigPlugin `yaml:"plugins" json:"plugins"`
+	Region  string         `yaml:"region" json:"region"`
 }
 
 type pluginInstance struct {
@@ -94,9 +119,49 @@ type ConfigCodeDeploy struct {
 }
 
 // Load loads configuration file from file path.
+//
+// Loading runs in two passes so that the tfstate / cfn / ssm functions
+// declared by plugins are available throughout the config (not just in
+// task / service definitions):
+//
+//  1. extractPlugins pulls just the `plugins` section out of the file
+//     in a format-appropriate way (lazy field eval for jsonnet, raw
+//     unmarshal for YAML / JSON). The result is template-rendered with
+//     the default funcs (env, must_env) and decoded into []ConfigPlugin.
+//  2. prepareAWSAndPlugins loads AWS config and runs plugin Setup, which
+//     registers each plugin's template funcs and jsonnet native funcs.
+//     The loader carries them onto its shared template loader and VM
+//     before the full file is re-read.
+//
+// The `plugins` section itself cannot reference plugin-provided
+// functions — that would be a chicken-and-egg loop.
 func (l *configLoader) Load(ctx context.Context, path string, version string) (*Config, error) {
 	conf := &Config{path: path}
 	ext := filepath.Ext(path)
+	switch ext {
+	case ymlExt, yamlExt, jsonExt, jsonnetExt:
+		// supported; continue.
+	default:
+		return nil, fmt.Errorf("unsupported config file extension: %s", ext)
+	}
+
+	// Pass 1.
+	plugins, region, err := l.extractPlugins(path, ext)
+	if err != nil {
+		return nil, err
+	}
+	pre := &Config{path: path, dir: filepath.Dir(path), Plugins: plugins, Region: region}
+	if err := pre.prepareAWSAndPlugins(ctx); err != nil {
+		return nil, err
+	}
+	for _, f := range pre.jsonnetNativeFuncs {
+		l.VM.NativeFunction(f)
+	}
+	for _, f := range pre.templateFuncs {
+		l.Funcs(f)
+	}
+
+	// Pass 2.
 	switch ext {
 	case ymlExt, yamlExt:
 		b, err := l.ReadWithEnv(path)
@@ -118,9 +183,15 @@ func (l *configLoader) Load(ctx context.Context, path string, version string) (*
 		if err := unmarshalJSON(b, conf, path); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal json: %w", err)
 		}
-	default:
-		return nil, fmt.Errorf("unsupported config file extension: %s", ext)
 	}
+
+	// Carry the pre-setup state into the final Config so Restrict does
+	// not re-run plugin setup.
+	conf.awsv2Config = pre.awsv2Config
+	conf.pluginInstances = pre.pluginInstances
+	conf.templateFuncs = pre.templateFuncs
+	conf.jsonnetNativeFuncs = pre.jsonnetNativeFuncs
+	conf.pluginsConfigured = true
 
 	conf.dir = filepath.Dir(path)
 	if err := conf.Restrict(ctx); err != nil {
@@ -129,13 +200,131 @@ func (l *configLoader) Load(ctx context.Context, path string, version string) (*
 	if err := conf.ValidateVersion(version); err != nil {
 		return nil, err
 	}
-	for _, f := range conf.templateFuncs {
-		l.Funcs(f)
-	}
-	for _, f := range conf.jsonnetNativeFuncs {
-		l.VM.NativeFunction(f)
-	}
 	return conf, nil
+}
+
+// extractPlugins returns the parsed `plugins` section of a config file
+// plus a best-effort `region` value, with `{{ env / must_env }}` template
+// literals expanded. The rest of the config is dropped — it may
+// reference plugin-provided functions that have not been set up yet.
+//
+// The shape per format is:
+//
+//   - jsonnet: `(import "<abs-path>").plugins` (and `.region`) —
+//     jsonnet evaluates object fields lazily, so `tfstate()` calls in
+//     `cluster` etc. are not reached. Region is extracted separately
+//     so a `region: tfstate(...)` expression failing to evaluate does
+//     not lose the plugin list.
+//   - JSON: jsonnet VM evaluates the file (.json is a jsonnet subset
+//     with no native-function calls in pure JSON), then plain
+//     json.Unmarshal into pluginsOnly{} drops every other field. Any
+//     `{{ tfstate ... }}` template literals in those dropped fields
+//     never reach the template engine.
+//   - YAML: yaml.YAMLToJSON + json.Unmarshal into pluginsOnly{}
+//     (matches the main config loader's YAML→JSON→struct flow).
+//     Template literals everywhere except the plugins / region fields
+//     are dropped before template rendering sees them.
+//
+// Plugins and region strings are then template-rendered through the
+// default funcs (env / must_env). Per-field rendering (rather than
+// JSON / YAML marshal round-tripping) avoids the marshaler's quote-
+// escape trap — `{{ env "FOO" }}` would otherwise be serialised as
+// `\"FOO\"` and break the Go template parser.
+//
+// If the extracted region cannot be rendered with the default funcs
+// (typically because it references a plugin-provided function), the
+// returned region is empty and prepareAWSAndPlugins falls back to the
+// AWS_REGION env var. The chicken-and-egg case (`region: tfstate(...)`
+// combined with cfn / ssm plugins) is documented as a limitation.
+func (l *configLoader) extractPlugins(path, ext string) ([]ConfigPlugin, string, error) {
+	var po pluginsOnly
+	switch ext {
+	case jsonnetExt:
+		absPath, err := filepath.Abs(path)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to resolve config path: %w", err)
+		}
+		pluginsOut, err := l.VM.EvaluateAnonymousSnippet(
+			"<plugins-only>",
+			fmt.Sprintf(
+				`local c = import %q; if std.objectHas(c, "plugins") then c.plugins else null`,
+				absPath,
+			),
+		)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to extract plugins from jsonnet: %w", err)
+		}
+		if trimmed := bytes.TrimSpace([]byte(pluginsOut)); len(trimmed) > 0 && !bytes.Equal(trimmed, []byte("null")) {
+			if err := json.Unmarshal([]byte(pluginsOut), &po.Plugins); err != nil {
+				return nil, "", fmt.Errorf("failed to parse plugins from jsonnet: %w", err)
+			}
+		}
+		// Region is extracted by a separate snippet so its evaluation
+		// failing (e.g. `region: tfstate(...)`) does not lose the
+		// plugins we just got. Best-effort: any error here is treated
+		// as "region not pre-resolvable, fall back to env".
+		regionOut, err := l.VM.EvaluateAnonymousSnippet(
+			"<region-only>",
+			fmt.Sprintf(
+				`local c = import %q; if std.objectHas(c, "region") then c.region else null`,
+				absPath,
+			),
+		)
+		if err == nil {
+			_ = json.Unmarshal([]byte(regionOut), &po.Region)
+		}
+	case jsonExt:
+		out, err := l.VM.EvaluateFile(path)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to evaluate json file: %w", err)
+		}
+		if err := json.Unmarshal([]byte(out), &po); err != nil {
+			return nil, "", fmt.Errorf("failed to parse plugins from json: %w", err)
+		}
+	case ymlExt, yamlExt:
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to read config file: %w", err)
+		}
+		asJSON, err := yaml.YAMLToJSON(raw)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to parse plugins from yaml: %w", err)
+		}
+		if err := json.Unmarshal(asJSON, &po); err != nil {
+			return nil, "", fmt.Errorf("failed to parse plugins from yaml: %w", err)
+		}
+	default:
+		return nil, "", nil
+	}
+	for i := range po.Plugins {
+		rendered, err := po.Plugins[i].Render(l.renderString)
+		if err != nil {
+			return nil, "", fmt.Errorf("plugins[%d]: %w", i, err)
+		}
+		po.Plugins[i] = rendered
+	}
+	region, err := l.renderString(po.Region)
+	if err != nil {
+		// Region references a plugin-provided function we cannot yet
+		// resolve. prepareAWSAndPlugins will fall back to AWS_REGION.
+		region = ""
+	}
+	return po.Plugins, region, nil
+}
+
+// renderString runs s through the loader's template engine (env /
+// must_env / json_escape and any plugin-provided funcs registered
+// later). Strings without `{{` are returned as-is so values like plain
+// S3 URLs are not paid for through the template parser.
+func (l *configLoader) renderString(s string) (string, error) {
+	if !strings.Contains(s, "{{") {
+		return s, nil
+	}
+	b, err := l.ReadWithEnvBytes([]byte(s))
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
 }
 
 func (c *Config) OverrideByCLIOptions(opt *CLIOptions) {
@@ -174,31 +363,58 @@ func (c *Config) Restrict(ctx context.Context) error {
 	if c.Timeout == nil {
 		c.Timeout = &Duration{Duration: DefaultTimeout}
 	}
-	if c.Region == "" {
-		c.Region = os.Getenv("AWS_REGION")
+	if err := c.loadAWSConfig(ctx); err != nil {
+		return err
 	}
-	var err error
-	var optsFunc []func(*awsConfig.LoadOptions) error
-	if len(awsv2ConfigLoadOptionsFunc) == 0 {
-		// default
-		// Log("[INFO] use default aws config load options")
-		optsFunc = []func(*awsConfig.LoadOptions) error{
-			awsConfig.WithRegion(c.Region),
+	if !c.pluginsConfigured {
+		if err := c.setupPlugins(ctx); err != nil {
+			return fmt.Errorf("failed to setup plugins: %w", err)
 		}
-	} else {
-		// Log("[INFO] override aws config load options")
-		optsFunc = awsv2ConfigLoadOptionsFunc
-	}
-	c.awsv2Config, err = awsConfig.LoadDefaultConfig(ctx, optsFunc...)
-	if err != nil {
-		return fmt.Errorf("failed to load aws config: %w", err)
-	}
-	if err := c.setupPlugins(ctx); err != nil {
-		return fmt.Errorf("failed to setup plugins: %w", err)
+		c.pluginsConfigured = true
 	}
 	if c.FilterCommand != "" {
 		LogWarn("filter_command is deprecated, use environment variable or CLI flag instead")
 	}
+	return nil
+}
+
+// loadAWSConfig builds c.awsv2Config from c.Region (falling back to the
+// AWS_REGION env var). Idempotent — Restrict re-runs it after the two-
+// pass jsonnet eval so the final c.awsv2Config reflects the Region the
+// config resolved to (which may have come from a tfstate lookup).
+// Plugins set up earlier keep the awsv2Config that was current at the
+// time of their Setup call.
+func (c *Config) loadAWSConfig(ctx context.Context) error {
+	if c.Region == "" {
+		c.Region = os.Getenv("AWS_REGION")
+	}
+	var optsFunc []func(*awsConfig.LoadOptions) error
+	if len(awsv2ConfigLoadOptionsFunc) == 0 {
+		optsFunc = []func(*awsConfig.LoadOptions) error{
+			awsConfig.WithRegion(c.Region),
+		}
+	} else {
+		optsFunc = awsv2ConfigLoadOptionsFunc
+	}
+	var err error
+	c.awsv2Config, err = awsConfig.LoadDefaultConfig(ctx, optsFunc...)
+	if err != nil {
+		return fmt.Errorf("failed to load aws config: %w", err)
+	}
+	return nil
+}
+
+// prepareAWSAndPlugins loads c.awsv2Config and runs plugin setup. Used
+// by the jsonnet two-pass loader before the second evaluation so plugin-
+// supplied native functions are registered on the VM.
+func (c *Config) prepareAWSAndPlugins(ctx context.Context) error {
+	if err := c.loadAWSConfig(ctx); err != nil {
+		return err
+	}
+	if err := c.setupPlugins(ctx); err != nil {
+		return fmt.Errorf("failed to setup plugins: %w", err)
+	}
+	c.pluginsConfigured = true
 	return nil
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -80,9 +80,35 @@ func TestLoadConfigWithPluginDuplicate(t *testing.T) {
 }
 
 func TestLoadConfigWithPlugin(t *testing.T) {
-	for _, ext := range []string{".yml", ".yaml", ".json", ".jsonnet"} {
+	// .yml / .yaml are excluded: the two-pass loader runs yaml.YAMLToJSON
+	// on the raw file to extract `plugins`, so unquoted `{{ ... }}` in
+	// YAML scalars is no longer accepted. See
+	// TestLoadConfigYAMLUnquotedTemplateIsIncompatible for the regression.
+	for _, ext := range []string{".json", ".jsonnet"} {
 		t.Run("tests/ecspresso"+ext, func(t *testing.T) {
 			testLoadConfigWithPlugin(t, "tests/ecspresso"+ext)
+		})
+	}
+}
+
+// Unquoted `{{ ... }}` at the start of a YAML scalar is parsed by YAML
+// as a flow-mapping opener, so the two-pass config loader can no longer
+// read these files. This is a documented incompatibility from the
+// switch to two-pass plugin loading. The test pins the behaviour to a
+// graceful error (not a panic).
+func TestLoadConfigYAMLUnquotedTemplateIsIncompatible(t *testing.T) {
+	t.Setenv("AWS_REGION", "ap-northeast-1")
+	for _, ext := range []string{".yml", ".yaml"} {
+		t.Run("tests/ecspresso"+ext, func(t *testing.T) {
+			app, err := ecspresso.New(t.Context(), &ecspresso.CLIOptions{
+				ConfigFilePath: "tests/ecspresso" + ext,
+			})
+			if err == nil {
+				t.Fatalf("expected error for unquoted YAML template, got app=%v", app)
+			}
+			if app != nil {
+				t.Errorf("expected nil app on error, got %v", app)
+			}
 		})
 	}
 }
@@ -94,7 +120,7 @@ func testLoadConfigWithPlugin(t *testing.T, path string) {
 	ctx := t.Context()
 	app, err := ecspresso.New(ctx, &ecspresso.CLIOptions{ConfigFilePath: path})
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	if app.Name() != "test/default" {
 		t.Errorf("unexpected name got %s", app.Name())

--- a/config_test.go
+++ b/config_test.go
@@ -424,6 +424,37 @@ func TestLoadConfigWithTFStatePluginOptional(t *testing.T) {
 	}
 }
 
+// Verifies that the tfstate plugin can be used in top-level config
+// fields (cluster / service / region / etc.), not only in task and
+// service definition templates. ecspresso evaluates the file in two
+// passes: pass 1 extracts only `plugins`, pass 2 re-reads the whole
+// file with the tfstate function registered. Same fixture content
+// across jsonnet / yaml / json to confirm the unified extraction
+// works for every supported format.
+func TestLoadConfigWithTFStateInConfig(t *testing.T) {
+	for _, ext := range []string{".jsonnet", ".yaml", ".json"} {
+		t.Run(ext, func(t *testing.T) {
+			t.Setenv("AWS_REGION", "ap-northeast-1")
+			ctx := t.Context()
+			app, err := ecspresso.New(ctx, &ecspresso.CLIOptions{
+				ConfigFilePath: "tests/config_tfstate_in_config" + ext,
+			})
+			if err != nil {
+				t.Fatalf("New failed: %s", err)
+			}
+			// tests/terraform.tfstate has an aws_ecs_cluster.main
+			// resource whose name is "test-cluster"; every fixture
+			// sets cluster: tfstate("aws_ecs_cluster.main.name").
+			if got, want := app.Config().Cluster, "test-cluster"; got != want {
+				t.Errorf("cluster = %q, want %q (tfstate-resolved value)", got, want)
+			}
+			if got, want := app.Name(), "test/test-cluster"; got != want {
+				t.Errorf("app.Name() = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
 // optional must be a bool. Other types (e.g. the string "true") are
 // rejected so users do not silently get the empty-state fallback by typo.
 func TestLoadConfigWithTFStatePluginOptionalInvalidType(t *testing.T) {

--- a/plugin.go
+++ b/plugin.go
@@ -27,6 +27,61 @@ type ConfigPlugin struct {
 	FuncPrefix string         `yaml:"func_prefix,omitempty" json:"func_prefix,omitempty"`
 }
 
+// Render returns a copy of p with each string value in Name,
+// FuncPrefix, and Config rendered through renderString. This lets the
+// config loader expand `{{ env / must_env }}` and similar template
+// literals inside plugin definitions before plugin Setup runs. Walks
+// nested maps and slices in Config so values at any depth are covered.
+func (p ConfigPlugin) Render(renderString func(string) (string, error)) (ConfigPlugin, error) {
+	name, err := renderString(p.Name)
+	if err != nil {
+		return p, fmt.Errorf("name: %w", err)
+	}
+	prefix, err := renderString(p.FuncPrefix)
+	if err != nil {
+		return p, fmt.Errorf("func_prefix: %w", err)
+	}
+	cfg, err := renderConfigStrings(p.Config, renderString)
+	if err != nil {
+		return p, fmt.Errorf("config: %w", err)
+	}
+	out := ConfigPlugin{Name: name, FuncPrefix: prefix}
+	if cfg != nil {
+		out.Config, _ = cfg.(map[string]any)
+	}
+	return out, nil
+}
+
+// renderConfigStrings walks a plugin Config (which arrives as
+// map[string]any after JSON / YAML decode) and template-renders every
+// string leaf via renderString.
+func renderConfigStrings(v any, renderString func(string) (string, error)) (any, error) {
+	switch x := v.(type) {
+	case string:
+		return renderString(x)
+	case map[string]any:
+		for k, sub := range x {
+			r, err := renderConfigStrings(sub, renderString)
+			if err != nil {
+				return nil, fmt.Errorf("%s: %w", k, err)
+			}
+			x[k] = r
+		}
+		return x, nil
+	case []any:
+		for i, sub := range x {
+			r, err := renderConfigStrings(sub, renderString)
+			if err != nil {
+				return nil, fmt.Errorf("[%d]: %w", i, err)
+			}
+			x[i] = r
+		}
+		return x, nil
+	default:
+		return v, nil
+	}
+}
+
 func (p ConfigPlugin) Setup(ctx context.Context, c *Config) error {
 	switch strings.ToLower(p.Name) {
 	case "tfstate":

--- a/tests/config_tfstate_in_config.json
+++ b/tests/config_tfstate_in_config.json
@@ -1,0 +1,16 @@
+{
+  "region": "ap-northeast-1",
+  "cluster": "{{ tfstate `aws_ecs_cluster.main.name` }}",
+  "service": "test",
+  "service_definition": "ecs-service-def.jsonnet",
+  "task_definition": "ecs-task-def.jsonnet",
+  "timeout": "10m0s",
+  "plugins": [
+    {
+      "name": "tfstate",
+      "config": {
+        "path": "terraform.tfstate"
+      }
+    }
+  ]
+}

--- a/tests/config_tfstate_in_config.jsonnet
+++ b/tests/config_tfstate_in_config.jsonnet
@@ -1,0 +1,24 @@
+// Demonstrates resolving config-level fields (cluster, service) from
+// the tfstate plugin. ecspresso evaluates the jsonnet file in two
+// passes: pass 1 extracts only `plugins` (lazy field access — the
+// `cluster` / `service` expressions below are not touched), pass 2
+// runs after plugins are initialised so std.native('tfstate') works.
+local must_env = std.native('must_env');
+local tfstate = std.native('tfstate');
+
+{
+  region: must_env('AWS_REGION'),
+  cluster: tfstate('aws_ecs_cluster.main.name'),
+  service: 'test',
+  service_definition: 'ecs-service-def.jsonnet',
+  task_definition: 'ecs-task-def.jsonnet',
+  timeout: '10m0s',
+  plugins: [
+    {
+      name: 'tfstate',
+      config: {
+        path: 'terraform.tfstate',
+      },
+    },
+  ],
+}

--- a/tests/config_tfstate_in_config.yaml
+++ b/tests/config_tfstate_in_config.yaml
@@ -1,0 +1,14 @@
+# Demonstrates resolving config-level fields from the tfstate plugin.
+# The loader extracts `plugins:` first (without template-rendering the
+# rest of the file), runs plugin setup, then re-reads the whole file
+# with `tfstate` registered as a template function.
+region: ap-northeast-1
+cluster: "{{ tfstate `aws_ecs_cluster.main.name` }}"
+service: test
+service_definition: ecs-service-def.jsonnet
+task_definition: ecs-task-def.jsonnet
+timeout: 10m0s
+plugins:
+  - name: tfstate
+    config:
+      path: terraform.tfstate

--- a/tests/ecspresso.yml
+++ b/tests/ecspresso.yml
@@ -1,5 +1,5 @@
 region: "{{ must_env `AWS_REGION` }}"
-cluster: default
+cluster: "{{ tfstate `aws_ecs_cluster.main.arn` }}"
 service: test
 service_definition: ecs-service-def.json
 task_definition: ecs-task-def.json

--- a/tests/ecspresso.yml
+++ b/tests/ecspresso.yml
@@ -1,5 +1,5 @@
 region: {{ must_env `AWS_REGION` }}
-cluster: {{ tfstate `aws_ecs_cluster.main.arn` }}
+cluster: default
 service: test
 service_definition: ecs-service-def.json
 task_definition: ecs-task-def.json

--- a/tests/ecspresso.yml
+++ b/tests/ecspresso.yml
@@ -1,5 +1,5 @@
-region: "{{ must_env `AWS_REGION` }}"
-cluster: "{{ tfstate `aws_ecs_cluster.main.arn` }}"
+region: {{ must_env `AWS_REGION` }}
+cluster: {{ tfstate `aws_ecs_cluster.main.arn` }}
 service: test
 service_definition: ecs-service-def.json
 task_definition: ecs-task-def.json

--- a/tests/terraform.tfstate
+++ b/tests/terraform.tfstate
@@ -67,6 +67,23 @@
             ]
         },
         {
+            "mode": "managed",
+            "type": "aws_ecs_cluster",
+            "name": "main",
+            "provider": "provider.aws",
+            "instances": [
+                {
+                    "schema_version": 0,
+                    "attributes": {
+                        "arn": "arn:aws:ecs:ap-northeast-1:123456789012:cluster/test-cluster",
+                        "id": "arn:aws:ecs:ap-northeast-1:123456789012:cluster/test-cluster",
+                        "name": "test-cluster",
+                        "tags": {}
+                    }
+                }
+            ]
+        },
+        {
             "mode": "data",
             "type": "aws_security_group",
             "name": "default",


### PR DESCRIPTION
## Summary

The tfstate / cloudformation / ssm functions used to be available only inside task and service definitions, because the plugins that register them are themselves declared inside the same config file. That left `cluster`, `service`, `region`, etc. unable to reference Terraform-managed values, even though that is exactly where users most often want them when ECS clusters are provisioned by Terraform.

This change loads configs in two passes and extends the behaviour to **jsonnet, JSON, and YAML** uniformly. It is targeted at the next major release (**v3**).

### Flow

1. `extractPlugins` pulls just the `plugins` section out of the file in a format-appropriate way:
   - **jsonnet**: `(import "<abs-path>").plugins` — fields are evaluated lazily, so `tfstate(...)` in other fields is never reached.
   - **JSON**: jsonnet VM evaluates (`.json` is a jsonnet subset with no native-function calls in pure JSON), then `json.Unmarshal` into a `pluginsOnly{}` struct drops every other field before the template engine ever sees it.
   - **YAML**: `yaml.Unmarshal` into `pluginsOnly{}` drops every other field the same way.

   Each string in the extracted plugin config is then template-rendered individually so `{{ env / must_env }}` etc. expand. Per-string rendering avoids a `json.Marshal` quote-escape trap (`{{ env "FOO" }}` would otherwise be serialised as `\"FOO\"` and break the Go template parser).

2. `prepareAWSAndPlugins` loads AWS config and runs plugin `Setup`. The loader carries the resulting template funcs and jsonnet native funcs onto its shared template loader / VM before the full file is read.

`Restrict` learns a `pluginsConfigured` flag so it does not re-run plugin Setup. AWS config loading is split out of `Restrict` into `loadAWSConfig` and is run again after pass 2 so a Region resolved via tfstate is honoured for downstream ECS calls; plugins themselves keep the awsv2Config that was current at their Setup.

The `plugins` block itself still cannot reference these functions — that would be a chicken-and-egg loop.

## Breaking change in v3: YAML configs must be valid YAML before template rendering

v2 template-rendered the whole config file first and parsed YAML afterwards, which silently tolerated YAML scalars starting with an unquoted `{{ ... }}`. v3 runs a YAML parser on the raw file in pass 1 to extract `plugins`, so the YAML configuration file must now be valid YAML on its own.

```yaml
# NG in v3 (worked in v2): YAML treats leading `{` as a flow-mapping opener
region: {{ must_env `AWS_REGION` }}

# OK: quote the scalar
region: "{{ must_env `AWS_REGION` }}"
```

JSON and Jsonnet configurations are unaffected. Existing v2 YAML configs that already quote their template literals (the common case) continue to work without changes. A regression test (`TestLoadConfigYAMLUnquotedTemplateIsIncompatible`) pins the new behaviour to a graceful error rather than a panic. README has been updated with this caveat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)