### PR TITLE
Remove deprecated filter_command config field

### DIFF
--- a/config.go
+++ b/config.go
@@ -64,7 +64,6 @@ type Config struct {
 	ExpressDefinitionPath string            `yaml:"express_definition,omitempty" json:"express_definition,omitempty"`
 	Plugins               []ConfigPlugin    `yaml:"plugins,omitempty" json:"plugins,omitempty"`
 	AppSpec               *appspec.AppSpec  `yaml:"appspec,omitempty" json:"appspec,omitempty"`
-	FilterCommand         string            `yaml:"filter_command,omitempty" json:"filter_command,omitempty"`
 	Timeout               *Duration         `yaml:"timeout,omitempty" json:"timeout,omitempty"`
 	CodeDeploy            *ConfigCodeDeploy `yaml:"codedeploy,omitempty" json:"codedeploy,omitempty"`
 	Ignore                *ConfigIgnore     `yaml:"ignore,omitempty" json:"ignore,omitempty"`
@@ -331,9 +330,6 @@ func (c *Config) OverrideByCLIOptions(opt *CLIOptions) {
 	if opt.Timeout != nil {
 		c.Timeout = &Duration{*opt.Timeout}
 	}
-	if opt.FilterCommand != "" {
-		c.FilterCommand = opt.FilterCommand
-	}
 }
 
 // Restrict restricts a configuration.
@@ -371,9 +367,6 @@ func (c *Config) Restrict(ctx context.Context) error {
 			return fmt.Errorf("failed to setup plugins: %w", err)
 		}
 		c.pluginsConfigured = true
-	}
-	if c.FilterCommand != "" {
-		LogWarn("filter_command is deprecated, use environment variable or CLI flag instead")
 	}
 	return nil
 }

--- a/config_test.go
+++ b/config_test.go
@@ -344,30 +344,6 @@ func TestLoadConfigForCodeDeploy(t *testing.T) {
 	}
 }
 
-var FilterCommandTests = []struct {
-	Env      string
-	Expected string
-}{
-	{"", "fzf"},
-	{"peco", "peco"},
-}
-
-func TestFilterCommandDeprecated(t *testing.T) {
-	ctx := t.Context()
-	for _, ts := range FilterCommandTests {
-		app, err := ecspresso.New(ctx, &ecspresso.CLIOptions{
-			ConfigFilePath: "tests/filter_command.yml",
-			FilterCommand:  ts.Env,
-		})
-		if err != nil {
-			t.Error(err)
-		}
-		if app.FilterCommand() != ts.Expected {
-			t.Errorf("expected %s, but got %s", ts.Expected, app.FilterCommand())
-		}
-	}
-}
-
 var ConfigIgnoreTests = []struct {
 	name         string
 	ignore       *ecspresso.ConfigIgnore

--- a/config_test.go
+++ b/config_test.go
@@ -344,6 +344,22 @@ func TestLoadConfigForCodeDeploy(t *testing.T) {
 	}
 }
 
+func TestFilterCommandFromCLIOption(t *testing.T) {
+	ctx := t.Context()
+	for _, want := range []string{"", "peco", "fzf"} {
+		app, err := ecspresso.New(ctx, &ecspresso.CLIOptions{
+			ConfigFilePath: "tests/test.yaml",
+			FilterCommand:  want,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := app.FilterCommand(); got != want {
+			t.Errorf("FilterCommand: want %q, got %q", want, got)
+		}
+	}
+}
+
 var ConfigIgnoreTests = []struct {
 	name         string
 	ignore       *ecspresso.ConfigIgnore

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -168,6 +168,8 @@ type App struct {
 	loader *configLoader
 	logger *slog.Logger
 
+	filterCommand string
+
 	startedAt time.Time
 }
 
@@ -227,18 +229,19 @@ func New(ctx context.Context, opt *CLIOptions, newAppOptions ...AppOption) (*App
 		Service: conf.Service,
 		Cluster: conf.Cluster,
 
-		ecs:         ecs.NewFromConfig(conf.awsv2Config),
-		autoScaling: applicationautoscaling.NewFromConfig(conf.awsv2Config),
-		codedeploy:  codedeploy.NewFromConfig(conf.awsv2Config),
-		cwl:         cloudwatchlogs.NewFromConfig(conf.awsv2Config),
-		iam:         iam.NewFromConfig(conf.awsv2Config),
-		elbv2:       elasticloadbalancingv2.NewFromConfig(conf.awsv2Config),
-		sd:          servicediscovery.NewFromConfig(conf.awsv2Config),
-		lattice:     vpclattice.NewFromConfig(conf.awsv2Config),
-		lambda:      lambda.NewFromConfig(conf.awsv2Config),
-		loader:      appOpts.loader,
-		config:      appOpts.config,
-		startedAt:   time.Now(),
+		ecs:           ecs.NewFromConfig(conf.awsv2Config),
+		autoScaling:   applicationautoscaling.NewFromConfig(conf.awsv2Config),
+		codedeploy:    codedeploy.NewFromConfig(conf.awsv2Config),
+		cwl:           cloudwatchlogs.NewFromConfig(conf.awsv2Config),
+		iam:           iam.NewFromConfig(conf.awsv2Config),
+		elbv2:         elasticloadbalancingv2.NewFromConfig(conf.awsv2Config),
+		sd:            servicediscovery.NewFromConfig(conf.awsv2Config),
+		lattice:       vpclattice.NewFromConfig(conf.awsv2Config),
+		lambda:        lambda.NewFromConfig(conf.awsv2Config),
+		loader:        appOpts.loader,
+		config:        appOpts.config,
+		filterCommand: opt.FilterCommand,
+		startedAt:     time.Now(),
 	}
 	if logFormat == logFormatJSON {
 		d.logger = appOpts.logger.With("cluster", d.Cluster, "service", d.Service)
@@ -693,5 +696,5 @@ func (d *App) GetLogInfo(task *types.Task, c *types.ContainerDefinition) (string
 }
 
 func (d *App) FilterCommand() string {
-	return d.config.FilterCommand
+	return d.filterCommand
 }

--- a/tests/filter_command.yml
+++ b/tests/filter_command.yml
@@ -1,5 +1,0 @@
-cluster: default
-service: test
-service_definition: ecs-service-def.json
-task_definition: ecs-task-def.json
-filter_command: fzf


### PR DESCRIPTION
## Summary

- The `filter_command` config field was deprecated in v2 (#469) in favor of the `ECSPRESSO_FILTER_COMMAND` environment variable and the `--filter-command` CLI flag.
- Removes the field from `Config`, the deprecation warning in `Restrict`, the `OverrideByCLIOptions` write, and the `TestFilterCommandDeprecated` test plus its `tests/filter_command.yml` fixture.
- `App.FilterCommand()` is preserved (now fed directly from `CLIOptions.FilterCommand` into `App.filterCommand`), so callers using the env-var / flag pathways are unaffected.

Tracked in [docs/v3-plan.md](docs/v3-plan.md#remove-deprecated-filter_command-config-field).