### PR TITLE
Remove deprecated exec and tasks flags

### DIFF
--- a/cli_test.go
+++ b/cli_test.go
@@ -910,23 +910,6 @@ var cliTests = []struct {
 			List:   &ecspresso.TasksListOption{},
 		},
 	},
-	// tasks: deprecated flags (backward compat)
-	{
-		args: []string{"tasks", "--id", "abcdefff", "--output", "json",
-			"--find", "--stop", "--force", "--trace",
-		},
-		sub: "tasks",
-		subOption: &ecspresso.TasksOption{
-			ID:     "abcdefff",
-			Output: "json",
-			List: &ecspresso.TasksListOption{
-				DeprecatedFind:  true,
-				DeprecatedStop:  true,
-				DeprecatedForce: true,
-				DeprecatedTrace: true,
-			},
-		},
-	},
 	// tasks: find subcommand
 	{
 		args: []string{"tasks", "find"},

--- a/cli_test.go
+++ b/cli_test.go
@@ -977,30 +977,6 @@ var cliTests = []struct {
 			},
 		},
 	},
-	// exec: deprecated --port-forward (backward compat)
-	{
-		args: []string{"exec",
-			"--id", "abcdefff",
-			"--command", "ls -la",
-			"--container", "mycontainer",
-			"--local-port", "8080",
-			"--port", "80",
-			"--host", "example.com",
-			"--port-forward",
-		},
-		sub: "exec",
-		subOption: &ecspresso.ExecOption{
-			ID:        "abcdefff",
-			Container: "mycontainer",
-			Run: &ecspresso.ExecRunOption{
-				Command:     "ls -la",
-				PortForward: true,
-				LocalPort:   8080,
-				Port:        80,
-				Host:        "example.com",
-			},
-		},
-	},
 	// exec: portforward subcommand
 	{
 		args: []string{"exec", "--id", "abcdefff", "portforward",

--- a/exec.go
+++ b/exec.go
@@ -17,15 +17,8 @@ type ExecOption struct {
 }
 
 // ExecRunOption is the default subcommand for exec.
-// Deprecated flags are kept as hidden for backward compatibility.
 type ExecRunOption struct {
 	Command string `help:"command to execute" default:"sh"`
-
-	PortForward bool   `name:"port-forward" hidden:"" default:"false"`
-	LocalPort   int    `name:"local-port" hidden:"" default:"0"`
-	Port        int    `name:"port" hidden:"" default:"0"`
-	Host        string `name:"host" hidden:"" default:""`
-	L           string `name:"L" short:"L" hidden:"" default:""`
 }
 
 type ExecPortforwardOption struct {
@@ -93,29 +86,13 @@ func (d *App) Exec(ctx context.Context, opt ExecOption) error {
 			Service:    service,
 		})
 	case opt.Run != nil:
-		run := opt.Run
-		switch {
-		case run.PortForward:
-			LogWarn("--port-forward flag is deprecated, use 'exec portforward' subcommand instead")
-			return ecstaApp.RunPortforward(ctx, &ecsta.PortforwardOption{
-				ID:         opt.ID,
-				Container:  opt.Container,
-				LocalPort:  run.LocalPort,
-				RemotePort: run.Port,
-				RemoteHost: run.Host,
-				L:          run.L,
-				Family:     &family,
-				Service:    service,
-			})
-		default:
-			return ecstaApp.RunExec(ctx, &ecsta.ExecOption{
-				ID:        opt.ID,
-				Command:   run.Command,
-				Container: opt.Container,
-				Family:    &family,
-				Service:   service,
-			})
-		}
+		return ecstaApp.RunExec(ctx, &ecsta.ExecOption{
+			ID:        opt.ID,
+			Command:   opt.Run.Command,
+			Container: opt.Container,
+			Family:    &family,
+			Service:   service,
+		})
 	}
 	return nil
 }

--- a/tasks.go
+++ b/tasks.go
@@ -22,13 +22,7 @@ type TasksOption struct {
 }
 
 // TasksListOption is the default subcommand for tasks.
-// Deprecated flags are kept as hidden for backward compatibility.
-type TasksListOption struct {
-	DeprecatedFind  bool `name:"find" hidden:"" default:"false"`
-	DeprecatedStop  bool `name:"stop" hidden:"" default:"false"`
-	DeprecatedForce bool `name:"force" hidden:"" default:"false"`
-	DeprecatedTrace bool `name:"trace" hidden:"" default:"false"`
-}
+type TasksListOption struct{}
 
 type TasksFindOption struct{}
 
@@ -101,37 +95,10 @@ func (d *App) Tasks(ctx context.Context, opt TasksOption) error {
 			JSON:      logFormat == logFormatJSON,
 		})
 	case opt.List != nil:
-		list := opt.List
-		switch {
-		case list.DeprecatedFind:
-			LogWarn("--find flag is deprecated, use 'tasks find' subcommand instead")
-			return ecstaApp.RunDescribe(ctx, &ecsta.DescribeOption{
-				ID:      opt.taskID(),
-				Family:  &family,
-				Service: service,
-			})
-		case list.DeprecatedStop:
-			LogWarn("--stop flag is deprecated, use 'tasks stop' subcommand instead")
-			return ecstaApp.RunStop(ctx, &ecsta.StopOption{
-				ID:      opt.taskID(),
-				Force:   list.DeprecatedForce,
-				Family:  &family,
-				Service: service,
-			})
-		case list.DeprecatedTrace:
-			LogWarn("--trace flag is deprecated, use 'tasks trace' subcommand instead")
-			return ecstaApp.RunTrace(ctx, &ecsta.TraceOption{
-				ID:       opt.taskID(),
-				Duration: time.Minute,
-				Family:   &family,
-				Service:  service,
-			})
-		default:
-			return ecstaApp.RunList(ctx, &ecsta.ListOption{
-				Family:  &family,
-				Service: service,
-			})
-		}
+		return ecstaApp.RunList(ctx, &ecsta.ListOption{
+			Family:  &family,
+			Service: service,
+		})
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Two related deprecated-flag cleanups that share the same shape (hidden in v2, removed in v3):

### `exec`
- The legacy `--port-forward` / `--local-port` / `--port` / `--host` / `-L` flags on `exec run` were replaced by the `exec portforward` subcommand.
- Drops the `ExecRunOption.{PortForward,LocalPort,Port,Host,L}` fields, the `case run.PortForward:` branch in `App.Exec` (with its `LogWarn`), and the "exec: deprecated --port-forward (backward compat)" test case in `cli_test.go`.

### `tasks`
- The legacy `--find` / `--stop` / `--force` / `--trace` flags on the default `tasks` (list) subcommand were replaced by the `tasks find`, `tasks stop`, and `tasks trace` subcommands.
- Drops the `TasksListOption.{DeprecatedFind,DeprecatedStop,DeprecatedForce,DeprecatedTrace}` fields, the three `LogWarn` branches in `App.Tasks`, and the "tasks: deprecated flags (backward compat)" test case in `cli_test.go`.

Tracked in [docs/v3-plan.md](docs/v3-plan.md#remove-deprecated-exec-flags).