### PR TITLE
Remove dead create dispatch case

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -2,7 +2,6 @@ package ecspresso
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"os"
 	"time"
@@ -158,8 +157,6 @@ func dispatchApp(ctx context.Context, sub string, usage func(), opts *CLIOptions
 		return app.Status(ctx, *opts.Status)
 	case "rollback":
 		return app.Rollback(ctx, *opts.Rollback)
-	case "create":
-		return fmt.Errorf("create command is deprecated. use deploy command instead")
 	case "delete":
 		return app.Delete(ctx, *opts.Delete)
 	case "run":


### PR DESCRIPTION
## Summary

- The `create` subcommand was removed from `CLIOptions` back in v2, so the Kong parser rejects `create` before dispatch ever runs.
- The `case "create":` branch in `dispatchApp` is unreachable dead code (along with its now-unused `fmt` import).

Tracked in [docs/v3-plan.md](docs/v3-plan.md#remove-dead-create-dispatch-case).