### PR TITLE
Drop --no-unified diff path and kylelemons/godebug direct dep

### DIFF
--- a/cli_test.go
+++ b/cli_test.go
@@ -804,15 +804,6 @@ var cliTests = []struct {
 		args: []string{"diff"},
 		sub:  "diff",
 		subOption: &ecspresso.DiffOption{
-			Unified:     true,
-			WithService: true,
-		},
-	},
-	{
-		args: []string{"diff", "--no-unified"},
-		sub:  "diff",
-		subOption: &ecspresso.DiffOption{
-			Unified:     false,
 			WithService: true,
 		},
 	},
@@ -820,7 +811,6 @@ var cliTests = []struct {
 		args: []string{"diff", "--no-color"},
 		sub:  "diff",
 		subOption: &ecspresso.DiffOption{
-			Unified:     true,
 			WithService: true,
 		},
 		fn: func(t *testing.T, o any) {
@@ -833,7 +823,6 @@ var cliTests = []struct {
 		args: []string{"diff", "--color"},
 		sub:  "diff",
 		subOption: &ecspresso.DiffOption{
-			Unified:     true,
 			WithService: true,
 		},
 		fn: func(t *testing.T, o any) {
@@ -846,7 +835,6 @@ var cliTests = []struct {
 		args: []string{"diff", "--without-service"},
 		sub:  "diff",
 		subOption: &ecspresso.DiffOption{
-			Unified:     true,
 			WithService: false,
 		},
 	},

--- a/deploy.go
+++ b/deploy.go
@@ -134,7 +134,7 @@ func (d *App) Deploy(ctx context.Context, opt DeployOption) error {
 			return err
 		}
 		addedTags, updatedTags, deletedTags := CompareTags(sv.Tags, newSv.Tags)
-		differ, err := diffServices(ctx, newSv, sv, d.config.ServiceDefinitionPath, &DiffOption{Unified: true, w: io.Discard})
+		differ, err := diffServices(ctx, newSv, sv, d.config.ServiceDefinitionPath, &DiffOption{w: io.Discard})
 		if err != nil {
 			return fmt.Errorf("failed to diff of service definitions: %w", err)
 		}

--- a/diff.go
+++ b/diff.go
@@ -22,12 +22,10 @@ import (
 	"github.com/hexops/gotextdiff"
 	"github.com/hexops/gotextdiff/myers"
 	"github.com/hexops/gotextdiff/span"
-	"github.com/kylelemons/godebug/diff"
 	"github.com/mattn/go-shellwords"
 )
 
 type DiffOption struct {
-	Unified     bool   `help:"unified diff format" default:"true" negatable:""`
 	Jsonnet     bool   `help:"render as jsonnet format" default:"false"`
 	External    string `help:"external command to format diff" env:"ECSPRESSO_DIFF_COMMAND"`
 	WithService bool   `help:"with service definition" default:"true" negatable:"without-service"`
@@ -203,19 +201,13 @@ func diffServices(ctx context.Context, local, remote *Service, localPath string,
 		return false, nil
 	}
 
-	switch {
-	case opt.External != "":
+	if opt.External != "" {
 		return true, diffExternal(ctx, opt.External, "service", remoteSv, newSv, opt)
-	case opt.Unified:
-		edits := myers.ComputeEdits(span.URIFromPath(remoteArn), remoteSv, newSv)
-		ds := fmt.Sprint(gotextdiff.ToUnified(remoteArn, localPath, remoteSv, edits))
-		fmt.Fprint(opt.w, coloredDiff(ds))
-		return true, nil
-	default:
-		ds := diff.Diff(remoteSv, newSv)
-		fmt.Fprint(opt.w, coloredDiff(fmt.Sprintf("--- %s\n+++ %s\n%s", remoteArn, localPath, ds)))
-		return true, nil
 	}
+	edits := myers.ComputeEdits(span.URIFromPath(remoteArn), remoteSv, newSv)
+	ds := fmt.Sprint(gotextdiff.ToUnified(remoteArn, localPath, remoteSv, edits))
+	fmt.Fprint(opt.w, coloredDiff(ds))
+	return true, nil
 }
 
 func diffTaskDefs(ctx context.Context, local, remote *TaskDefinitionInput, localPath, remoteArn string, opt *DiffOption) (bool, error) {
@@ -246,19 +238,13 @@ func diffTaskDefs(ctx context.Context, local, remote *TaskDefinitionInput, local
 		return false, nil
 	}
 
-	switch {
-	case opt.External != "":
+	if opt.External != "" {
 		return true, diffExternal(ctx, opt.External, "taskdef", remoteTd, newTd, opt)
-	case opt.Unified:
-		edits := myers.ComputeEdits(span.URIFromPath(remoteArn), remoteTd, newTd)
-		ds := fmt.Sprint(gotextdiff.ToUnified(remoteArn, localPath, remoteTd, edits))
-		fmt.Fprint(opt.w, coloredDiff(ds))
-		return true, nil
-	default:
-		ds := diff.Diff(remoteTd, newTd)
-		fmt.Fprint(opt.w, coloredDiff(fmt.Sprintf("--- %s\n+++ %s\n%s", remoteArn, localPath, ds)))
-		return true, nil
 	}
+	edits := myers.ComputeEdits(span.URIFromPath(remoteArn), remoteTd, newTd)
+	ds := fmt.Sprint(gotextdiff.ToUnified(remoteArn, localPath, remoteTd, edits))
+	fmt.Fprint(opt.w, coloredDiff(ds))
+	return true, nil
 }
 
 func diffExternal(ctx context.Context, diffCmd string, target, remote, local string, opt *DiffOption) error {

--- a/diff_test.go
+++ b/diff_test.go
@@ -233,7 +233,7 @@ var testServiceDefinitionHasDesiredCount = &ecspresso.Service{
 func TestDiffServices(t *testing.T) {
 	ctx := t.Context()
 	b := new(bytes.Buffer)
-	opt := &ecspresso.DiffOption{Unified: true}
+	opt := &ecspresso.DiffOption{}
 	opt.SetWriter(b)
 	color.NoColor = true
 
@@ -373,7 +373,7 @@ func TestDiffServices(t *testing.T) {
 func TestDiffServicesCodeDeployTargetGroupArn(t *testing.T) {
 	ctx := t.Context()
 	b := new(bytes.Buffer)
-	opt := &ecspresso.DiffOption{Unified: true}
+	opt := &ecspresso.DiffOption{}
 	opt.SetWriter(b)
 	color.NoColor = true
 
@@ -462,7 +462,7 @@ func TestDiffServicesCodeDeployTargetGroupArn(t *testing.T) {
 func TestDiffJsonnet(t *testing.T) {
 	ctx := t.Context()
 	b := new(bytes.Buffer)
-	opt := &ecspresso.DiffOption{Unified: true, Jsonnet: true}
+	opt := &ecspresso.DiffOption{Jsonnet: true}
 	opt.SetWriter(b)
 	color.NoColor = true
 
@@ -550,7 +550,7 @@ func TestDiffWithoutService(t *testing.T) {
 
 	t.Run("WithService=true shows service diff", func(t *testing.T) {
 		b := new(bytes.Buffer)
-		opt := &ecspresso.DiffOption{Unified: true, WithService: true}
+		opt := &ecspresso.DiffOption{WithService: true}
 		opt.SetWriter(b)
 
 		diff, err := ecspresso.DiffServices(ctx, localSv, remoteSv, "file", opt)
@@ -567,7 +567,7 @@ func TestDiffWithoutService(t *testing.T) {
 
 	t.Run("WithService=false produces only task def diff", func(t *testing.T) {
 		b := new(bytes.Buffer)
-		opt := &ecspresso.DiffOption{Unified: true, WithService: false}
+		opt := &ecspresso.DiffOption{WithService: false}
 		opt.SetWriter(b)
 
 		localTd := &ecspresso.TaskDefinitionInput{
@@ -613,7 +613,7 @@ func TestDiffWithoutService(t *testing.T) {
 
 	t.Run("WithService=true produces both service and task def diff", func(t *testing.T) {
 		b := new(bytes.Buffer)
-		opt := &ecspresso.DiffOption{Unified: true, WithService: true}
+		opt := &ecspresso.DiffOption{WithService: true}
 		opt.SetWriter(b)
 
 		localTd := &ecspresso.TaskDefinitionInput{
@@ -660,7 +660,7 @@ func TestDiffWithoutService(t *testing.T) {
 func TestDiffTaskDefs(t *testing.T) {
 	ctx := t.Context()
 	b := new(bytes.Buffer)
-	opt := &ecspresso.DiffOption{Unified: true}
+	opt := &ecspresso.DiffOption{}
 	opt.SetWriter(b)
 	color.NoColor = true
 

--- a/express.go
+++ b/express.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hexops/gotextdiff"
 	"github.com/hexops/gotextdiff/myers"
 	"github.com/hexops/gotextdiff/span"
-	"github.com/kylelemons/godebug/diff"
 )
 
 type ExpressGatewayService struct {
@@ -174,19 +173,13 @@ func diffExpressGatewayServices(ctx context.Context, local, remote *ExpressGatew
 		return false, nil
 	}
 
-	switch {
-	case opt.External != "":
+	if opt.External != "" {
 		return true, diffExternal(ctx, opt.External, "service", remoteSv, newSv, opt)
-	case opt.Unified:
-		edits := myers.ComputeEdits(span.URIFromPath(remoteArn), remoteSv, newSv)
-		ds := fmt.Sprint(gotextdiff.ToUnified(remoteArn, localPath, remoteSv, edits))
-		fmt.Fprint(opt.w, coloredDiff(ds))
-		return true, nil
-	default:
-		ds := diff.Diff(remoteSv, newSv)
-		fmt.Fprint(opt.w, coloredDiff(fmt.Sprintf("--- %s\n+++ %s\n%s", remoteArn, localPath, ds)))
-		return true, nil
 	}
+	edits := myers.ComputeEdits(span.URIFromPath(remoteArn), remoteSv, newSv)
+	ds := fmt.Sprint(gotextdiff.ToUnified(remoteArn, localPath, remoteSv, edits))
+	fmt.Fprint(opt.w, coloredDiff(ds))
+	return true, nil
 }
 
 func exToUpdateExpressGatewayServiceInput(ex *ExpressGatewayService, sv *Service) *ecs.UpdateExpressGatewayServiceInput {

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,6 @@ require (
 	github.com/hexops/gotextdiff v1.0.3
 	github.com/itchyny/gojq v0.12.19
 	github.com/kayac/go-config v0.7.0
-	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-isatty v0.0.22
 	github.com/mattn/go-shellwords v1.0.13
 	github.com/olekukonko/tablewriter v1.1.4
@@ -117,6 +116,7 @@ require (
 	github.com/hashicorp/go-tfe v1.103.0 // indirect
 	github.com/hashicorp/jsonapi v1.4.3-0.20250220162346-81a76b606f3e // indirect
 	github.com/itchyny/timefmt-go v0.1.8 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-runewidth v0.0.23 // indirect
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect


### PR DESCRIPTION
## Summary

- `DiffOption.Unified` was `default:"true"` and every callsite (internal and tests) used `Unified: true`. The non-unified branch was the only thing keeping `github.com/kylelemons/godebug/diff` (no upstream pushes since 2022-06) as a direct dependency.
- Drops the `Unified` field from `DiffOption` (and the `--[no-]unified` CLI flag).
- Drops the non-unified arm in `diffServices` / `diffTaskDefs` / `diffExpressGatewayServices`, collapsing each `switch` into a single `External`-or-unified branch.
- Drops the `kylelemons/godebug/diff` import. `go mod tidy` keeps `kylelemons/godebug` in `go.mod` as `// indirect` since Azure SDK and `tfstate-lookup` still pull it in transitively, but it is no longer a direct dependency of this repo.
- `hexops/gotextdiff` (unified output) stays — also stale but self-contained.

### Breaking changes

- `ecspresso diff --no-unified` (and `--unified`) now flag-parse errors.
- Library callers passing `DiffOption{Unified: true, ...}` must drop the field.

Tracked in [docs/v3-plan.md](docs/v3-plan.md#drop-the---no-unified-diff-path-and-the-kylelemonsgodebug-dependency).