### PR TITLE
v3 cleanups: sentinel errors, unexport internals, const tuning vars

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ make packages
 
 - **App** (`ecspresso.go`): Main application struct that holds AWS clients (ECS, CodeDeploy, CloudWatch Logs, IAM, etc.) and orchestrates operations
 - **Config** (`config.go`): Configuration loading and validation. Supports YAML, JSON, and Jsonnet formats with template functions
-- **CLI** (`cli.go`, `cliv2.go`): Command-line interface using Kong. Each subcommand (deploy, run, diff, etc.) has its own option struct and handler
+- **CLI** (`cli.go`, `cli_parse.go`): Command-line interface using Kong. Each subcommand (deploy, run, diff, etc.) has its own option struct and handler
 
 ### Command Structure
 

--- a/cli.go
+++ b/cli.go
@@ -62,7 +62,7 @@ func (opt *CLIOptions) resolveConfigFilePath() (path string) {
 	return
 }
 
-func (opts *CLIOptions) ForSubCommand(sub string) any {
+func (opts *CLIOptions) forSubCommand(sub string) any {
 	switch sub {
 	case "appspec":
 		return opts.Appspec
@@ -189,9 +189,7 @@ func dispatchApp(ctx context.Context, sub string, usage func(), opts *CLIOptions
 	}
 }
 
-type CLIParseFunc func([]string) (string, *CLIOptions, func(), error)
-
-func CLI(ctx context.Context, parse CLIParseFunc) (int, error) {
+func CLI(ctx context.Context, parse func([]string) (string, *CLIOptions, func(), error)) (int, error) {
 	sub, opts, usage, err := parse(os.Args[1:])
 	if err != nil {
 		return 1, err

--- a/cli_parse.go
+++ b/cli_parse.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fatih/color"
 )
 
-func ParseCLIv2(args []string) (string, *CLIOptions, func(), error) {
+func ParseCLI(args []string) (string, *CLIOptions, func(), error) {
 	// compatible with v1
 	if len(args) == 0 || len(args) > 0 && args[0] == "help" {
 		args = []string{"--help"}
@@ -30,7 +30,7 @@ func ParseCLIv2(args []string) (string, *CLIOptions, func(), error) {
 	clearInactiveSubcommands(&opts, c.Command())
 
 	for _, envFile := range opts.Envfile {
-		if err := ExportEnvFile(envFile); err != nil {
+		if err := exportEnvFile(envFile); err != nil {
 			return sub, &opts, nil, fmt.Errorf("failed to load envfile: %w", err)
 		}
 	}

--- a/cli_test.go
+++ b/cli_test.go
@@ -991,10 +991,10 @@ var cliTests = []struct {
 	},
 }
 
-func TestParseCLIv2(t *testing.T) {
+func TestParseCLI(t *testing.T) {
 	for _, tt := range cliTests {
 		t.Run(strings.Join(tt.args, "_"), func(t *testing.T) {
-			sub, opt, _, err := ecspresso.ParseCLIv2(tt.args)
+			sub, opt, _, err := ecspresso.ParseCLI(tt.args)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 				return
@@ -1019,12 +1019,12 @@ func TestParseCLIv2(t *testing.T) {
 	}
 }
 
-func TestParseCLIv2WithInvalidWaitUntilOption(t *testing.T) {
-	_, _, _, err := ecspresso.ParseCLIv2([]string{"deploy", "--wait-until=UNSUPPORTED"})
+func TestParseCLIWithInvalidWaitUntilOption(t *testing.T) {
+	_, _, _, err := ecspresso.ParseCLI([]string{"deploy", "--wait-until=UNSUPPORTED"})
 	if err == nil {
 		t.Errorf("invalid wait-until should return error")
 	}
-	_, _, _, err = ecspresso.ParseCLIv2([]string{"deploy", "--wait-until=codedeploy:"}) // lifecycle event name is empty (i.e., prefix only)
+	_, _, _, err = ecspresso.ParseCLI([]string{"deploy", "--wait-until=codedeploy:"}) // lifecycle event name is empty (i.e., prefix only)
 	if err == nil {
 		t.Errorf("invalid wait-until should return error")
 	}

--- a/cmd/ecspresso/main.go
+++ b/cmd/ecspresso/main.go
@@ -13,7 +13,7 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), trapSignals...)
 	defer stop()
 
-	exitCode, err := ecspresso.CLI(ctx, ecspresso.ParseCLIv2)
+	exitCode, err := ecspresso.CLI(ctx, ecspresso.ParseCLI)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			ecspresso.LogWarn("Interrupted")

--- a/config.go
+++ b/config.go
@@ -297,7 +297,7 @@ func (l *configLoader) extractPlugins(path, ext string) ([]ConfigPlugin, string,
 		return nil, "", nil
 	}
 	for i := range po.Plugins {
-		rendered, err := po.Plugins[i].Render(l.renderString)
+		rendered, err := po.Plugins[i].render(l.renderString)
 		if err != nil {
 			return nil, "", fmt.Errorf("plugins[%d]: %w", i, err)
 		}

--- a/create.go
+++ b/create.go
@@ -100,7 +100,7 @@ func (d *App) createService(ctx context.Context, opt DeployOption) error {
 	}
 
 	if err := doWait(ctx, sv); err != nil {
-		if errors.As(err, &errNotFound) && sv.isCodeDeploy() {
+		if errors.Is(err, ErrNotFound) && sv.isCodeDeploy() {
 			d.LogInfo(err.Error())
 			return d.WaitTaskSetStable(ctx, sv)
 		}

--- a/deploy.go
+++ b/deploy.go
@@ -92,7 +92,7 @@ func (d *App) Deploy(ctx context.Context, opt DeployOption) error {
 	d.LogInfo("Starting deploy", withDryRun(opt.DryRun)...)
 	sv, err := d.DescribeServiceStatus(ctx, 0)
 	if err != nil {
-		if errors.As(err, &errNotFound) {
+		if errors.Is(err, ErrNotFound) {
 			d.LogInfo("service not found, creating a new service", withDryRun(opt.DryRun)...)
 			if d.config.isExpressMode() {
 				return d.createExpressGatewayService(ctx, opt)
@@ -182,7 +182,7 @@ func (d *App) Deploy(ctx context.Context, opt DeployOption) error {
 	}
 
 	if err := doWait(ctx, sv); err != nil {
-		if errors.As(err, &errNotFound) {
+		if errors.Is(err, ErrNotFound) {
 			d.LogInfo(err.Error())
 			// no need to wait
 			return nil
@@ -343,11 +343,12 @@ func (d *App) findDeploymentInfo(ctx context.Context) (*cdTypes.DeploymentInfo, 
 			}
 		}
 	}
-	return nil, ErrNotFound(fmt.Sprintf(
-		"failed to find CodeDeploy Application/DeploymentGroup for ECS service %s on cluster %s",
+	return nil, fmt.Errorf(
+		"failed to find CodeDeploy Application/DeploymentGroup for ECS service %s on cluster %s: %w",
 		d.config.Service,
 		d.config.Cluster,
-	))
+		ErrNotFound,
+	)
 }
 
 func (d *App) findCodeDeployApplications(ctx context.Context) ([]cdTypes.ApplicationInfo, error) {
@@ -365,7 +366,7 @@ func (d *App) findCodeDeployApplications(ctx context.Context) ([]cdTypes.Applica
 		}
 	}
 	if len(appNames) == 0 {
-		return nil, ErrNotFound("no CodeDeploy applications found")
+		return nil, fmt.Errorf("no CodeDeploy applications found: %w", ErrNotFound)
 	}
 	d.LogDebug("found CodeDeploy applications: %v", appNames)
 
@@ -387,7 +388,7 @@ func (d *App) findCodeDeployApplications(ctx context.Context) ([]cdTypes.Applica
 		}
 	}
 	if len(apps) == 0 {
-		return nil, ErrNotFound("no CodeDeploy applications found")
+		return nil, fmt.Errorf("no CodeDeploy applications found: %w", ErrNotFound)
 	}
 	return apps, nil
 }
@@ -562,7 +563,7 @@ func (d *App) UpdateServiceTags(ctx context.Context, sv *Service, added, updated
 func (d *App) taskDefinitionArnForDeploy(ctx context.Context, sv *Service, opt DeployOption) (string, error) {
 	if opt.Revision > 0 {
 		if opt.LatestTaskDefinition {
-			return "", ErrConflictOptions("revision and latest-task-definition are exclusive")
+			return "", fmt.Errorf("revision and latest-task-definition are exclusive: %w", ErrConflictOptions)
 		}
 		family := strings.Split(arnToName(aws.ToString(sv.TaskDefinition)), ":")[0]
 		return fmt.Sprintf("%s:%d", family, opt.Revision), nil

--- a/diff.go
+++ b/diff.go
@@ -82,7 +82,7 @@ func (d *App) diff(ctx context.Context, opt DiffOption) (bool, error) {
 		}
 		remoteSv, err := d.DescribeService(ctx)
 		if err != nil {
-			if errors.As(err, &errNotFound) {
+			if errors.Is(err, ErrNotFound) {
 				d.LogInfo("service not found, will create a new service")
 			} else {
 				return false, fmt.Errorf("failed to describe service: %w", err)
@@ -108,7 +108,7 @@ func (d *App) diff(ctx context.Context, opt DiffOption) (bool, error) {
 	if remoteTaskDefArn == "" {
 		arn, err := d.findLatestTaskDefinitionArn(ctx, *newTd.Family)
 		if err != nil {
-			if errors.As(err, &errNotFound) {
+			if errors.Is(err, ErrNotFound) {
 				d.LogInfo("task definition not found, will register a new task definition")
 			} else {
 				return false, err
@@ -151,7 +151,7 @@ func (d *App) diffExpress(ctx context.Context, opt DiffOption) (bool, error) {
 	}
 	remoteEx, err := d.DescribeExpressGatewayService(ctx, sv)
 	if err != nil {
-		if errors.As(err, &errNotFound) {
+		if errors.Is(err, ErrNotFound) {
 			d.LogInfo("express gateway service not found, will create a new express gateway service")
 		} else {
 			return false, fmt.Errorf("failed to describe express gateway service: %w", err)

--- a/docs_test.go
+++ b/docs_test.go
@@ -162,7 +162,7 @@ func TestDocsOptionDefault(t *testing.T) {
 		JSON:    false,
 	}
 	args := []string{"docs"}
-	_, opts, _, err := ecspresso.ParseCLIv2(args)
+	_, opts, _, err := ecspresso.ParseCLI(args)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -35,10 +35,12 @@ const DefaultDesiredCount = -1
 const DefaultConfigFilePath = "ecspresso.yml"
 const dryRunStr = "DRY RUN"
 
-var delayForServiceChanged = 3 * time.Second
-var refreshInterval = 10 * time.Second
-var waiterMaxDelay = 15 * time.Second
-var spcIndent = "  "
+const (
+	delayForServiceChanged = 3 * time.Second
+	refreshInterval        = 10 * time.Second
+	waiterMaxDelay         = 15 * time.Second
+	spcIndent              = "  "
+)
 
 type TaskDefinition types.TaskDefinition
 
@@ -187,12 +189,6 @@ func WithConfig(c *Config) AppOption {
 	}
 }
 
-func WithConfigLoader(extstr, extcode map[string]string) AppOption {
-	return func(o *appOptions) {
-		o.loader = newConfigLoader(extstr, extcode)
-	}
-}
-
 func WithLogger(l *slog.Logger) AppOption {
 	return func(o *appOptions) {
 		o.logger = l
@@ -319,14 +315,14 @@ func (d *App) DescribeService(ctx context.Context) (*Service, error) {
 		return nil, fmt.Errorf("failed to describe service: %w", err)
 	}
 	if len(out.Services) == 0 {
-		return nil, ErrNotFound(fmt.Sprintf("service %s is not found", d.Service))
+		return nil, fmt.Errorf("service %s is not found: %w", d.Service, ErrNotFound)
 	}
 	status := aws.ToString(out.Services[0].Status)
 	switch status {
 	case "DRAINING":
 		d.LogWarn("service status warning", "status", status)
 	case "INACTIVE":
-		return nil, ErrNotFound(fmt.Sprintf("service %s is %s", d.Service, status))
+		return nil, fmt.Errorf("service %s is %s: %w", d.Service, status, ErrNotFound)
 	default:
 		d.LogDebug("service %s is %s", d.Service, status)
 	}
@@ -537,7 +533,7 @@ func (d *App) GetLogEvents(ctx context.Context, logGroup string, logStream strin
 	if err != nil {
 		var notfound *cwlTypes.ResourceNotFoundException
 		if errors.As(err, &notfound) {
-			return nextToken, ErrNotFound(err.Error())
+			return nextToken, fmt.Errorf("%s: %w", err.Error(), ErrNotFound)
 		}
 		return nextToken, wrapPermissionError(err)
 	}
@@ -575,7 +571,7 @@ func (d *App) findLatestTaskDefinitionArn(ctx context.Context, family string) (s
 		return "", fmt.Errorf("failed to list task definitions: %w", err)
 	}
 	if len(out.TaskDefinitionArns) == 0 {
-		return "", ErrNotFound(fmt.Sprintf("no task definitions family %s are found", family))
+		return "", fmt.Errorf("no task definitions family %s are found: %w", family, ErrNotFound)
 	}
 	return out.TaskDefinitionArns[0], nil
 }

--- a/envfile.go
+++ b/envfile.go
@@ -6,8 +6,8 @@ import (
 	"github.com/hashicorp/go-envparse"
 )
 
-// ExportEnvFile exports envfile to environment variables.
-func ExportEnvFile(file string) error {
+// exportEnvFile exports envfile to environment variables.
+func exportEnvFile(file string) error {
 	if file == "" {
 		return nil
 	}

--- a/errors.go
+++ b/errors.go
@@ -2,38 +2,20 @@ package ecspresso
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/aws/smithy-go"
 )
 
-type ErrSkipVerify string
-
-func (e ErrSkipVerify) Error() string {
-	return string(e)
-}
-
-type ErrNotFound string
-
-func (e ErrNotFound) Error() string {
-	return string(e)
-}
-
-type ErrConflictOptions string
-
-func (e ErrConflictOptions) Error() string {
-	return string(e)
-}
-
-type ErrPermissionDenied string
-
-func (e ErrPermissionDenied) Error() string {
-	return string(e)
-}
-
+// Sentinel errors. Use errors.Is to test for a specific category, and
+// fmt.Errorf("...: %w", ..., Err...) to construct a wrapped instance
+// that carries context. Detection by type (errors.As against the old
+// string-typed errors) is no longer supported.
 var (
-	errNotFound         = ErrNotFound("not found")
-	errSkipVerify       = ErrSkipVerify("skip verify")
-	errPermissionDenied = ErrPermissionDenied("permission denied")
+	ErrSkipVerify       = errors.New("skip verify")
+	ErrNotFound         = errors.New("not found")
+	ErrConflictOptions  = errors.New("conflicting options")
+	ErrPermissionDenied = errors.New("permission denied")
 )
 
 func isPermissionError(err error) bool {
@@ -60,7 +42,7 @@ func wrapPermissionError(err error) error {
 		return nil
 	}
 	if isPermissionError(err) {
-		return ErrPermissionDenied(err.Error())
+		return fmt.Errorf("%s: %w", err.Error(), ErrPermissionDenied)
 	}
 	return err
 }

--- a/export_test.go
+++ b/export_test.go
@@ -79,3 +79,7 @@ func (i *ConfigIgnore) FilterTags(tags []types.Tag) []types.Tag {
 func SleepContext(ctx context.Context, d time.Duration) {
 	sleepContext(ctx, d)
 }
+
+func (opts *CLIOptions) ForSubCommand(sub string) any {
+	return opts.forSubCommand(sub)
+}

--- a/express.go
+++ b/express.go
@@ -71,7 +71,7 @@ func (d *App) DescribeExpressGatewayService(ctx context.Context, sv *Service) (*
 	}
 	rex := res.Service
 	if res.Service == nil {
-		return nil, ErrNotFound("express gateway service is not found")
+		return nil, fmt.Errorf("express gateway service is not found: %w", ErrNotFound)
 	}
 	if len(rex.ActiveConfigurations) == 0 {
 		return nil, fmt.Errorf("express gateway service %s has no active configuration", aws.ToString(rex.ServiceName))

--- a/plugin.go
+++ b/plugin.go
@@ -27,12 +27,12 @@ type ConfigPlugin struct {
 	FuncPrefix string         `yaml:"func_prefix,omitempty" json:"func_prefix,omitempty"`
 }
 
-// Render returns a copy of p with each string value in Name,
+// render returns a copy of p with each string value in Name,
 // FuncPrefix, and Config rendered through renderString. This lets the
 // config loader expand `{{ env / must_env }}` and similar template
 // literals inside plugin definitions before plugin Setup runs. Walks
 // nested maps and slices in Config so values at any depth are covered.
-func (p ConfigPlugin) Render(renderString func(string) (string, error)) (ConfigPlugin, error) {
+func (p ConfigPlugin) render(renderString func(string) (string, error)) (ConfigPlugin, error) {
 	name, err := renderString(p.Name)
 	if err != nil {
 		return p, fmt.Errorf("name: %w", err)

--- a/rollback.go
+++ b/rollback.go
@@ -248,7 +248,7 @@ func (d *App) FindRollbackTarget(ctx context.Context, taskDefinitionArn string) 
 			return "", fmt.Errorf("failed to list task definitions: %w", err)
 		}
 		if len(out.TaskDefinitionArns) == 0 {
-			return "", fmt.Errorf("rollback target is not found: %s: %w", err, ErrNotFound)
+			return "", fmt.Errorf("rollback target is not found for family %s: %w", family, ErrNotFound)
 		}
 		for _, tdArn := range out.TaskDefinitionArns {
 			if found {

--- a/rollback.go
+++ b/rollback.go
@@ -81,7 +81,7 @@ func (d *App) Rollback(ctx context.Context, opt RollbackOption) error {
 
 	sleepContext(ctx, delayForServiceChanged) // wait for service updated
 	if err := doWait(ctx, sv); err != nil {
-		if errors.As(err, &errNotFound) {
+		if errors.Is(err, ErrNotFound) {
 			d.LogInfo(err.Error())
 			return d.rollbackTaskDefinition(ctx, rollbackedTdArn, opt)
 		}
@@ -146,8 +146,7 @@ func (d *App) RollbackServiceTasks(ctx context.Context, sv *Service, targetArn s
 func (d *App) RollbackExpressService(ctx context.Context, sv *Service, _ string, opt RollbackOption) (string, error) {
 	deploymentArn, err := d.findActiveECSDeploymentArn(ctx, 0)
 	if err != nil {
-		var errNotFound ErrNotFound
-		if errors.As(err, &errNotFound) {
+		if errors.Is(err, ErrNotFound) {
 			return "", errors.New("no active service deployment found")
 		}
 		return "", err
@@ -161,8 +160,7 @@ func (d *App) RollbackECSService(ctx context.Context, sv *Service, targetArn str
 	// Check if there's an active deployment in progress
 	deploymentArn, err := d.findActiveECSDeploymentArn(ctx, 0)
 	if err != nil {
-		var errNotFound ErrNotFound
-		if errors.As(err, &errNotFound) {
+		if errors.Is(err, ErrNotFound) {
 			d.LogInfo("no active deployment, rolling back service tasks", withDryRun(opt.DryRun, "target", arnToName(targetArn))...)
 			return d.RollbackServiceTasks(ctx, sv, targetArn, opt)
 		}
@@ -187,7 +185,7 @@ func (d *App) RollbackByCodeDeploy(ctx context.Context, sv *Service, targetArn s
 		return "", fmt.Errorf("failed to list deployments: %w", err)
 	}
 	if len(ld.Deployments) == 0 {
-		return "", ErrNotFound("no deployments are found")
+		return "", fmt.Errorf("no deployments are found: %w", ErrNotFound)
 	}
 
 	out, err := d.codedeploy.GetDeployment(ctx, &codedeploy.GetDeploymentInput{
@@ -250,7 +248,7 @@ func (d *App) FindRollbackTarget(ctx context.Context, taskDefinitionArn string) 
 			return "", fmt.Errorf("failed to list task definitions: %w", err)
 		}
 		if len(out.TaskDefinitionArns) == 0 {
-			return "", ErrNotFound(fmt.Sprintf("rollback target is not found: %s", err))
+			return "", fmt.Errorf("rollback target is not found: %s: %w", err, ErrNotFound)
 		}
 		for _, tdArn := range out.TaskDefinitionArns {
 			if found {
@@ -265,7 +263,7 @@ func (d *App) FindRollbackTarget(ctx context.Context, taskDefinitionArn string) 
 			break
 		}
 	}
-	return "", ErrNotFound("rollback target is not found")
+	return "", fmt.Errorf("rollback target is not found: %w", ErrNotFound)
 }
 
 type rollbackFunc func(ctx context.Context, sv *Service, targetArn string, opt RollbackOption) (string, error)
@@ -368,7 +366,7 @@ func (d *App) findActiveECSDeploymentArn(ctx context.Context, timeout time.Durat
 		case <-ctx.Done():
 			return "", ctx.Err()
 		case <-tm.C: // Timeout reached
-			return "", ErrNotFound("no active service deployments found")
+			return "", fmt.Errorf("no active service deployments found: %w", ErrNotFound)
 		default:
 			d.LogInfo("no service deployments found, waiting...")
 			sleepContext(ctx, delayForServiceChanged)

--- a/run.go
+++ b/run.go
@@ -216,11 +216,11 @@ func (d *App) WaitRunTask(ctx context.Context, task *types.Task, watchContainer 
 					if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 						return
 					}
-					if errors.As(err, &errPermissionDenied) {
+					if errors.Is(err, ErrPermissionDenied) {
 						d.LogWarn("failed to get log events: check logs:GetLogEvents permission", "error", err.Error())
 						return
 					}
-					if !errors.As(err, &errNotFound) {
+					if !errors.Is(err, ErrNotFound) {
 						d.LogWarn("failed to get log events", "error", err.Error())
 					}
 					continue
@@ -269,7 +269,7 @@ func (d *App) resolveTaskDefinitionForRun(ctx context.Context, opt RunOption) (*
 	switch {
 	case *opt.Revision > 0:
 		if opt.LatestTaskDefinition {
-			return nil, ErrConflictOptions("revision and latest-task-definition are exclusive")
+			return nil, fmt.Errorf("revision and latest-task-definition are exclusive: %w", ErrConflictOptions)
 		}
 		family, _, err := d.resolveTaskdefinition(ctx)
 		if err != nil {

--- a/run_test.go
+++ b/run_test.go
@@ -111,7 +111,7 @@ func TestTaskDefinitionArnForRun(t *testing.T) {
 		for _, s := range suites {
 			args := []string{"run", "--dry-run"}
 			args = append(args, s.opts...)
-			_, cliopts, _, err := ecspresso.ParseCLIv2(args)
+			_, cliopts, _, err := ecspresso.ParseCLI(args)
 			if err != nil {
 				t.Error(err)
 			}

--- a/verify.go
+++ b/verify.go
@@ -76,7 +76,7 @@ func (v *verifier) ecrClient(region string) *ecr.Client {
 
 func (v *verifier) existsSecretValue(ctx context.Context, from string) error {
 	if !v.opt.GetSecrets {
-		return ErrSkipVerify(fmt.Sprintf("get a secret value for %s", from))
+		return fmt.Errorf("get a secret value for %s: %w", from, ErrSkipVerify)
 	}
 
 	// secrets manager
@@ -135,7 +135,7 @@ func (v *verifier) existsSecretValue(ctx context.Context, from string) error {
 
 func (v *verifier) existsEnvironmentFile(ctx context.Context, envFile types.EnvironmentFile) error {
 	if envFile.Type != types.EnvironmentFileTypeS3 {
-		return ErrSkipVerify("unsupported environment file type: " + string(envFile.Type))
+		return fmt.Errorf("unsupported environment file type: %s: %w", envFile.Type, ErrSkipVerify)
 	}
 	s3arn := aws.ToString(envFile.Value)
 	a, err := arn.Parse(s3arn)
@@ -348,13 +348,12 @@ func (vs *verifyState) VerifyResource(ctx context.Context, name string, verifyFu
 	err, hit := vs.cache.Do(ctx, name, verifyFunc)
 	r.Cached = hit
 	if err != nil {
-		var permErr ErrPermissionDenied
-		if errors.As(err, &permErr) {
+		if errors.Is(err, ErrPermissionDenied) {
 			r.Error = err.Error()
 			r.Result = verifyResultWarn
 			return r, nil
 		}
-		if errors.As(err, &errSkipVerify) {
+		if errors.Is(err, ErrSkipVerify) {
 			r.Error = err.Error()
 			r.Result = verifyResultSkip
 			return r, nil
@@ -375,7 +374,7 @@ func (d *App) verifyCluster(ctx context.Context) error {
 	if err != nil {
 		return wrapPermissionError(err)
 	} else if len(out.Clusters) == 0 {
-		return ErrNotFound(fmt.Sprintf("cluster %s is not found", cluster))
+		return fmt.Errorf("cluster %s is not found: %w", cluster, ErrNotFound)
 	}
 	return nil
 }
@@ -383,7 +382,7 @@ func (d *App) verifyCluster(ctx context.Context) error {
 func (d *App) verifyServiceDefinition(ctx context.Context) error {
 	vs := ctx.Value(verifyStateKey).(*verifyState)
 	if d.config.ServiceDefinitionPath == "" {
-		return ErrSkipVerify("no ServiceDefinition")
+		return fmt.Errorf("no ServiceDefinition: %w", ErrSkipVerify)
 	}
 	sv, err := d.LoadServiceDefinition(d.config.ServiceDefinitionPath)
 	if err != nil {
@@ -461,7 +460,7 @@ func (d *App) verifyServiceDefinition(ctx context.Context) error {
 func (d *App) verifyExpressDefinition(ctx context.Context) error {
 	vs := ctx.Value(verifyStateKey).(*verifyState)
 	if d.config.ExpressDefinitionPath == "" {
-		return ErrSkipVerify("no ExpressDefinition")
+		return fmt.Errorf("no ExpressDefinition: %w", ErrSkipVerify)
 	}
 	ex, err := d.LoadExpressDefinition(d.config.ExpressDefinitionPath)
 	if err != nil {
@@ -596,7 +595,7 @@ func (d *App) verifyLoadBalancer(ctx context.Context, lb types.LoadBalancer, td 
 			return wrapPermissionError(err)
 		}
 		if len(out.TargetGroups) == 0 {
-			return ErrNotFound(fmt.Sprintf("target group %s is not found", tgArn))
+			return fmt.Errorf("target group %s is not found: %w", tgArn, ErrNotFound)
 		}
 		return nil
 	})
@@ -626,7 +625,7 @@ func (d *App) verifyLoadBalancer(ctx context.Context, lb types.LoadBalancer, td 
 				return wrapPermissionError(err)
 			}
 			if len(out.TargetGroups) == 0 {
-				return ErrNotFound(fmt.Sprintf("target group %s is not found", tgArn))
+				return fmt.Errorf("target group %s is not found: %w", tgArn, ErrNotFound)
 			}
 			return nil
 		})
@@ -746,7 +745,7 @@ func (d *App) verifyRegistryImage(ctx context.Context, image, user, password str
 	ok, err = repo.HasPlatformImage(ctx, tagOrDigest, arch, os)
 	if err != nil {
 		if errors.Is(err, registry.ErrDeprecatedManifest) || errors.Is(err, registry.ErrPullRateLimitExceeded) {
-			return ErrSkipVerify(err.Error())
+			return fmt.Errorf("%s: %w", err.Error(), ErrSkipVerify)
 		}
 		return err
 	}
@@ -917,7 +916,7 @@ func (d *App) verifyExpressLogConfiguration(ctx context.Context, lc *types.Expre
 	}
 
 	if !d.verifier.opt.PutLogs {
-		return ErrSkipVerify(fmt.Sprintf("putting logs to %s", group))
+		return fmt.Errorf("putting logs to %s: %w", group, ErrSkipVerify)
 	}
 
 	var stream string
@@ -961,7 +960,7 @@ func (d *App) verifyLogConfiguration(ctx context.Context, c *types.ContainerDefi
 	}
 
 	if !d.verifier.opt.PutLogs {
-		return ErrSkipVerify(fmt.Sprintf("putting logs to %s", group))
+		return fmt.Errorf("putting logs to %s: %w", group, ErrSkipVerify)
 	}
 
 	if options["awslogs-create-group"] == "true" {

--- a/verify_test.go
+++ b/verify_test.go
@@ -3,6 +3,7 @@ package ecspresso_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -281,7 +282,7 @@ func TestVerifySkipResource(t *testing.T) {
 		vs := ecspresso.NewVerifyState(cache)
 		for i := range 3 {
 			r, err := vs.VerifyResource(context.TODO(), "skip resource", func(_ context.Context) error {
-				return ecspresso.ErrSkipVerify("hello")
+				return fmt.Errorf("hello: %w", ecspresso.ErrSkipVerify)
 			})
 			if err != nil {
 				t.Error("unexpected error for skip resource", err)
@@ -484,8 +485,7 @@ func TestWrapPermissionError(t *testing.T) {
 					t.Errorf("expected nil, got %v", result)
 				}
 			case "ErrPermissionDenied":
-				var permErr ecspresso.ErrPermissionDenied
-				if !errors.As(result, &permErr) {
+				if !errors.Is(result, ecspresso.ErrPermissionDenied) {
 					t.Errorf("expected ErrPermissionDenied, got %T", result)
 				}
 			case "mockAPIError":

--- a/wait.go
+++ b/wait.go
@@ -133,7 +133,7 @@ func (d *App) Wait(ctx context.Context, opt WaitOption) error {
 		return err
 	}
 	if err := doWait(ctx, sv); err != nil {
-		if errors.As(err, &errNotFound) && sv.isCodeDeploy() {
+		if errors.Is(err, ErrNotFound) && sv.isCodeDeploy() {
 			d.LogInfo(err.Error())
 			return d.WaitTaskSetStable(ctx, sv)
 		}
@@ -225,7 +225,7 @@ func (d *App) WaitServiceDeployCompleted(ctx context.Context, sv *Service) error
 	d.LogInfo("Waiting for service deployed...(it will take a few minutes)")
 	deploymentArn, err := d.findActiveECSDeploymentArn(ctx, time.Second*10)
 	if err != nil {
-		if errors.As(err, &errNotFound) {
+		if errors.Is(err, ErrNotFound) {
 			d.LogInfo("No active deployment found")
 			return nil // no active deployment, nothing to wait for
 		}
@@ -256,7 +256,7 @@ func (d *App) WaitServiceDeployCompleted(ctx context.Context, sv *Service) error
 			return fmt.Errorf("failed to describe service deployments: %w", err)
 		}
 		if len(resp.ServiceDeployments) == 0 {
-			return ErrNotFound("service deployment not found: " + deploymentArn)
+			return fmt.Errorf("service deployment not found: %s: %w", deploymentArn, ErrNotFound)
 		}
 		dp := resp.ServiceDeployments[0]
 
@@ -310,7 +310,7 @@ func (d *App) getCodeDeployDeploymentID(ctx context.Context) (string, error) {
 		return "", err
 	}
 	if len(out.Deployments) == 0 {
-		return "", ErrNotFound("No deployments found in progress on CodeDeploy")
+		return "", fmt.Errorf("No deployments found in progress on CodeDeploy: %w", ErrNotFound)
 	}
 
 	return out.Deployments[0], nil
@@ -419,7 +419,7 @@ func (d *App) showServiceStatus(ctx context.Context, st *showState) error {
 		return fmt.Errorf("failed to describe services: %w", err)
 	}
 	if len(out.Services) == 0 {
-		return ErrNotFound(fmt.Sprintf("service %s is not found", d.Service))
+		return fmt.Errorf("service %s is not found: %w", d.Service, ErrNotFound)
 	}
 	sv := out.Services[0]
 


### PR DESCRIPTION
## Summary

Bundles all the `## Cleanups` items from [docs/v3-plan.md](docs/v3-plan.md) — each is a small intentional API break, kept together to keep follow-up PRs focused.

### Sentinel errors
- Replace the string-typed `ErrSkipVerify` / `ErrNotFound` / `ErrConflictOptions` / `ErrPermissionDenied` value types with idiomatic `var Err... = errors.New(...)` sentinels.
- Construction: `fmt.Errorf("...: %w", ..., ErrXxx)`. Detection: `errors.Is(err, ErrXxx)` everywhere.
- `wrapPermissionError` wraps with `fmt.Errorf("%s: %w", err.Error(), ErrPermissionDenied)` instead of constructing a typed value.
- `"conflict options"` → `"conflicting options"`.

### Unexport library internals
- Delete `WithConfigLoader` (zero callers).
- Drop the `CLIParseFunc` named type; `CLI()` takes the function signature inline.
- `CLIOptions.ForSubCommand` → `forSubCommand` (re-exported in `export_test.go` for `package ecspresso_test`).
- `ExportEnvFile` → `exportEnvFile`.
- `ConfigPlugin.Render` → `render` (added in pre-v3 #1023, unexporting before v3 ships and external code starts depending on it).

### Tuning vars become const
- `delayForServiceChanged` / `refreshInterval` / `waiterMaxDelay` / `spcIndent` were package-level mutable `var`s but no code writes to them. Make them `const`.

### Rename
- `cliv2.go` → `cli_parse.go`, `ParseCLIv2` → `ParseCLI`. The v1→v2 parser switch this was named for is long gone.

### Breaking changes for library callers
- Anyone using `errors.As(err, &ecspresso.ErrXxx{...})` against the old string types must switch to `errors.Is(err, ecspresso.ErrXxx)`.
- `WithConfigLoader`, `CLIParseFunc`, `ForSubCommand`, `ExportEnvFile`, `ConfigPlugin.Render` are no longer reachable.
- `ParseCLIv2` is now `ParseCLI`.

Tracked in [docs/v3-plan.md](docs/v3-plan.md#cleanups).