### PR TITLE
Add WithPluginInstance AppOption to inject plugin backings

### DIFF
--- a/config.go
+++ b/config.go
@@ -135,7 +135,7 @@ type ConfigCodeDeploy struct {
 //
 // The `plugins` section itself cannot reference plugin-provided
 // functions — that would be a chicken-and-egg loop.
-func (l *configLoader) Load(ctx context.Context, path string, version string) (*Config, error) {
+func (l *configLoader) Load(ctx context.Context, path string, version string, preProvided []preProvidedPlugin) (*Config, error) {
 	conf := &Config{path: path}
 	ext := filepath.Ext(path)
 	switch ext {
@@ -151,7 +151,7 @@ func (l *configLoader) Load(ctx context.Context, path string, version string) (*
 		return nil, err
 	}
 	pre := &Config{path: path, dir: filepath.Dir(path), Plugins: plugins, Region: region}
-	if err := pre.prepareAWSAndPlugins(ctx); err != nil {
+	if err := pre.prepareAWSAndPlugins(ctx, preProvided); err != nil {
 		return nil, err
 	}
 	for _, f := range pre.jsonnetNativeFuncs {
@@ -364,7 +364,12 @@ func (c *Config) Restrict(ctx context.Context) error {
 		return err
 	}
 	if !c.pluginsConfigured {
-		if err := c.setupPlugins(ctx); err != nil {
+		// Reached only when the loader was bypassed (WithConfig). There
+		// is no preProvided list to honour here — callers wiring a
+		// Config manually are expected to populate c.pluginInstances
+		// and templateFuncs / jsonnetNativeFuncs themselves if they
+		// need that.
+		if err := c.setupPlugins(ctx, nil); err != nil {
 			return fmt.Errorf("failed to setup plugins: %w", err)
 		}
 		c.pluginsConfigured = true
@@ -400,12 +405,14 @@ func (c *Config) loadAWSConfig(ctx context.Context) error {
 
 // prepareAWSAndPlugins loads c.awsv2Config and runs plugin setup. Used
 // by the jsonnet two-pass loader before the second evaluation so plugin-
-// supplied native functions are registered on the VM.
-func (c *Config) prepareAWSAndPlugins(ctx context.Context) error {
+// supplied native functions are registered on the VM. preProvided
+// instances bypass the corresponding plugin Setup (see
+// WithPluginInstance).
+func (c *Config) prepareAWSAndPlugins(ctx context.Context, preProvided []preProvidedPlugin) error {
 	if err := c.loadAWSConfig(ctx); err != nil {
 		return err
 	}
-	if err := c.setupPlugins(ctx); err != nil {
+	if err := c.setupPlugins(ctx, preProvided); err != nil {
 		return fmt.Errorf("failed to setup plugins: %w", err)
 	}
 	c.pluginsConfigured = true
@@ -422,14 +429,51 @@ func (c *Config) AssumeRole(assumeRoleARN string) {
 	c.awsv2Config.Credentials = aws.NewCredentialsCache(assumeRoleProvider)
 }
 
-func (c *Config) setupPlugins(ctx context.Context) error {
+type pluginKey struct {
+	name       string
+	funcPrefix string
+}
+
+// setupPlugins runs Setup for every plugin in c.Plugins plus the
+// default (ssm, secretsmanager) plugins. When a (name, funcPrefix)
+// pair appears in preProvided, that plugin's Setup is bypassed and the
+// caller-supplied instance is registered instead — see
+// WithPluginInstance for the rationale. Pre-provided instances that
+// match no config plugin entry are still registered after the loop, so
+// callers can drive lookups without having to add a corresponding
+// `plugins:` entry to the config file.
+func (c *Config) setupPlugins(ctx context.Context, preProvided []preProvidedPlugin) error {
+	pre := make(map[pluginKey]PluginInstance, len(preProvided))
+	for _, p := range preProvided {
+		pre[pluginKey{p.name, p.funcPrefix}] = p.instance
+	}
+
 	plugins := []ConfigPlugin{}
 	for _, name := range defaultPluginNames {
 		plugins = append(plugins, ConfigPlugin{Name: name})
 	}
 	plugins = append(plugins, c.Plugins...)
+
 	for _, p := range plugins {
+		key := pluginKey{p.Name, p.FuncPrefix}
+		if inst, ok := pre[key]; ok {
+			if err := p.register(ctx, c, inst); err != nil {
+				return err
+			}
+			delete(pre, key)
+			continue
+		}
 		if err := p.Setup(ctx, c); err != nil {
+			return err
+		}
+	}
+
+	// Pre-provided instances with no matching config plugin entry are
+	// still registered so the host can supply funcs (e.g. `tfstate(...)`)
+	// without forcing users to add a corresponding `plugins:` block.
+	for key, inst := range pre {
+		p := ConfigPlugin{Name: key.name, FuncPrefix: key.funcPrefix}
+		if err := p.register(ctx, c, inst); err != nil {
 			return err
 		}
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	"github.com/fujiwara/tfstate-lookup/tfstate"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/kayac/ecspresso/v2"
@@ -65,7 +66,7 @@ func TestLoadConfigWithPluginDuplicate(t *testing.T) {
 	t.Setenv("JSON", `{"foo":"bar"}`)
 	ctx := t.Context()
 	loader := ecspresso.NewConfigLoader(nil, nil)
-	_, err := loader.Load(ctx, "tests/config_duplicate_plugins.yaml", "")
+	_, err := loader.Load(ctx, "tests/config_duplicate_plugins.yaml", "", nil)
 	if err == nil {
 		t.Log("expected an error to occur, but it didn't.")
 		t.FailNow()
@@ -306,7 +307,7 @@ func TestLoadConfigWithoutTimeout(t *testing.T) {
 
 	ctx := t.Context()
 	loader := ecspresso.NewConfigLoader(nil, nil)
-	conf, err := loader.Load(ctx, "tests/notimeout.yml", "")
+	conf, err := loader.Load(ctx, "tests/notimeout.yml", "", nil)
 	if err != nil {
 		t.Log("unexpected an error", err)
 		t.FailNow()
@@ -328,7 +329,7 @@ func TestLoadConfigForCodeDeploy(t *testing.T) {
 	loader := ecspresso.NewConfigLoader(nil, nil)
 	for _, ext := range []string{"yml", "json", "jsonnet"} {
 		name := "tests/config_codedeploy." + ext
-		conf, err := loader.Load(ctx, name, "")
+		conf, err := loader.Load(ctx, name, "", nil)
 		if err != nil {
 			t.Error(err)
 		}
@@ -470,6 +471,64 @@ func TestLoadConfigWithTFStateInConfig(t *testing.T) {
 				t.Errorf("app.Name() = %q, want %q", got, want)
 			}
 		})
+	}
+}
+
+// A caller-supplied *tfstate.TFState injected via WithPluginInstance
+// must drive `tfstate(...)` lookups in the config even when the
+// config file has no `plugins:` block at all. Confirms the loader
+// registers funcMaps from pre-provided instances that match no
+// config plugin entry.
+func TestLoadConfigWithPluginInstanceNoConfigEntry(t *testing.T) {
+	t.Setenv("AWS_REGION", "ap-northeast-1")
+	state := tfstate.Empty()
+	state.SetOverrides(map[string]any{
+		"aws_ecs_cluster.main.name": "injected-cluster",
+		"aws_ecs_service.main.name": "injected-service",
+	})
+	ctx := t.Context()
+	app, err := ecspresso.New(ctx,
+		&ecspresso.CLIOptions{ConfigFilePath: "tests/config_tfstate_injected.yaml"},
+		ecspresso.WithPluginInstance("tfstate", "", state),
+	)
+	if err != nil {
+		t.Fatalf("New failed: %s", err)
+	}
+	if got, want := app.Config().Cluster, "injected-cluster"; got != want {
+		t.Errorf("cluster = %q, want %q (pre-provided override)", got, want)
+	}
+	if got, want := app.Config().Service, "injected-service"; got != want {
+		t.Errorf("service = %q, want %q (pre-provided override)", got, want)
+	}
+	if inst := app.PluginInstance("tfstate", ""); inst == nil {
+		t.Errorf("PluginInstance(tfstate, \"\") = nil, want the injected *tfstate.TFState")
+	}
+}
+
+// A pre-provided tfstate instance wins over a matching `plugins:`
+// entry in the config: the entry's Setup is skipped (so a broken
+// `path:` does not fail Load), and lookups resolve from the
+// in-memory overrides.
+func TestLoadConfigWithPluginInstanceWinsOverConfigEntry(t *testing.T) {
+	t.Setenv("AWS_REGION", "ap-northeast-1")
+	state := tfstate.Empty()
+	state.SetOverrides(map[string]any{
+		"aws_ecs_cluster.main.name": "from-override",
+	})
+	ctx := t.Context()
+	app, err := ecspresso.New(ctx,
+		// This fixture has plugins: [{name: tfstate, config: {path: terraform.tfstate}}].
+		// The on-disk tfstate file's value is "test-cluster"; the
+		// override below is "from-override". If the pre-provided
+		// instance correctly wins, we see "from-override".
+		&ecspresso.CLIOptions{ConfigFilePath: "tests/config_tfstate_in_config.yaml"},
+		ecspresso.WithPluginInstance("tfstate", "", state),
+	)
+	if err != nil {
+		t.Fatalf("New failed: %s", err)
+	}
+	if got, want := app.Config().Cluster, "from-override"; got != want {
+		t.Errorf("cluster = %q, want %q (pre-provided override wins)", got, want)
 	}
 }
 

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -176,9 +176,16 @@ type App struct {
 }
 
 type appOptions struct {
-	config *Config
-	loader *configLoader
-	logger *slog.Logger
+	config             *Config
+	loader             *configLoader
+	logger             *slog.Logger
+	preProvidedPlugins []preProvidedPlugin
+}
+
+type preProvidedPlugin struct {
+	name       string
+	funcPrefix string
+	instance   PluginInstance
 }
 
 type AppOption func(*appOptions)
@@ -192,6 +199,36 @@ func WithConfig(c *Config) AppOption {
 func WithLogger(l *slog.Logger) AppOption {
 	return func(o *appOptions) {
 		o.logger = l
+	}
+}
+
+// WithPluginInstance pre-provides a runtime plugin instance keyed by
+// (name, funcPrefix). When the config loader encounters a matching
+// plugin entry — or even when no such entry exists — it registers the
+// instance's template funcs and jsonnet native funcs instead of running
+// the plugin's Setup. Use this to drive tfstate / cfn / ssm /
+// secretsmanager lookups from an in-memory source (e.g. terraform
+// provider state, test fixtures) without touching ecspresso's on-disk
+// config or making AWS calls during config load.
+//
+// Match semantics: pluginKey is the pair (name, funcPrefix). For the
+// default plugins (ssm, secretsmanager) funcPrefix is "". A
+// pre-provided instance with a matching key wins; the corresponding
+// config plugin's Setup is skipped entirely. A pre-provided instance
+// that matches no config plugin entry is still registered, so
+// `plugins:` can be omitted from the config file altogether when the
+// host supplies all the bindings it needs.
+//
+// The instance must remain usable for the lifetime of the returned
+// *App: every template render and jsonnet evaluation will call into
+// it.
+func WithPluginInstance(name, funcPrefix string, instance PluginInstance) AppOption {
+	return func(o *appOptions) {
+		o.preProvidedPlugins = append(o.preProvidedPlugins, preProvidedPlugin{
+			name:       name,
+			funcPrefix: funcPrefix,
+			instance:   instance,
+		})
 	}
 }
 
@@ -210,7 +247,7 @@ func New(ctx context.Context, opt *CLIOptions, newAppOptions ...AppOption) (*App
 
 	// load config file
 	if appOpts.config == nil {
-		if config, err := appOpts.loader.Load(ctx, opt.ConfigFilePath, Version); err != nil {
+		if config, err := appOpts.loader.Load(ctx, opt.ConfigFilePath, Version, appOpts.preProvidedPlugins); err != nil {
 			return nil, fmt.Errorf("failed to load config file %s: %w", opt.ConfigFilePath, err)
 		} else {
 			appOpts.config = config

--- a/plugin.go
+++ b/plugin.go
@@ -21,6 +21,19 @@ import (
 
 var defaultPluginNames = []string{"ssm", "secretsmanager"}
 
+// PluginInstance is the public surface a plugin instance exposes to the
+// config loader. tfstate.TFState, *cfn.App, *ssm.App,
+// *secretsmanager.App and *external.Plugin all satisfy this interface
+// directly. Callers can hand a pre-built instance to ecspresso.New via
+// WithPluginInstance so the loader skips the plugin's own Setup and
+// uses the provided instance instead. This lets hosts (terraform
+// providers, test harnesses) inject in-memory tfstate / cfn / ssm /
+// secretsmanager backings without touching the on-disk config.
+type PluginInstance interface {
+	FuncMap(ctx context.Context) template.FuncMap
+	JsonnetNativeFuncs(ctx context.Context) []*jsonnet.NativeFunction
+}
+
 type ConfigPlugin struct {
 	Name       string         `yaml:"name" json:"name,omitempty"`
 	Config     map[string]any `yaml:"config" json:"config,omitempty"`
@@ -97,6 +110,24 @@ func (p ConfigPlugin) Setup(ctx context.Context, c *Config) error {
 	default:
 		return fmt.Errorf("plugin %s is not available", p.Name)
 	}
+}
+
+// register binds a caller-supplied PluginInstance to this plugin
+// entry: records it in c.pluginInstances and registers its template
+// funcs and jsonnet native funcs (prefixed with p.FuncPrefix). The
+// plugin's own Setup is bypassed — no AWS calls, no tfstate file read,
+// no external command exec — so callers can drive the lookups in
+// memory.
+func (p ConfigPlugin) register(ctx context.Context, c *Config, inst PluginInstance) error {
+	c.pluginInstances = append(c.pluginInstances, pluginInstance{
+		name:       p.Name,
+		funcPrefix: p.FuncPrefix,
+		value:      inst,
+	})
+	if err := p.AppendFuncMap(c, inst.FuncMap(ctx)); err != nil {
+		return err
+	}
+	return p.AppendJsonnetNativeFuncs(c, inst.JsonnetNativeFuncs(ctx))
 }
 
 func (p ConfigPlugin) AppendFuncMap(c *Config, funcMap template.FuncMap) error {

--- a/tests/config_tfstate_injected.yaml
+++ b/tests/config_tfstate_injected.yaml
@@ -1,0 +1,11 @@
+# Uses `tfstate(...)` for cluster/service but defines no `plugins:`
+# block. The host injects the tfstate instance via
+# ecspresso.WithPluginInstance — config evaluation must still
+# succeed because the loader registers funcMaps from the pre-provided
+# instance even when it matches no config plugin entry.
+region: ap-northeast-1
+cluster: "{{ tfstate `aws_ecs_cluster.main.name` }}"
+service: "{{ tfstate `aws_ecs_service.main.name` }}"
+service_definition: ecs-service-def.jsonnet
+task_definition: ecs-task-def.jsonnet
+timeout: 10m0s


### PR DESCRIPTION
## Summary
- Add `ecspresso.PluginInstance` interface (`FuncMap`, `JsonnetNativeFuncs`) — already satisfied by `*tfstate.TFState`, `*cfn.App`, `*ssm.App`, `*secretsmanager.App`, `*external.Plugin`.
- Add `ecspresso.WithPluginInstance(name, funcPrefix, instance)` AppOption.
- In the two-pass loader, pre-provided instances bypass the matching plugin's Setup and register their funcs directly. Pre-provided entries that match no config plugin are still registered, so the host can drop the `plugins:` block entirely.

## Why
Pass 1 of the loader runs plugin Setup (e.g. tfstate reads its file), then Pass 2 evaluates config-level fields like `cluster: tfstate(...)`. There is currently no way for a host driving ecspresso as a library to inject its own state between those passes — `app.PluginInstance(...).SetOverrides(...)` runs after `New()` returns, too late for `cluster`/`service`/`region`.

Motivating use case: `terraform-provider-ecspresso` wants `tfstate_values` to be the single source of truth for every `tfstate(...)` lookup in the ecspresso config, including the new pre-v3 config-level fields. With `WithPluginInstance`, the provider hands in an in-memory `*tfstate.TFState` and no on-disk tfstate file or `plugins:` entry is needed.

## Breaking change
- `configLoader.Load` gains a `preProvided []preProvidedPlugin` parameter. The type is unexported, so external callers can only pass `nil`.

Acceptable on pre-v3.