### PR TITLE
Add jsonrpc mode to external plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1793,9 +1793,9 @@ Response format (error):
 
 - `method` is the `name` field from the plugin config.
 - `params` is an array of string arguments passed to the template function.
-- The `id` field correlates a request with its response. ecspresso rejects a response whose `id` does not match the request and restarts the process.
-- `timeout` applies per call. When a call times out the process is killed and will be restarted on the next call.
-- The process is terminated (its stdin is closed, then SIGTERM/SIGKILL) when ecspresso exits.
+- The `id` field correlates a request with its response. A response whose `id` does not match the request is treated as an error.
+- `timeout` applies per call. A call that times out fails immediately, the same as `exec` mode. The process is killed so a stalled command does not linger.
+- The process is also terminated when ecspresso exits (its stdin is closed, then SIGTERM/SIGKILL).
 
 Example configuration using a long-running Python server:
 

--- a/README.md
+++ b/README.md
@@ -1751,6 +1751,9 @@ The `config` section defines the following parameters:
 - `num_args`: number of arguments (optional, default 0)
 - `parser`: parser type "json" or "string" (optional, default "json")
 - `timeout`: command execution timeout (optional, default never timeout). Accepts a duration string (`"30s"`, `"5m"`, `"1h"`) or a bare number / digit string interpreted as seconds (`30` → 30 seconds).
+- `mode`: execution mode "exec" or "jsonrpc" (optional, default "exec")
+  - `exec`: the command is launched once per template function call (default)
+  - `jsonrpc`: the command is launched once on the first call and kept running; subsequent calls communicate over stdin/stdout using [JSON RPC 2.0](https://www.jsonrpc.org/specification). Useful for commands with high startup cost.
 
 And use the template function in the definition files as follows.
 
@@ -1765,6 +1768,46 @@ local jq = std.native('jq');
 {
   "today": "{{ (jq `{Now: now | todateiso8601}`).Now }}"
 }
+```
+
+#### JSON RPC mode
+
+When `mode: jsonrpc` is set, ecspresso launches the command once and keeps it running. Each template function call sends a [JSON RPC 2.0](https://www.jsonrpc.org/specification) request to the process's stdin and reads the response from stdout.
+
+The external process must read newline-delimited JSON requests from stdin and write newline-delimited JSON responses to stdout.
+
+Request format:
+```json
+{"jsonrpc":"2.0","method":"<name>","params":["arg0","arg1"],"id":1}
+```
+
+Response format (success):
+```json
+{"jsonrpc":"2.0","result":<any JSON value>,"id":1}
+```
+
+Response format (error):
+```json
+{"jsonrpc":"2.0","error":{"code":-32600,"message":"error message"},"id":1}
+```
+
+- `method` is the `name` field from the plugin config.
+- `params` is an array of string arguments passed to the template function.
+- The `id` field correlates a request with its response. ecspresso rejects a response whose `id` does not match the request and restarts the process.
+- `timeout` applies per call. When a call times out the process is killed and will be restarted on the next call.
+- The process is terminated (its stdin is closed, then SIGTERM/SIGKILL) when ecspresso exits.
+
+Example configuration using a long-running Python server:
+
+```yaml
+plugins:
+  - name: external
+    config:
+      name: lookup
+      command: ["python3", "lookup_server.py"]
+      num_args: 1
+      mode: jsonrpc
+      timeout: 10
 ```
 
 ## LICENSE

--- a/cli.go
+++ b/cli.go
@@ -145,7 +145,11 @@ func dispatchApp(ctx context.Context, sub string, usage func(), opts *CLIOptions
 	if err != nil {
 		return err
 	}
-	defer app.Close()
+	defer func() {
+		if err := app.Close(); err != nil {
+			app.LogWarn("failed to close app", "error", err.Error())
+		}
+	}()
 	app.LogDebug("dispatching subcommand: %s", sub)
 	switch sub {
 	case "deploy":

--- a/cli.go
+++ b/cli.go
@@ -145,6 +145,7 @@ func dispatchApp(ctx context.Context, sub string, usage func(), opts *CLIOptions
 	if err != nil {
 		return err
 	}
+	defer app.Close()
 	app.LogDebug("dispatching subcommand: %s", sub)
 	switch sub {
 	case "deploy":

--- a/docs/v3-plan.md
+++ b/docs/v3-plan.md
@@ -183,6 +183,19 @@ duration value is unusually large for a timeout; interpreted as seconds (v2 inte
 - Users who wrote `timeout: 600` meaning "ten minutes" but got 600 ns in v2 are silently fixed.
 - Users who deliberately wrote nanoseconds as a plain number now get a behaviour change, but they also get a clear warning at load time.
 
+## Features
+
+### Add jsonrpc mode to the external plugin
+
+PR: https://github.com/kayac/ecspresso/pull/1041
+
+The `external` plugin execs its command once per template function call, which is costly for commands with high startup time. A new `mode: jsonrpc` starts the command once and keeps it running, communicating over stdin/stdout with JSON RPC 2.0.
+
+- New `mode` config field selects `exec` (default, unchanged behaviour) or `jsonrpc`.
+- In `jsonrpc` mode the process starts on first use and is reused across calls.
+- `timeout` applies per call. On timeout, IO error, or response-id mismatch the process is reset and restarted on the next call.
+- The process is registered as a plugin instance and terminated via `App.Close` (stdin closed, then SIGTERM/SIGKILL) when ecspresso exits.
+
 ## Cleanups
 
 All cleanup items below ship together in PR: https://github.com/kayac/ecspresso/pull/1029

--- a/ecspresso.go
+++ b/ecspresso.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"sort"
@@ -307,6 +308,24 @@ func (d *App) PluginInstance(name, funcPrefix string) any {
 		}
 	}
 	return nil
+}
+
+// Close releases resources held by the App, such as long-running
+// external plugin processes started in jsonrpc mode. Plugins that do not
+// hold such resources are skipped. It is safe to call multiple times.
+func (d *App) Close() error {
+	if d.config == nil {
+		return nil
+	}
+	var errs []error
+	for _, inst := range d.config.pluginInstances {
+		if c, ok := inst.value.(io.Closer); ok {
+			if err := c.Close(); err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+	return errors.Join(errs...)
 }
 
 func (d *App) Timeout() time.Duration {

--- a/external/external.go
+++ b/external/external.go
@@ -147,10 +147,13 @@ func (p *Plugin) startProcess() (*rpcProcess, error) {
 	}
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
+		stdin.Close() //nolint:errcheck
 		return nil, fmt.Errorf("failed to create stdout pipe: %w", err)
 	}
 	cmd.Stderr = os.Stderr
 	if err := cmd.Start(); err != nil {
+		stdin.Close()  //nolint:errcheck
+		stdout.Close() //nolint:errcheck
 		return nil, fmt.Errorf("failed to start jsonrpc process: %w", err)
 	}
 	return &rpcProcess{
@@ -197,8 +200,12 @@ func (p *Plugin) resetProcess() {
 	proc.stdin.Close()  //nolint:errcheck
 	proc.stdout.Close() //nolint:errcheck
 
+	// Send SIGTERM synchronously so it is delivered even if the program
+	// exits right after Close(); reaping the process (and escalating to
+	// SIGKILL) happens in the background.
+	proc.cmd.Process.Signal(syscall.SIGTERM) //nolint:errcheck
+
 	go func() {
-		proc.cmd.Process.Signal(syscall.SIGTERM) //nolint:errcheck
 		done := make(chan struct{})
 		go func() {
 			proc.cmd.Wait() //nolint:errcheck
@@ -208,7 +215,7 @@ func (p *Plugin) resetProcess() {
 		case <-done:
 		case <-time.After(5 * time.Second):
 			proc.cmd.Process.Kill() //nolint:errcheck
-			proc.cmd.Wait()         //nolint:errcheck
+			<-done                  // let the single Wait above return
 		}
 	}()
 }

--- a/external/external.go
+++ b/external/external.go
@@ -5,7 +5,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"os"
 	"os/exec"
+	"sync"
+	"sync/atomic"
 	"syscall"
 	"text/template"
 	"time"
@@ -15,9 +19,10 @@ import (
 	"github.com/kayac/ecspresso/v2/duration"
 )
 
-type Plugin struct {
-	Config *Config
-}
+const (
+	ModeExec    = "exec"
+	ModeJSONRPC = "jsonrpc"
+)
 
 type Config struct {
 	Name    string            `json:"name" yaml:"name"`
@@ -25,6 +30,42 @@ type Config struct {
 	NumArgs int               `json:"num_args" yaml:"num_args"`
 	Parser  string            `json:"parser" yaml:"parser"`
 	Timeout duration.Duration `json:"timeout" yaml:"timeout"`
+	Mode    string            `json:"mode" yaml:"mode"`
+}
+
+type Plugin struct {
+	Config *Config
+	proc   *rpcProcess
+	mu     sync.Mutex
+}
+
+type rpcProcess struct {
+	cmd    *exec.Cmd
+	enc    *json.Encoder
+	dec    *json.Decoder
+	stdin  io.WriteCloser
+	stdout io.ReadCloser
+	mu     sync.Mutex
+	id     atomic.Int64
+}
+
+type rpcRequest struct {
+	JSONRPC string   `json:"jsonrpc"`
+	Method  string   `json:"method"`
+	Params  []string `json:"params"`
+	ID      int64    `json:"id"`
+}
+
+type rpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+	ID      int64           `json:"id"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
 }
 
 func NewPlugin(ctx context.Context, cfg *Config) (*Plugin, error) {
@@ -35,15 +76,30 @@ func NewPlugin(ctx context.Context, cfg *Config) (*Plugin, error) {
 		return nil, fmt.Errorf("name is required")
 	}
 	if cfg.Parser == "" {
-		cfg.Parser = "json" // default parser
+		cfg.Parser = "json"
 	}
 	if cfg.Parser != "json" && cfg.Parser != "string" {
 		return nil, fmt.Errorf("unsupported parser: %s", cfg.Parser)
+	}
+	if cfg.Mode == "" {
+		cfg.Mode = ModeExec
+	}
+	if cfg.Mode != ModeExec && cfg.Mode != ModeJSONRPC {
+		return nil, fmt.Errorf("unsupported mode: %s", cfg.Mode)
 	}
 	return &Plugin{Config: cfg}, nil
 }
 
 func (p *Plugin) Exec(ctx context.Context, extraArgs []string) (any, error) {
+	switch p.Config.Mode {
+	case ModeJSONRPC:
+		return p.callRPC(ctx, extraArgs)
+	default:
+		return p.execOnce(ctx, extraArgs)
+	}
+}
+
+func (p *Plugin) execOnce(ctx context.Context, extraArgs []string) (any, error) {
 	cmd, args := p.Config.Command[0], p.Config.Command[1:]
 	args = append(args, extraArgs...)
 	stdout := new(bytes.Buffer)
@@ -62,7 +118,7 @@ func (p *Plugin) Exec(ctx context.Context, extraArgs []string) (any, error) {
 		timedOut = true
 		return c.Process.Signal(syscall.SIGTERM)
 	}
-	c.WaitDelay = 5 * time.Second // SIGKILL after 5 seconds
+	c.WaitDelay = 5 * time.Second
 	if err := c.Run(); err != nil {
 		return nil, fmt.Errorf("failed to run command: %w stdout:%s stderr:%s", err, stdout.String(), stderr.String())
 	}
@@ -83,13 +139,181 @@ func (p *Plugin) Exec(ctx context.Context, extraArgs []string) (any, error) {
 	}
 }
 
+func (p *Plugin) startProcess() (*rpcProcess, error) {
+	cmd := exec.Command(p.Config.Command[0], p.Config.Command[1:]...)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create stdin pipe: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create stdout pipe: %w", err)
+	}
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("failed to start jsonrpc process: %w", err)
+	}
+	return &rpcProcess{
+		cmd:    cmd,
+		enc:    json.NewEncoder(stdin),
+		dec:    json.NewDecoder(stdout),
+		stdin:  stdin,
+		stdout: stdout,
+	}, nil
+}
+
+func (p *Plugin) getOrStartProcess() (*rpcProcess, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.proc != nil {
+		return p.proc, nil
+	}
+	proc, err := p.startProcess()
+	if err != nil {
+		return nil, err
+	}
+	p.proc = proc
+	return proc, nil
+}
+
+// resetProcess clears p.proc and tears down the running process so the
+// next call will restart it. The pipes are closed synchronously so any
+// in-flight Encode/Decode unblocks immediately; the process itself is
+// reaped in the background (SIGTERM, then SIGKILL after a grace period).
+// Safe to call concurrently with callRPC.
+func (p *Plugin) resetProcess() {
+	p.mu.Lock()
+	if p.proc == nil {
+		p.mu.Unlock()
+		return
+	}
+	proc := p.proc
+	p.proc = nil
+	p.mu.Unlock()
+
+	// Closing the pipes unblocks a goroutine blocked in dec.Decode (or a
+	// blocked enc.Encode) right away, instead of waiting for the process
+	// to notice EOF and exit.
+	proc.stdin.Close()  //nolint:errcheck
+	proc.stdout.Close() //nolint:errcheck
+
+	go func() {
+		proc.cmd.Process.Signal(syscall.SIGTERM) //nolint:errcheck
+		done := make(chan struct{})
+		go func() {
+			proc.cmd.Wait() //nolint:errcheck
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			proc.cmd.Process.Kill() //nolint:errcheck
+			proc.cmd.Wait()         //nolint:errcheck
+		}
+	}()
+}
+
+func (p *Plugin) callRPC(ctx context.Context, extraArgs []string) (any, error) {
+	if p.Config.Timeout.Duration > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, p.Config.Timeout.Duration)
+		defer cancel()
+	}
+
+	params := extraArgs
+	if params == nil {
+		params = []string{}
+	}
+
+	// Retry once if the process we obtained was retired (by another
+	// call's reset) between getOrStartProcess and acquiring proc.mu, so
+	// the caller transparently uses the freshly started process instead
+	// of failing on a dead pipe.
+	for range 2 {
+		proc, err := p.getOrStartProcess()
+		if err != nil {
+			return nil, err
+		}
+		proc.mu.Lock()
+		p.mu.Lock()
+		stale := p.proc != proc
+		p.mu.Unlock()
+		if stale {
+			proc.mu.Unlock()
+			continue
+		}
+		result, err := p.rpcRoundtrip(ctx, proc, params)
+		proc.mu.Unlock()
+		return result, err
+	}
+	return nil, fmt.Errorf("jsonrpc process repeatedly restarted: %s", p.Config.Name)
+}
+
+// rpcRoundtrip sends a single request and waits for its response. The
+// caller must hold proc.mu so requests are serialized and responses are
+// read in order. On any I/O error, timeout, or response-id mismatch the
+// process is reset so a subsequent call restarts it from a clean state.
+func (p *Plugin) rpcRoundtrip(ctx context.Context, proc *rpcProcess, params []string) (any, error) {
+	req := rpcRequest{
+		JSONRPC: "2.0",
+		Method:  p.Config.Name,
+		Params:  params,
+		ID:      proc.id.Add(1),
+	}
+	if err := proc.enc.Encode(req); err != nil {
+		p.resetProcess()
+		return nil, fmt.Errorf("failed to send jsonrpc request: %w", err)
+	}
+
+	type decodeResult struct {
+		resp rpcResponse
+		err  error
+	}
+	ch := make(chan decodeResult, 1)
+	go func() {
+		var resp rpcResponse
+		err := proc.dec.Decode(&resp)
+		ch <- decodeResult{resp, err}
+	}()
+
+	select {
+	case r := <-ch:
+		if r.err != nil {
+			p.resetProcess()
+			return nil, fmt.Errorf("failed to read jsonrpc response: %w", r.err)
+		}
+		if r.resp.ID != req.ID {
+			// Responses are out of sync with requests; the stream is no
+			// longer trustworthy, so discard the process.
+			p.resetProcess()
+			return nil, fmt.Errorf("jsonrpc response id mismatch: got %d, want %d", r.resp.ID, req.ID)
+		}
+		if r.resp.Error != nil {
+			return nil, fmt.Errorf("jsonrpc error: %s (code: %d)", r.resp.Error.Message, r.resp.Error.Code)
+		}
+		var value any
+		if err := json.Unmarshal(r.resp.Result, &value); err != nil {
+			return nil, fmt.Errorf("failed to decode jsonrpc result: %w", err)
+		}
+		return value, nil
+	case <-ctx.Done():
+		p.resetProcess()
+		return nil, fmt.Errorf("jsonrpc call timed out: %s", p.Config.Name)
+	}
+}
+
+// Close terminates the long-running jsonrpc process if one is running.
+func (p *Plugin) Close() error {
+	p.resetProcess()
+	return nil
+}
+
 func (p *Plugin) FuncMap(ctx context.Context) template.FuncMap {
-	funcs := template.FuncMap{
+	return template.FuncMap{
 		p.Config.Name: func(args ...string) (any, error) {
 			return p.Exec(ctx, args)
 		},
 	}
-	return funcs
 }
 
 func (p *Plugin) JsonnetNativeFuncs(ctx context.Context) []*jsonnet.NativeFunction {
@@ -104,11 +328,11 @@ func (p *Plugin) JsonnetNativeFuncs(ctx context.Context) []*jsonnet.NativeFuncti
 			Func: func(args []any) (any, error) {
 				pArgs := make([]string, len(args))
 				for i, arg := range args {
-					if s, ok := arg.(string); ok {
-						pArgs[i] = s
-					} else {
+					s, ok := arg.(string)
+					if !ok {
 						return nil, fmt.Errorf("arg%d must be string", i)
 					}
+					pArgs[i] = s
 				}
 				return p.Exec(ctx, pArgs)
 			},

--- a/external/external.go
+++ b/external/external.go
@@ -176,11 +176,11 @@ func (p *Plugin) getOrStartProcess() (*rpcProcess, error) {
 	return proc, nil
 }
 
-// resetProcess clears p.proc and tears down the running process so the
-// next call will restart it. The pipes are closed synchronously so any
-// in-flight Encode/Decode unblocks immediately; the process itself is
-// reaped in the background (SIGTERM, then SIGKILL after a grace period).
-// Safe to call concurrently with callRPC.
+// resetProcess clears p.proc and tears down the running process. The
+// pipes are closed synchronously so any in-flight Encode/Decode unblocks
+// immediately; the process itself is reaped in the background (SIGTERM,
+// then SIGKILL after a grace period). Safe to call concurrently with
+// callRPC.
 func (p *Plugin) resetProcess() {
 	p.mu.Lock()
 	if p.proc == nil {
@@ -251,8 +251,9 @@ func (p *Plugin) callRPC(ctx context.Context, extraArgs []string) (any, error) {
 
 // rpcRoundtrip sends a single request and waits for its response. The
 // caller must hold proc.mu so requests are serialized and responses are
-// read in order. On any I/O error, timeout, or response-id mismatch the
-// process is reset so a subsequent call restarts it from a clean state.
+// read in order. On any I/O error, timeout, or response-id mismatch it
+// returns the error and kills the process (the stream can no longer be
+// trusted), matching exec mode where a timed-out call fails immediately.
 func (p *Plugin) rpcRoundtrip(ctx context.Context, proc *rpcProcess, params []string) (any, error) {
 	req := rpcRequest{
 		JSONRPC: "2.0",

--- a/external/external.go
+++ b/external/external.go
@@ -232,28 +232,17 @@ func (p *Plugin) callRPC(ctx context.Context, extraArgs []string) (any, error) {
 		params = []string{}
 	}
 
-	// Retry once if the process we obtained was retired (by another
-	// call's reset) between getOrStartProcess and acquiring proc.mu, so
-	// the caller transparently uses the freshly started process instead
-	// of failing on a dead pipe.
-	for range 2 {
-		proc, err := p.getOrStartProcess()
-		if err != nil {
-			return nil, err
-		}
-		proc.mu.Lock()
-		p.mu.Lock()
-		stale := p.proc != proc
-		p.mu.Unlock()
-		if stale {
-			proc.mu.Unlock()
-			continue
-		}
-		result, err := p.rpcRoundtrip(ctx, proc, params)
-		proc.mu.Unlock()
-		return result, err
+	// Calls are serialized on proc.mu (template / jsonnet rendering is
+	// single-goroutine, so this is the only contention point). A dead
+	// process surfaces as an error from rpcRoundtrip, which resets it; the
+	// next call then starts a fresh one via getOrStartProcess.
+	proc, err := p.getOrStartProcess()
+	if err != nil {
+		return nil, err
 	}
-	return nil, fmt.Errorf("jsonrpc process repeatedly restarted: %s", p.Config.Name)
+	proc.mu.Lock()
+	defer proc.mu.Unlock()
+	return p.rpcRoundtrip(ctx, proc, params)
 }
 
 // rpcRoundtrip sends a single request and waits for its response. The

--- a/external/external_test.go
+++ b/external/external_test.go
@@ -182,36 +182,17 @@ func TestExternalPluginJSONRPCTimeout(t *testing.T) {
 	}
 	defer p.Close()
 
-	if _, err := p.Exec(ctx, []string{"hello"}); err == nil {
-		t.Fatal("timeout did not trigger")
-	} else {
-		t.Log(err)
-	}
-
-	// After timeout the process is restarted; a new call should succeed.
-	// Remove the delay by using a fresh config with no delay.
-	config2 := external.Config{
-		Name:    "myfunc",
-		Command: []string{jsonrpcServerBin},
-		NumArgs: 1,
-		Mode:    external.ModeJSONRPC,
-	}
-	p2, err := external.NewPlugin(ctx, &config2)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer p2.Close()
-
-	result, err := p2.Exec(ctx, []string{"after-restart"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	m, ok := result.(map[string]any)
-	if !ok {
-		t.Fatalf("result is not map: %T", result)
-	}
-	if m["param"] != "after-restart" {
-		t.Errorf("unexpected param: %v", m["param"])
+	// The server delays 2s while the timeout is 200ms, so every call times
+	// out. The first timeout kills the process; the same plugin instance
+	// must restart it for the second call (rather than hanging or erroring
+	// on a dead pipe), so the second call reaches a fresh process and times
+	// out the same way.
+	for i := range 2 {
+		if _, err := p.Exec(ctx, []string{"hello"}); err == nil {
+			t.Fatalf("call %d: timeout did not trigger", i+1)
+		} else {
+			t.Logf("call %d: %v", i+1, err)
+		}
 	}
 }
 

--- a/external/external_test.go
+++ b/external/external_test.go
@@ -10,17 +10,31 @@ import (
 	"github.com/kayac/ecspresso/v2/external"
 )
 
-const jsonrpcServerBin = "testdata/jsonrpc_server/jsonrpc_server"
+const (
+	jsonrpcServerBin = "testdata/jsonrpc_server/jsonrpc_server"
+	badIDServerBin   = "testdata/jsonrpc_badidserver/jsonrpc_badidserver"
+)
 
 func TestMain(m *testing.M) {
-	cmd := exec.Command("go", "build", "-o", jsonrpcServerBin, "./testdata/jsonrpc_server/")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
+	// The jrpc2-based server is a separate Go module, so build it with the
+	// working directory set inside that module.
+	jrpcBuild := exec.Command("go", "build", "-o", "jsonrpc_server", ".")
+	jrpcBuild.Dir = "testdata/jsonrpc_server"
+	jrpcBuild.Stdout = os.Stdout
+	jrpcBuild.Stderr = os.Stderr
+	if err := jrpcBuild.Run(); err != nil {
 		panic("failed to build jsonrpc_server: " + err.Error())
+	}
+	// The bad-id server has no dependencies and stays in the main module.
+	badBuild := exec.Command("go", "build", "-o", badIDServerBin, "./testdata/jsonrpc_badidserver/")
+	badBuild.Stdout = os.Stdout
+	badBuild.Stderr = os.Stderr
+	if err := badBuild.Run(); err != nil {
+		panic("failed to build jsonrpc_badidserver: " + err.Error())
 	}
 	code := m.Run()
 	os.Remove(jsonrpcServerBin)
+	os.Remove(badIDServerBin)
 	os.Exit(code)
 }
 
@@ -200,7 +214,7 @@ func TestExternalPluginJSONRPCIDMismatch(t *testing.T) {
 	ctx := t.Context()
 	config := external.Config{
 		Name:    "myfunc",
-		Command: []string{jsonrpcServerBin, "-bad-id"},
+		Command: []string{badIDServerBin},
 		NumArgs: 1,
 		Mode:    external.ModeJSONRPC,
 	}

--- a/external/external_test.go
+++ b/external/external_test.go
@@ -1,12 +1,28 @@
 package external_test
 
 import (
+	"os"
+	"os/exec"
 	"testing"
 	"time"
 
 	"github.com/kayac/ecspresso/v2/duration"
 	"github.com/kayac/ecspresso/v2/external"
 )
+
+const jsonrpcServerBin = "testdata/jsonrpc_server/jsonrpc_server"
+
+func TestMain(m *testing.M) {
+	cmd := exec.Command("go", "build", "-o", jsonrpcServerBin, "./testdata/jsonrpc_server/")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		panic("failed to build jsonrpc_server: " + err.Error())
+	}
+	code := m.Run()
+	os.Remove(jsonrpcServerBin)
+	os.Exit(code)
+}
 
 func TestExternalPlugin(t *testing.T) {
 	ctx := t.Context()
@@ -88,5 +104,192 @@ func TestExternalPluginString(t *testing.T) {
 		}
 	} else {
 		t.Fatalf("result is not a string: %T", result)
+	}
+}
+
+func TestExternalPluginJSONRPC(t *testing.T) {
+	ctx := t.Context()
+	config := external.Config{
+		Name:    "myfunc",
+		Command: []string{jsonrpcServerBin},
+		NumArgs: 1,
+		Mode:    external.ModeJSONRPC,
+	}
+	p, err := external.NewPlugin(ctx, &config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	result, err := p.Exec(ctx, []string{"hello"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, ok := result.(map[string]any)
+	if !ok {
+		t.Fatalf("result is not map: %T", result)
+	}
+	if m["param"] != "hello" {
+		t.Errorf("unexpected param: %v", m["param"])
+	}
+	if m["count"] != float64(1) {
+		t.Errorf("unexpected count: %v", m["count"])
+	}
+}
+
+func TestExternalPluginJSONRPCMultipleCalls(t *testing.T) {
+	ctx := t.Context()
+	config := external.Config{
+		Name:    "myfunc",
+		Command: []string{jsonrpcServerBin},
+		NumArgs: 1,
+		Mode:    external.ModeJSONRPC,
+	}
+	p, err := external.NewPlugin(ctx, &config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	for i := 1; i <= 3; i++ {
+		result, err := p.Exec(ctx, []string{"arg"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		m, ok := result.(map[string]any)
+		if !ok {
+			t.Fatalf("call %d: result is not map: %T", i, result)
+		}
+		// count increments across calls, proving the same process is reused
+		if m["count"] != float64(i) {
+			t.Errorf("call %d: expected count=%d, got %v", i, i, m["count"])
+		}
+	}
+}
+
+func TestExternalPluginJSONRPCTimeout(t *testing.T) {
+	ctx := t.Context()
+	config := external.Config{
+		Name:    "myfunc",
+		Command: []string{jsonrpcServerBin, "-delay", "2s"},
+		NumArgs: 1,
+		Mode:    external.ModeJSONRPC,
+		Timeout: duration.Duration{Duration: 200 * time.Millisecond},
+	}
+	p, err := external.NewPlugin(ctx, &config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	if _, err := p.Exec(ctx, []string{"hello"}); err == nil {
+		t.Fatal("timeout did not trigger")
+	} else {
+		t.Log(err)
+	}
+
+	// After timeout the process is restarted; a new call should succeed.
+	// Remove the delay by using a fresh config with no delay.
+	config2 := external.Config{
+		Name:    "myfunc",
+		Command: []string{jsonrpcServerBin},
+		NumArgs: 1,
+		Mode:    external.ModeJSONRPC,
+	}
+	p2, err := external.NewPlugin(ctx, &config2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p2.Close()
+
+	result, err := p2.Exec(ctx, []string{"after-restart"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, ok := result.(map[string]any)
+	if !ok {
+		t.Fatalf("result is not map: %T", result)
+	}
+	if m["param"] != "after-restart" {
+		t.Errorf("unexpected param: %v", m["param"])
+	}
+}
+
+func TestExternalPluginJSONRPCIDMismatch(t *testing.T) {
+	ctx := t.Context()
+	config := external.Config{
+		Name:    "myfunc",
+		Command: []string{jsonrpcServerBin, "-bad-id"},
+		NumArgs: 1,
+		Mode:    external.ModeJSONRPC,
+	}
+	p, err := external.NewPlugin(ctx, &config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	if _, err := p.Exec(ctx, []string{"hello"}); err == nil {
+		t.Fatal("expected id mismatch error")
+	} else {
+		t.Log(err)
+	}
+}
+
+func TestExternalPluginJSONRPCError(t *testing.T) {
+	ctx := t.Context()
+	config := external.Config{
+		Name:    "myfunc",
+		Command: []string{jsonrpcServerBin, "-error"},
+		NumArgs: 1,
+		Mode:    external.ModeJSONRPC,
+	}
+	p, err := external.NewPlugin(ctx, &config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	if _, err := p.Exec(ctx, []string{"hello"}); err == nil {
+		t.Fatal("expected jsonrpc error")
+	} else {
+		t.Log(err)
+	}
+}
+
+func TestExternalPluginJSONRPCRestart(t *testing.T) {
+	ctx := t.Context()
+	config := external.Config{
+		Name:    "myfunc",
+		Command: []string{jsonrpcServerBin},
+		NumArgs: 1,
+		Mode:    external.ModeJSONRPC,
+	}
+	p, err := external.NewPlugin(ctx, &config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	// First call starts the process (count=1).
+	result, err := p.Exec(ctx, []string{"first"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := result.(map[string]any)
+	if m["count"] != float64(1) {
+		t.Errorf("expected count=1, got %v", m["count"])
+	}
+
+	// Close restarts the process; the next call starts a fresh process (count=1 again).
+	p.Close()
+
+	result, err = p.Exec(ctx, []string{"after-close"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	m = result.(map[string]any)
+	if m["count"] != float64(1) {
+		t.Errorf("after restart expected count=1, got %v", m["count"])
 	}
 }

--- a/external/testdata/jsonrpc_badidserver/main.go
+++ b/external/testdata/jsonrpc_badidserver/main.go
@@ -1,0 +1,30 @@
+// Command jsonrpc_badidserver is a deliberately non-conforming JSON-RPC
+// server used to test the client's response-id validation: it replies with
+// an id that does not match the request. It has no dependencies and stays
+// in the main ecspresso module (a correct jrpc2 server cannot reproduce an
+// id mismatch).
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+)
+
+func main() {
+	scanner := bufio.NewScanner(os.Stdin)
+	enc := json.NewEncoder(os.Stdout)
+	for scanner.Scan() {
+		var req struct {
+			ID int64 `json:"id"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+			continue
+		}
+		enc.Encode(map[string]any{ //nolint:errcheck
+			"jsonrpc": "2.0",
+			"id":      req.ID + 1000, // intentionally mismatched
+			"result":  map[string]any{"count": 1},
+		})
+	}
+}

--- a/external/testdata/jsonrpc_server/go.mod
+++ b/external/testdata/jsonrpc_server/go.mod
@@ -1,0 +1,10 @@
+module ecspresso.test/jsonrpcserver
+
+go 1.25.0
+
+require github.com/creachadair/jrpc2 v1.3.5
+
+require (
+	github.com/creachadair/mds v0.26.1 // indirect
+	golang.org/x/sync v0.19.0 // indirect
+)

--- a/external/testdata/jsonrpc_server/go.sum
+++ b/external/testdata/jsonrpc_server/go.sum
@@ -1,0 +1,8 @@
+github.com/creachadair/jrpc2 v1.3.5 h1:onJko+1u6xoiRph3xwWmfNISR91teCRhbJwSyS9Svzo=
+github.com/creachadair/jrpc2 v1.3.5/go.mod h1:YXDmS53AavsiytbAwskrczJPcVHvKC9GoyWzwfSQXoE=
+github.com/creachadair/mds v0.26.1 h1:CQG8f4cueHX/c20q5Sy/Ubk8Bvy+aRzVgbpxVieMBAs=
+github.com/creachadair/mds v0.26.1/go.mod h1:dMBTCSy3iS3dwh4Rb1zxeZz2d7K8+N24GCTsayWtQRI=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
+golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=

--- a/external/testdata/jsonrpc_server/main.go
+++ b/external/testdata/jsonrpc_server/main.go
@@ -1,65 +1,49 @@
+// Command jsonrpc_server is a JSON-RPC 2.0 server used by the external
+// plugin tests. It is built on the creachadair/jrpc2 library so the tests
+// exercise interoperability between ecspresso's hand-written client and a
+// standard JSON-RPC 2.0 server. It lives in its own Go module so the main
+// ecspresso module does not depend on jrpc2.
 package main
 
 import (
-	"bufio"
-	"encoding/json"
+	"context"
 	"flag"
-	"fmt"
 	"os"
+	"sync/atomic"
 	"time"
+
+	"github.com/creachadair/jrpc2"
+	"github.com/creachadair/jrpc2/channel"
+	"github.com/creachadair/jrpc2/handler"
 )
-
-type request struct {
-	JSONRPC string   `json:"jsonrpc"`
-	Method  string   `json:"method"`
-	Params  []string `json:"params"`
-	ID      int64    `json:"id"`
-}
-
-type response struct {
-	JSONRPC string `json:"jsonrpc"`
-	Result  any    `json:"result,omitempty"`
-	Error   any    `json:"error,omitempty"`
-	ID      int64  `json:"id"`
-}
 
 var (
 	delay   = flag.Duration("delay", 0, "delay before each response")
-	badID   = flag.Bool("bad-id", false, "reply with a mismatched response id")
 	respErr = flag.Bool("error", false, "reply with a jsonrpc error")
 )
 
 func main() {
 	flag.Parse()
-	scanner := bufio.NewScanner(os.Stdin)
-	enc := json.NewEncoder(os.Stdout)
-	var count int
-	for scanner.Scan() {
-		count++
-		var req request
-		if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
-			fmt.Fprintf(os.Stderr, "jsonrpc_server: decode error: %v\n", err)
-			continue
-		}
+
+	var count atomic.Int64
+	myfunc := func(ctx context.Context, params []string) (map[string]any, error) {
+		n := count.Add(1)
 		if *delay > 0 {
 			time.Sleep(*delay)
 		}
-		resp := response{JSONRPC: "2.0", ID: req.ID}
-		switch {
-		case *respErr:
-			resp.Error = map[string]any{"code": -32000, "message": "boom"}
-		case *badID:
-			resp.ID = req.ID + 1000
-			resp.Result = map[string]any{"count": count}
-		default:
-			result := map[string]any{"count": count}
-			if len(req.Params) > 0 {
-				result["param"] = req.Params[0]
-			}
-			resp.Result = result
+		if *respErr {
+			return nil, jrpc2.Errorf(jrpc2.Code(-32000), "boom")
 		}
-		if err := enc.Encode(resp); err != nil {
-			fmt.Fprintf(os.Stderr, "jsonrpc_server: encode error: %v\n", err)
+		result := map[string]any{"count": n}
+		if len(params) > 0 {
+			result["param"] = params[0]
 		}
+		return result, nil
 	}
+
+	srv := jrpc2.NewServer(handler.Map{
+		"myfunc": handler.New(myfunc),
+	}, nil)
+	srv.Start(channel.Line(os.Stdin, os.Stdout))
+	srv.Wait()
 }

--- a/external/testdata/jsonrpc_server/main.go
+++ b/external/testdata/jsonrpc_server/main.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+)
+
+type request struct {
+	JSONRPC string   `json:"jsonrpc"`
+	Method  string   `json:"method"`
+	Params  []string `json:"params"`
+	ID      int64    `json:"id"`
+}
+
+type response struct {
+	JSONRPC string `json:"jsonrpc"`
+	Result  any    `json:"result,omitempty"`
+	Error   any    `json:"error,omitempty"`
+	ID      int64  `json:"id"`
+}
+
+var (
+	delay   = flag.Duration("delay", 0, "delay before each response")
+	badID   = flag.Bool("bad-id", false, "reply with a mismatched response id")
+	respErr = flag.Bool("error", false, "reply with a jsonrpc error")
+)
+
+func main() {
+	flag.Parse()
+	scanner := bufio.NewScanner(os.Stdin)
+	enc := json.NewEncoder(os.Stdout)
+	var count int
+	for scanner.Scan() {
+		count++
+		var req request
+		if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+			fmt.Fprintf(os.Stderr, "jsonrpc_server: decode error: %v\n", err)
+			continue
+		}
+		if *delay > 0 {
+			time.Sleep(*delay)
+		}
+		resp := response{JSONRPC: "2.0", ID: req.ID}
+		switch {
+		case *respErr:
+			resp.Error = map[string]any{"code": -32000, "message": "boom"}
+		case *badID:
+			resp.ID = req.ID + 1000
+			resp.Result = map[string]any{"count": count}
+		default:
+			result := map[string]any{"count": count}
+			if len(req.Params) > 0 {
+				result["param"] = req.Params[0]
+			}
+			resp.Result = result
+		}
+		if err := enc.Encode(resp); err != nil {
+			fmt.Fprintf(os.Stderr, "jsonrpc_server: encode error: %v\n", err)
+		}
+	}
+}

--- a/plugin.go
+++ b/plugin.go
@@ -264,11 +264,7 @@ func setupPluginExternal(ctx context.Context, p ConfigPlugin, c *Config) error {
 	if err != nil {
 		return err
 	}
-	if err := p.AppendFuncMap(c, ext.FuncMap(ctx)); err != nil {
-		return err
-	}
-	if err := p.AppendJsonnetNativeFuncs(c, ext.JsonnetNativeFuncs(ctx)); err != nil {
-		return err
-	}
-	return nil
+	// register records ext in c.pluginInstances so its long-running
+	// jsonrpc process (if any) is torn down on App.Close.
+	return p.register(ctx, c, ext)
 }


### PR DESCRIPTION
## What

Add a `jsonrpc` execution mode to the `external` plugin.

Until now the `external` plugin runs (`exec`) its command **once per template function call**. For commands with a high startup cost (JVM, Python with heavy imports, a tool that loads a large dataset, ...) this is slow because the startup is paid on every lookup.

With `mode: jsonrpc`, ecspresso starts the command **once on first use and keeps it running**, then talks to it over stdin/stdout using [JSON-RPC 2.0](https://www.jsonrpc.org/specification). Subsequent lookups reuse the same process, so the startup cost is paid only once.

## How to use

`mode` is a new config field. It defaults to `exec`, so **existing configs are unaffected**.

```yaml
plugins:
  - name: external
    config:
      name: lookup                          # template/jsonnet function name
      command: ["python3", "lookup_server.py"]
      num_args: 1
      mode: jsonrpc                          # opt in to the long-running mode
      timeout: 10                            # per-call timeout (seconds)
```

Used from definitions exactly like the existing `exec` mode:

```jsonnet
local lookup = std.native('lookup');
{ value: lookup('some-key') }
```

## What the command (server) must implement

The process reads newline-delimited JSON-RPC 2.0 requests from **stdin** and writes newline-delimited responses to **stdout**:

```
--> {"jsonrpc":"2.0","method":"lookup","params":["some-key"],"id":1}
<-- {"jsonrpc":"2.0","result":<any JSON value>,"id":1}
```

- `method` is the `name` from the config; `params` is the array of string arguments.
- On failure, reply with a JSON-RPC `error` object instead of `result`.
- Echo back the request `id`; a mismatched `id` is treated as an error.

Because the wire format is standard JSON-RPC 2.0, the server can be written with any off-the-shelf JSON-RPC 2.0 library (the tests use one to verify interoperability).

## Behavior / lifecycle notes

- `timeout` applies **per call**. A timed-out call fails immediately, the same as `exec` mode; the stalled process is killed.
- The process is terminated when ecspresso exits (stdin closed, then SIGTERM/SIGKILL).
- `exec` mode is unchanged.

See README "Execute external commands" → "JSON RPC mode" for the full spec.