### PR TITLE
Fix error handling in CircleCI orb install command

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -35,7 +35,7 @@ commands:
             DOWNLOAD_OS="<< parameters.os >>"
             DOWNLOAD_ARCH="<< parameters.arch >>"
             if [ "${VERSION}" = "latest" ]; then
-              DOWNLOAD_URL=$(curl -sS --retry 3 https://api.github.com/repos/kayac/ecspresso/releases | jq --arg arch ${DOWNLOAD_OS}.${DOWNLOAD_ARCH}. -r '[.[]|select(.tag_name > "v2.0")|select(.prerelease==false)][0].assets[].browser_download_url|select(match($arch))')
+              DOWNLOAD_URL=$(curl -sSf --retry 3 https://api.github.com/repos/kayac/ecspresso/releases | jq --arg arch ${DOWNLOAD_OS}.${DOWNLOAD_ARCH}. -r '[.[]|select(.tag_name > "v2.0")|select(.prerelease==false)][0].assets[].browser_download_url|select(match($arch))')
             else
               DOWNLOAD_URL=https://github.com/kayac/ecspresso/releases/download/${VERSION}/ecspresso_${VERSION:1}_${DOWNLOAD_OS}_${DOWNLOAD_ARCH}.tar.gz
             fi

--- a/orb.yml
+++ b/orb.yml
@@ -27,6 +27,7 @@ commands:
           name: "Install ecspresso"
           shell: bash
           command: |
+            set -euo pipefail
             VERSION="<< parameters.version >>"
             if [ -n "<< parameters.version-file >>" ]; then
               VERSION="v$(cat << parameters.version-file >>)"
@@ -34,12 +35,12 @@ commands:
             DOWNLOAD_OS="<< parameters.os >>"
             DOWNLOAD_ARCH="<< parameters.arch >>"
             if [ "${VERSION}" = "latest" ]; then
-              DOWNLOAD_URL=$(curl -sS https://api.github.com/repos/kayac/ecspresso/releases | jq --arg arch ${DOWNLOAD_OS}.${DOWNLOAD_ARCH}. -r '[.[]|select(.tag_name > "v2.0")|select(.prerelease==false)][0].assets[].browser_download_url|select(match($arch))')
+              DOWNLOAD_URL=$(curl -sS --retry 3 https://api.github.com/repos/kayac/ecspresso/releases | jq --arg arch ${DOWNLOAD_OS}.${DOWNLOAD_ARCH}. -r '[.[]|select(.tag_name > "v2.0")|select(.prerelease==false)][0].assets[].browser_download_url|select(match($arch))')
             else
               DOWNLOAD_URL=https://github.com/kayac/ecspresso/releases/download/${VERSION}/ecspresso_${VERSION:1}_${DOWNLOAD_OS}_${DOWNLOAD_ARCH}.tar.gz
             fi
             cd /tmp
-            curl -sfLO ${DOWNLOAD_URL}
+            curl -sSfLO --retry 3 ${DOWNLOAD_URL}
             if [[ "${DOWNLOAD_URL}" =~ \.tar\.gz$ ]]; then
               FILENAME=$(basename $DOWNLOAD_URL .tar.gz)
               tar xzvf ${FILENAME}.tar.gz


### PR DESCRIPTION
## Problem

The orb's `install` command sets `shell: bash`, which drops CircleCI's default `-eo pipefail`. As a result, a failed `curl` download (e.g. a transient network/HTTP error) is not caught and execution continues to `tar`, surfacing a misleading secondary error instead of the real cause:

```
tar (child): ecspresso_2.3.5_linux_amd64.tar.gz: Cannot open: No such file or directory
tar (child): Error is not recoverable: exiting now
tar: Child returned status 2
tar: Error is not recoverable: exiting now
install: cannot stat 'ecspresso': No such file or directory

Exited with code exit status 1
```

Reproduced via `.circleci/config.yml`:

```yaml
orbs:
  ecspresso: fujiwara/ecspresso@2.0.4
# ...
      - ecspresso/install:
          version: v2.3.5
# ...
```

Retrying the job made it pass, confirming the failure was transient (a network error during download). The `tar` / `install` errors are just symptoms — the real failure (curl) is swallowed and never reported.

## Changes

- **`set -euo pipefail`** — a curl failure now stops the script immediately with the real error, instead of cascading into a confusing `tar`/`install` failure.
- **`-S` on the download curl** — curl now prints the actual HTTP/network error, which was previously silenced by `-s` alone.
- **`-f` on the GitHub API curl** — without `--fail`, an HTTP error response (e.g. 403 rate limiting, 5xx) exits 0 and gets piped to `jq`, which then fails with a less actionable parse error. With `-f` a persistent API error fails at the network call with a clear curl error, mirroring the download curl.
- **`--retry 3` on both curl calls** — absorbs transient failures so users don't have to manually re-run the job. curl only retries transient conditions (timeouts, connection failures, HTTP 408/429/5xx), so a genuinely missing version (404) still fails fast rather than retrying pointlessly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)