### PR TITLE
Add v2 to v3 migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ ecspresso also supports ECS Express mode for simplified deployments and provides
 
 ## Documents
 
+- [Differences between v2 and v3](docs/v2-v3.md).
 - [Differences between v1 and v2](docs/v1-v2.md).
 - [ecspresso Advent Calendar 2020](https://adventar.org/calendars/5916) (Japanese)
 - [ecspresso handbook](https://zenn.dev/fujiwara/books/ecspresso-handbook-v2) (Japanese)

--- a/docs/v2-v3.md
+++ b/docs/v2-v3.md
@@ -2,9 +2,8 @@
 
 See also [v3-plan.md](v3-plan.md), issues and pull requests labeled `v3`.
 
-## Breaking changes
+## Breaking changes (CLI / configuration)
 
-- Go module path bumped from `github.com/kayac/ecspresso/v2` to `github.com/kayac/ecspresso/v3`. Library callers must update their import paths.
 - YAML configuration files must be valid YAML before template rendering. Template literals that begin a YAML scalar value must be quoted. JSON and Jsonnet configs are unaffected. (#1023)
   ```yaml
   # NG in v3
@@ -15,24 +14,25 @@ See also [v3-plan.md](v3-plan.md), issues and pull requests labeled `v3`.
 - Remove `filter_command` configuration field. Use `ECSPRESSO_FILTER_COMMAND` environment variable or `--filter-command` CLI flag instead. (#1024)
 - Remove deprecated `exec` flags (`--port-forward`, `--local-port`, `--port`, `--host`). Use `exec portforward` subcommand instead. (#1025)
 - Remove deprecated `tasks` flags (`--find`, `--stop`, `--force`, `--trace`). Use `tasks find`, `tasks stop`, `tasks trace` subcommands instead. (#1025)
-- Remove dead `create` dispatch case. (#1026)
-- Remove `diff --unified` / `--no-unified` flag. Unified diff is now always used. Drop the `github.com/kylelemons/godebug/diff` dependency. (#1027)
+- Remove `diff --unified` / `--no-unified` flag. Unified diff is now always used. (#1027)
 - `Duration` handling changed: plain numbers and pure-digit strings in configuration are interpreted as seconds, not nanoseconds. String durations like `"30s"` or `"10m"` are unaffected. (#1028)
-- Sentinel error types (`ErrNotFound`, `ErrSkipVerify`, etc.) replaced with `errors.New` sentinels. Library callers using `errors.As` must switch to `errors.Is`. (#1029)
-- Several library internals unexported: `WithConfigLoader`, `CLIParseFunc`, `ForSubCommand`, `ExportEnvFile`. (#1029)
-- `ParseCLIv2` renamed to `ParseCLI`. `cliv2.go` renamed to `cli_parse.go`. (#1029)
 - `rollback` command now requires an active deployment by default. If no active deployment is found, it returns an error. Use `--with-previous-task-definition` to explicitly find and deploy the previous task definition revision (the v2 default behavior). (#1047)
 
-## Enhanced
+## New features
 
 - Plugin functions (`tfstate`, `cloudformation`, `ssm`, `secretsmanager`) can be used in top-level configuration fields across all formats (YAML, JSON, Jsonnet). (#1023)
-- `WithPluginInstance` `AppOption` added to inject plugin runtime instances for library callers. (#1031)
 - Support pause lifecycle hooks for ECS service deployments. (#1047)
   - Add `continue` command to proceed or rollback deployments paused at lifecycle hooks.
   - Add `--wait-until=paused` option to `deploy`, `rollback`, and `wait` commands.
 - Add `jsonrpc` mode to the `external` plugin. Starts the external command once and communicates over stdin/stdout with JSON-RPC 2.0, reducing startup overhead. (#1041)
 - Support monitoring configuration for high resolution CloudWatch metrics. (#1045)
 
-## Others
+## Breaking changes (library)
 
-- Package-level tuning variables (`delayForServiceChanged`, `refreshInterval`, `waiterMaxDelay`, `spcIndent`) changed from `var` to `const`. (#1029)
+These changes only affect users who import ecspresso as a Go library.
+
+- Go module path bumped from `github.com/kayac/ecspresso/v2` to `github.com/kayac/ecspresso/v3`. Update import paths accordingly.
+- Sentinel error types (`ErrNotFound`, `ErrSkipVerify`, etc.) replaced with `errors.New` sentinels. Use `errors.Is` instead of `errors.As`. (#1029)
+- Several internals unexported: `WithConfigLoader`, `CLIParseFunc`, `ForSubCommand`, `ExportEnvFile`. (#1029)
+- `ParseCLIv2` renamed to `ParseCLI`. (#1029)
+- `WithPluginInstance` `AppOption` added to inject plugin runtime instances. (#1031)

--- a/docs/v2-v3.md
+++ b/docs/v2-v3.md
@@ -1,0 +1,38 @@
+# Differences of ecspresso v2 and v3.
+
+See also [v3-plan.md](v3-plan.md), issues and pull requests labeled `v3`.
+
+## Breaking changes
+
+- Go module path bumped from `github.com/kayac/ecspresso/v2` to `github.com/kayac/ecspresso/v3`. Library callers must update their import paths.
+- YAML configuration files must be valid YAML before template rendering. Template literals that begin a YAML scalar value must be quoted. JSON and Jsonnet configs are unaffected. (#1023)
+  ```yaml
+  # NG in v3
+  region: {{ must_env `AWS_REGION` }}
+  # OK
+  region: "{{ must_env `AWS_REGION` }}"
+  ```
+- Remove `filter_command` configuration field. Use `ECSPRESSO_FILTER_COMMAND` environment variable or `--filter-command` CLI flag instead. (#1024)
+- Remove deprecated `exec` flags (`--port-forward`, `--local-port`, `--port`, `--host`). Use `exec portforward` subcommand instead. (#1025)
+- Remove deprecated `tasks` flags (`--find`, `--stop`, `--force`, `--trace`). Use `tasks find`, `tasks stop`, `tasks trace` subcommands instead. (#1025)
+- Remove dead `create` dispatch case. (#1026)
+- Remove `diff --unified` / `--no-unified` flag. Unified diff is now always used. Drop the `github.com/kylelemons/godebug/diff` dependency. (#1027)
+- `Duration` handling changed: plain numbers and pure-digit strings in configuration are interpreted as seconds, not nanoseconds. String durations like `"30s"` or `"10m"` are unaffected. (#1028)
+- Sentinel error types (`ErrNotFound`, `ErrSkipVerify`, etc.) replaced with `errors.New` sentinels. Library callers using `errors.As` must switch to `errors.Is`. (#1029)
+- Several library internals unexported: `WithConfigLoader`, `CLIParseFunc`, `ForSubCommand`, `ExportEnvFile`. (#1029)
+- `ParseCLIv2` renamed to `ParseCLI`. `cliv2.go` renamed to `cli_parse.go`. (#1029)
+- `rollback` command now requires an active deployment by default. If no active deployment is found, it returns an error. Use `--with-previous-task-definition` to explicitly find and deploy the previous task definition revision (the v2 default behavior). (#1047)
+
+## Enhanced
+
+- Plugin functions (`tfstate`, `cloudformation`, `ssm`, `secretsmanager`) can be used in top-level configuration fields across all formats (YAML, JSON, Jsonnet). (#1023)
+- `WithPluginInstance` `AppOption` added to inject plugin runtime instances for library callers. (#1031)
+- Support pause lifecycle hooks for ECS service deployments. (#1047)
+  - Add `continue` command to proceed or rollback deployments paused at lifecycle hooks.
+  - Add `--wait-until=paused` option to `deploy`, `rollback`, and `wait` commands.
+- Add `jsonrpc` mode to the `external` plugin. Starts the external command once and communicates over stdin/stdout with JSON-RPC 2.0, reducing startup overhead. (#1041)
+- Support monitoring configuration for high resolution CloudWatch metrics. (#1045)
+
+## Others
+
+- Package-level tuning variables (`delayForServiceChanged`, `refreshInterval`, `waiterMaxDelay`, `spcIndent`) changed from `var` to `const`. (#1029)

--- a/docs/v3-plan.md
+++ b/docs/v3-plan.md
@@ -257,7 +257,9 @@ File and function names date back to the v1 → v2 CLI parser switch (kingpin �
 
 ### docs/v1-v2.md
 
-Migration notes from the v1 → v2 cut. Keep as historical reference, but link to it from this document so the v3 migration story is self-contained.
+Migration notes from the v1 → v2 cut. Kept as historical reference: [docs/v1-v2.md](v1-v2.md).
+
+The v2 → v3 migration guide is at [docs/v2-v3.md](v2-v3.md).
 
 ## Out of scope (intentionally kept)
 


### PR DESCRIPTION
## Summary
- Add `docs/v2-v3.md` documenting all breaking changes, enhancements, and other changes from v2 to v3
- Add link to the migration guide in README Documents section
- Add cross-reference from `docs/v3-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)