### PR TITLE
Fix verify 404 for images pinned as repo:tag@sha256:digest

### DIFF
--- a/verify.go
+++ b/verify.go
@@ -1099,8 +1099,13 @@ func parseIAMPolicyDocument(s string) (*iamPolicyDocument, error) {
 
 func parseImageURL(image string) (imageName string, tagOrDigest string) {
 	if strings.Contains(image, "@sha256:") {
-		p := strings.SplitN(image, "@", 2)
-		return p[0], p[1]
+		name, digest, _ := strings.Cut(image, "@")
+		// Strip a tag from "repo:tag@sha256:..." because the digest identifies
+		// the image; the registry must be queried with the bare repository name.
+		if idx := strings.LastIndex(name, ":"); idx != -1 && !strings.Contains(name[idx+1:], "/") {
+			name = name[:idx]
+		}
+		return name, digest
 	} else if idx := strings.LastIndex(image, ":"); idx != -1 && !strings.Contains(image[idx+1:], "/") {
 		// The last colon is a tag separator only if there is no slash after it.
 		// If there is a slash (e.g. "host:443/repo"), the colon indicates a port.

--- a/verify_test.go
+++ b/verify_test.go
@@ -195,6 +195,16 @@ var imageURLTestCases = []struct {
 		expectedImageName:   "example.com:443/repo/image",
 		expectedTagOrDigest: "sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
 	},
+	{
+		imageURL:            "public.ecr.aws/nginx/nginx:1.27@sha256:df80ece7fa07f8ed4f3b70e883fe322732954d0287e562f1fdc790018f7d2c66",
+		expectedImageName:   "public.ecr.aws/nginx/nginx",
+		expectedTagOrDigest: "sha256:df80ece7fa07f8ed4f3b70e883fe322732954d0287e562f1fdc790018f7d2c66",
+	},
+	{
+		imageURL:            "example.com:443/repo/image:tag@sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+		expectedImageName:   "example.com:443/repo/image",
+		expectedTagOrDigest: "sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+	},
 }
 
 func TestParseImageURL(t *testing.T) {


### PR DESCRIPTION
Fixes #1053.

## What

`parseImageURL` now strips the tag from the repository name when an image is pinned in the combined tag + digest form (`repo:tag@sha256:...`). A colon followed by a slash (registry port, e.g. `example.com:443/repo`) is still kept.

## Why

For `repo:tag@sha256:...`, the parser split only on `@` and returned `repo:tag` as the repository name. The registry client then requested `GET /v2/repo:tag/manifests/<digest>`, which is an invalid repository path, so `ecspresso verify` failed with "not found in Registry" even though the image exists. #908 fixed the digest-only form but not the combined form, which is a common supply-chain pinning pattern (readable tag + immutable digest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)