### PR TITLE
Fix panic in verify for PAUSE lifecycle hooks

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -79,3 +79,11 @@ func (i *ConfigIgnore) FilterTags(tags []types.Tag) []types.Tag {
 func SleepContext(ctx context.Context, d time.Duration) {
 	sleepContext(ctx, d)
 }
+
+func (d *App) VerifyDeploymentConfiguration(ctx context.Context, dc *types.DeploymentConfiguration) error {
+	return d.verifyDeploymentConfiguration(ctx, dc)
+}
+
+func ContextWithVerifyState(ctx context.Context, vs *verifyState) context.Context {
+	return context.WithValue(ctx, verifyStateKey, vs)
+}

--- a/verify.go
+++ b/verify.go
@@ -558,14 +558,25 @@ func (d *App) verifyDeploymentConfiguration(ctx context.Context, dc *types.Deplo
 	for i, hook := range dc.LifecycleHooks {
 		name := fmt.Sprintf("LifecycleHooks[%d]", i)
 		_, err := vs.VerifyResource(ctx, name, func(context.Context) error {
-			roleArn := *hook.RoleArn
-			_, err := vs.VerifyResource(ctx, fmt.Sprintf("RoleArn[%s]", roleArn), func(ctx context.Context) error {
-				return d.verifyRole(ctx, roleArn, "ecs.amazonaws.com")
-			})
-			if err != nil {
-				return err
+			if hook.TargetType == types.DeploymentLifecycleHookTargetTypePause {
+				// PAUSE hooks have no role and no hook target.
+				return nil
 			}
-			_, err = vs.VerifyResource(ctx, fmt.Sprintf("HookTargetArn[%s]", aws.ToString(hook.HookTargetArn)), func(ctx context.Context) error {
+			// AWS_LAMBDA hooks (the default when targetType is not specified)
+			roleArn := aws.ToString(hook.RoleArn)
+			if roleArn != "" {
+				_, err := vs.VerifyResource(ctx, fmt.Sprintf("RoleArn[%s]", roleArn), func(ctx context.Context) error {
+					return d.verifyRole(ctx, roleArn, "ecs.amazonaws.com")
+				})
+				if err != nil {
+					return err
+				}
+			}
+			hookTargetArn := aws.ToString(hook.HookTargetArn)
+			if hookTargetArn == "" {
+				return fmt.Errorf("hookTargetArn is required for %s lifecycle hooks", types.DeploymentLifecycleHookTargetTypeAwsLambda)
+			}
+			_, err := vs.VerifyResource(ctx, fmt.Sprintf("HookTargetArn[%s]", hookTargetArn), func(ctx context.Context) error {
 				_, err := d.lambda.GetFunction(ctx, &lambda.GetFunctionInput{
 					FunctionName: hook.HookTargetArn,
 				})

--- a/verify_test.go
+++ b/verify_test.go
@@ -3,6 +3,7 @@ package ecspresso_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -597,4 +598,50 @@ func TestParseIAMPolicyDocument(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestVerifyDeploymentConfigurationLifecycleHooks(t *testing.T) {
+	color.NoColor = true
+	app := &ecspresso.App{}
+
+	t.Run("nil deployment configuration", func(t *testing.T) {
+		ctx := ecspresso.ContextWithVerifyState(t.Context(), ecspresso.NewVerifyState(false))
+		if err := app.VerifyDeploymentConfiguration(ctx, nil); err != nil {
+			t.Errorf("unexpected error: %s", err)
+		}
+	})
+
+	t.Run("pause hook without roleArn and hookTargetArn", func(t *testing.T) {
+		ctx := ecspresso.ContextWithVerifyState(t.Context(), ecspresso.NewVerifyState(false))
+		dc := &types.DeploymentConfiguration{
+			LifecycleHooks: []types.DeploymentLifecycleHook{
+				{
+					TargetType:      types.DeploymentLifecycleHookTargetTypePause,
+					LifecycleStages: []types.DeploymentLifecycleHookStage{types.DeploymentLifecycleHookStagePostScaleUp},
+				},
+			},
+		}
+		if err := app.VerifyDeploymentConfiguration(ctx, dc); err != nil {
+			t.Errorf("unexpected error: %s", err)
+		}
+	})
+
+	t.Run("lambda hook without hookTargetArn", func(t *testing.T) {
+		ctx := ecspresso.ContextWithVerifyState(t.Context(), ecspresso.NewVerifyState(false))
+		dc := &types.DeploymentConfiguration{
+			LifecycleHooks: []types.DeploymentLifecycleHook{
+				{
+					// targetType is not specified, so it defaults to AWS_LAMBDA
+					LifecycleStages: []types.DeploymentLifecycleHookStage{types.DeploymentLifecycleHookStagePostScaleUp},
+				},
+			},
+		}
+		err := app.VerifyDeploymentConfiguration(ctx, dc)
+		if err == nil {
+			t.Fatal("error must be returned for a lambda hook without hookTargetArn")
+		}
+		if !strings.Contains(err.Error(), "hookTargetArn is required") {
+			t.Errorf("unexpected error: %s", err)
+		}
+	})
 }


### PR DESCRIPTION
## What

- `verify` no longer panics when a deployment lifecycle hook is of `PAUSE` target type. Role and hook target verification is skipped for PAUSE hooks since they have neither `roleArn` nor `hookTargetArn`.
- `verify` now reports an error when an `AWS_LAMBDA` hook (the default when `targetType` is not specified) is missing `hookTargetArn`, instead of silently passing.

## Why

The ECS SDK update introduced the `PAUSE` target type for deployment lifecycle hooks, which pauses the deployment instead of invoking a Lambda function. Such hooks have no `roleArn` / `hookTargetArn`, so `verifyDeploymentConfiguration` panicked on a nil dereference of `hook.RoleArn`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)