### PR TITLE
Add migration guides to docs command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1427,7 +1427,7 @@ Flags:
 
 ### Show documentation
 
-The `docs` command shows the embedded documentation (this README) directly from the ecspresso binary. This command does not require AWS credentials or a configuration file.
+The `docs` command shows the embedded documentation (this README and migration guides) directly from the ecspresso binary. This command does not require AWS credentials or a configuration file.
 
 ```
 Flags:
@@ -1469,6 +1469,14 @@ List available articles:
 ```console
 $ ecspresso docs --list
 readme	ecspresso README
+v1-v2	Migration guide from v1 to v2
+v2-v3	Migration guide from v2 to v3
+```
+
+Show a migration guide:
+
+```console
+$ ecspresso docs --article v2-v3
 ```
 
 ### LLM agent integration

--- a/docs.go
+++ b/docs.go
@@ -11,7 +11,7 @@ import (
 
 // DocsOption defines CLI options for the docs subcommand.
 type DocsOption struct {
-	Article string `help:"article name to display" default:"readme" enum:"readme"`
+	Article string `help:"article name to display" default:"readme" enum:"readme,v1-v2,v2-v3"`
 	List    bool   `help:"list available articles" default:"false"`
 	Index   bool   `help:"show table of contents" default:"false"`
 	Search  string `help:"search keyword in documents" default:""`
@@ -39,6 +39,8 @@ type docsArticle struct {
 
 var articles = []docsArticle{
 	{Name: "readme", Description: "ecspresso README"},
+	{Name: "v1-v2", Description: "Migration guide from v1 to v2"},
+	{Name: "v2-v3", Description: "Migration guide from v2 to v3"},
 }
 
 func dispatchDocs(ctx context.Context, opt *DocsOption) error {
@@ -72,6 +74,10 @@ func getArticle(name string) (string, error) {
 	switch name {
 	case "readme":
 		return readmeContent, nil
+	case "v1-v2":
+		return docsV1V2Content, nil
+	case "v2-v3":
+		return docsV2V3Content, nil
 	default:
 		return "", fmt.Errorf("unknown article: %s", name)
 	}

--- a/docs_embed.go
+++ b/docs_embed.go
@@ -8,5 +8,11 @@ import (
 //go:embed README.md
 var readmeContent string
 
+//go:embed docs/v1-v2.md
+var docsV1V2Content string
+
+//go:embed docs/v2-v3.md
+var docsV2V3Content string
+
 //go:embed skills
 var skillsFS embed.FS

--- a/docs_test.go
+++ b/docs_test.go
@@ -105,6 +105,35 @@ func TestParseSectionsReadme(t *testing.T) {
 	}
 }
 
+func TestGetArticleMigrationGuides(t *testing.T) {
+	tests := []struct {
+		article string
+		heading string
+	}{
+		{"v1-v2", "# Differences of ecspresso v1 and v2."},
+		{"v2-v3", "# Differences of ecspresso v2 and v3."},
+	}
+	for _, tt := range tests {
+		content, err := ecspresso.GetArticle(tt.article)
+		if err != nil {
+			t.Fatalf("article %q: %v", tt.article, err)
+		}
+		if !strings.HasPrefix(content, tt.heading) {
+			t.Errorf("article %q should start with %q", tt.article, tt.heading)
+		}
+		sections := ecspresso.ParseSections(content)
+		if len(sections) == 0 {
+			t.Errorf("article %q: expected non-zero sections", tt.article)
+		}
+	}
+}
+
+func TestGetArticleUnknown(t *testing.T) {
+	if _, err := ecspresso.GetArticle("unknown"); err == nil {
+		t.Error("expected an error for unknown article")
+	}
+}
+
 func TestDocsSearch(t *testing.T) {
 	content := ecspresso.ReadmeContent
 	sections := ecspresso.ParseSections(content)

--- a/export_test.go
+++ b/export_test.go
@@ -35,6 +35,7 @@ var (
 	ParseIAMPolicyDocument = parseIAMPolicyDocument
 	ParseSections          = parseSections
 	ReadmeContent          = readmeContent
+	GetArticle             = getArticle
 )
 
 type ModifyAutoScalingParams = modifyAutoScalingParams

--- a/skills/ecspresso/SKILL.md
+++ b/skills/ecspresso/SKILL.md
@@ -30,9 +30,27 @@ ecspresso docs --search "fargate" --json
 
 # Read the full documentation
 ecspresso docs --json
+
+# List available articles (README and migration guides)
+ecspresso docs --list --json
+
+# Read a specific article
+ecspresso docs --article v2-v3 --json
 ```
 
 Always use `--json` for structured output that is easier to parse.
+
+### Version upgrades
+
+When upgrading ecspresso across major versions (v1 to v2, or v2 to v3), always read the embedded migration guide first to learn about breaking changes:
+
+```bash
+# Migration guide from v1 to v2
+ecspresso docs --article v1-v2 --json
+
+# Migration guide from v2 to v3
+ecspresso docs --article v2-v3 --json
+```
 
 ## Common workflows
 
@@ -185,3 +203,4 @@ Use `ecspresso init --jsonnet` to generate Jsonnet files from an existing servic
 - Use `--dry-run` on destructive operations (`deploy`, `rollback`, `delete`, `scale`) to preview the action.
 - The `verify` command checks IAM roles, container images, secrets, and log groups referenced in definitions.
 - When you need to learn more about a specific feature, use `ecspresso docs --search "<keyword>" --json` to find the relevant documentation section.
+- When upgrading ecspresso to a new major version, read the migration guide via `ecspresso docs --article <version>-<next-version> --json` (e.g. `v2-v3`) before changing any configuration.


### PR DESCRIPTION
## What

- Embed `docs/v1-v2.md` and `docs/v2-v3.md` as articles in the `docs` command, selectable via `--article v1-v2` / `--article v2-v3` (also listed in `--list`).
- Update the embedded agent skill (SKILL.md) to instruct agents to read the migration guide via `ecspresso docs --article <from>-<to>` before major version upgrades.
- Update README for the new articles.

## Why

Migration guides were only available in the repository. Embedding them in the binary lets users and LLM agents look up breaking changes (e.g. v2 to v3) directly with `ecspresso docs`, without AWS credentials or network access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)