### PR TITLE
Support --wait-until ecs:<lifecycle stage>

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,9 +428,10 @@ Events:
   --force-new-deployment                 force a new deployment of the service
   --[no-]wait                            wait for service stable
   --wait-until="deployed"                Choose whether to wait for service stable or the deployment finishes. For
-                                         ECS deployment controller: "(stable|deployed)"; For CodeDeploy deployment
-                                         controller: "codedeploy:*", this accepts CodeDeploy lifecycle event (e.g.,
-                                         "codedeploy:AfterAllowTraffic")
+                                         ECS deployment controller: "(stable|deployed)", or "ecs:*", this accepts a
+                                         deployment lifecycle stage (e.g., "ecs:BAKE_TIME"); For CodeDeploy
+                                         deployment controller: "codedeploy:*", this accepts CodeDeploy lifecycle
+                                         event (e.g., "codedeploy:AfterAllowTraffic")
   --suspend-auto-scaling                 suspend application auto-scaling attached with the ECS service
   --resume-auto-scaling                  resume application auto-scaling attached with the ECS service
   --auto-scaling-min=AUTO-SCALING-MIN    set minimum capacity of application auto-scaling attached with the ECS service

--- a/cli_test.go
+++ b/cli_test.go
@@ -231,6 +231,24 @@ var cliTests = []struct {
 		},
 	},
 	{
+		args: []string{"deploy", "--wait-until=ecs:BAKE_TIME"},
+		sub:  "deploy",
+		subOption: &ecspresso.DeployOption{
+			SuspendAutoScaling:   nil,
+			ResumeAutoScaling:    nil,
+			DryRun:               false,
+			DesiredCount:         ptr(int32(-1)),
+			SkipTaskDefinition:   false,
+			Revision:             0,
+			ForceNewDeployment:   false,
+			Wait:                 true,
+			WaitUntil:            "ecs:BAKE_TIME",
+			RollbackEvents:       "",
+			UpdateService:        true,
+			LatestTaskDefinition: false,
+		},
+	},
+	{
 		args: []string{"scale", "--tasks=5"},
 		sub:  "scale",
 		subOption: &ecspresso.ScaleOption{
@@ -1078,6 +1096,18 @@ func TestParseCLIv2WithInvalidWaitUntilOption(t *testing.T) {
 		t.Errorf("invalid wait-until should return error")
 	}
 	_, _, _, err = ecspresso.ParseCLIv2([]string{"deploy", "--wait-until=codedeploy:"}) // lifecycle event name is empty (i.e., prefix only)
+	if err == nil {
+		t.Errorf("invalid wait-until should return error")
+	}
+	_, _, _, err = ecspresso.ParseCLIv2([]string{"deploy", "--wait-until=ecs:"}) // lifecycle stage is empty (i.e., prefix only)
+	if err == nil {
+		t.Errorf("invalid wait-until should return error")
+	}
+	_, _, _, err = ecspresso.ParseCLIv2([]string{"deploy", "--wait-until=ecs:NO_SUCH_STAGE"})
+	if err == nil {
+		t.Errorf("invalid wait-until should return error")
+	}
+	_, _, _, err = ecspresso.ParseCLIv2([]string{"deploy", "--wait-until=ecs:bake_time"}) // lifecycle stage is case sensitive
 	if err == nil {
 		t.Errorf("invalid wait-until should return error")
 	}

--- a/deploy.go
+++ b/deploy.go
@@ -31,7 +31,7 @@ type DeployOption struct {
 	Revision             int64  `help:"revision of the task definition to run when --skip-task-definition" default:"0"`
 	ForceNewDeployment   bool   `help:"force a new deployment of the service" default:"false"`
 	Wait                 bool   `help:"wait for service stable" default:"true" negatable:""`
-	WaitUntil            string `help:"Choose whether to wait for service stable or the deployment finishes. For ECS deployment controller: \"(stable|deployed)\"; For CodeDeploy deployment controller: \"codedeploy:*\", this accepts CodeDeploy lifecycle event (e.g., \"codedeploy:AfterAllowTraffic\")" default:"deployed"`
+	WaitUntil            string `help:"Choose whether to wait for service stable or the deployment finishes. For ECS deployment controller: \"(stable|deployed)\", or \"ecs:*\", this accepts a deployment lifecycle stage (e.g., \"ecs:BAKE_TIME\"); For CodeDeploy deployment controller: \"codedeploy:*\", this accepts CodeDeploy lifecycle event (e.g., \"codedeploy:AfterAllowTraffic\")" default:"deployed"`
 	SuspendAutoScaling   *bool  `help:"suspend application auto-scaling attached with the ECS service"`
 	ResumeAutoScaling    *bool  `help:"resume application auto-scaling attached with the ECS service"`
 	AutoScalingMin       *int32 `help:"set minimum capacity of application auto-scaling attached with the ECS service"`

--- a/export_test.go
+++ b/export_test.go
@@ -35,6 +35,9 @@ var (
 	ParseIAMPolicyDocument = parseIAMPolicyDocument
 	ParseSections          = parseSections
 	ReadmeContent          = readmeContent
+
+	LifecycleStageIndex             = lifecycleStageIndex
+	ValidateLifecycleStageSupported = validateLifecycleStageSupported
 )
 
 type ModifyAutoScalingParams = modifyAutoScalingParams

--- a/wait.go
+++ b/wait.go
@@ -26,6 +26,7 @@ const (
 	waitUntilStable           waitUntil = "stable"
 	waitUntilDeployed         waitUntil = "deployed"
 	waitUntilCodeDeployPrefix           = "codedeploy:"
+	waitUntilECSPrefix                  = "ecs:"
 )
 
 func (u waitUntil) Validate() error {
@@ -35,7 +36,14 @@ func (u waitUntil) Validate() error {
 	if strings.HasPrefix(string(u), waitUntilCodeDeployPrefix) && len(u) > len(waitUntilCodeDeployPrefix) {
 		return nil
 	}
-	return fmt.Errorf("invalid waitUntil value: %s (expected: stable, deployed, or codedeploy:*)", u)
+	if strings.HasPrefix(string(u), waitUntilECSPrefix) {
+		stage := types.ServiceDeploymentLifecycleStage(u.ecsLifecycleStage())
+		if lifecycleStageIndex(stage) < 0 {
+			return fmt.Errorf("invalid waitUntil value: %s (expected one of %s)", u, strings.Join(lifecycleStageNames(), ", "))
+		}
+		return nil
+	}
+	return fmt.Errorf("invalid waitUntil value: %s (expected: stable, deployed, codedeploy:*, or ecs:*)", u)
 }
 
 func (u waitUntil) forCodeDeployLifecycle() bool {
@@ -47,6 +55,37 @@ func (u waitUntil) codeDeployLifecycleEvent() string {
 		return strings.TrimPrefix(string(u), waitUntilCodeDeployPrefix)
 	}
 	return ""
+}
+
+func (u waitUntil) forECSLifecycleStage() bool {
+	return strings.HasPrefix(string(u), waitUntilECSPrefix)
+}
+
+func (u waitUntil) ecsLifecycleStage() string {
+	if u.forECSLifecycleStage() {
+		return strings.TrimPrefix(string(u), waitUntilECSPrefix)
+	}
+	return ""
+}
+
+// lifecycleStageIndex returns the position of the stage in the deployment
+// lifecycle, or -1 when the stage is unknown (including an empty stage, which
+// is what a rolling deployment reports).
+func lifecycleStageIndex(stage types.ServiceDeploymentLifecycleStage) int {
+	for i, s := range stage.Values() {
+		if s == stage {
+			return i
+		}
+	}
+	return -1
+}
+
+func lifecycleStageNames() []string {
+	var names []string
+	for _, s := range types.ServiceDeploymentLifecycleStage("").Values() {
+		names = append(names, waitUntilECSPrefix+string(s))
+	}
+	return names
 }
 
 type waitFunc func(ctx context.Context, sv *Service) error
@@ -76,8 +115,15 @@ func (d *App) WaitFunc(sv *Service, confirm confirmFunc, until waitUntil) (waitF
 			if until.forCodeDeployLifecycle() {
 				return d.WaitForCodeDeployLifecycle(until.codeDeployLifecycleEvent()), nil
 			}
+			if until.forECSLifecycleStage() {
+				return nil, fmt.Errorf("unsupported waitUntil: %s (a deployment lifecycle stage is only reported by the ECS deployment controller)", until)
+			}
 			return d.WaitForCodeDeploy, nil
 		case types.DeploymentControllerTypeEcs:
+			if until.forECSLifecycleStage() {
+				stage := types.ServiceDeploymentLifecycleStage(until.ecsLifecycleStage())
+				return d.WaitServiceDeployLifecycleStage(stage), nil
+			}
 			switch until {
 			case waitUntilDeployed:
 				return confirm.wrap(d.WaitServiceDeployCompleted), nil
@@ -223,6 +269,50 @@ func serviceRevisionsSummaries(dp *types.ServiceDeployment) []string {
 
 func (d *App) WaitServiceDeployCompleted(ctx context.Context, sv *Service) error {
 	d.LogInfo("Waiting for service deployed...(it will take a few minutes)")
+	return d.waitServiceDeployment(ctx, nil)
+}
+
+// WaitServiceDeployLifecycleStage waits until the deployment reaches the target
+// lifecycle stage, instead of waiting for the whole deployment to finish. This
+// allows returning before a long bakeTimeInMinutes elapses.
+func (d *App) WaitServiceDeployLifecycleStage(stage types.ServiceDeploymentLifecycleStage) waitFunc {
+	return func(ctx context.Context, sv *Service) error {
+		if err := validateLifecycleStageSupported(sv, stage); err != nil {
+			return err
+		}
+		d.LogInfo("Waiting for service deployment lifecycle stage...", "stage", string(stage))
+		target := lifecycleStageIndex(stage)
+		// Stages such as PRODUCTION_TRAFFIC_SHIFT are transient and can be
+		// skipped between polls, so compare positions rather than equality.
+		return d.waitServiceDeployment(ctx, func(dp *types.ServiceDeployment) bool {
+			return lifecycleStageIndex(dp.LifecycleStage) >= target
+		})
+	}
+}
+
+// validateLifecycleStageSupported rejects a lifecycle stage target on a service
+// whose deployment never reports one, which would otherwise wait until timeout.
+func validateLifecycleStageSupported(sv *Service, stage types.ServiceDeploymentLifecycleStage) error {
+	if sv == nil || sv.DeploymentConfiguration == nil {
+		return nil
+	}
+	switch strategy := sv.DeploymentConfiguration.Strategy; strategy {
+	case types.DeploymentStrategyBlueGreen, types.DeploymentStrategyLinear, types.DeploymentStrategyCanary:
+		return nil
+	case "":
+		return nil // not set by the service definition, let the deployment decide
+	default:
+		return fmt.Errorf(
+			"waiting for lifecycle stage %s requires a traffic shifting deployment strategy, but the service uses %s",
+			stage, strategy,
+		)
+	}
+}
+
+// waitServiceDeployment polls the active service deployment until done reports
+// true, or until the deployment reaches a terminal status. A nil done waits for
+// the deployment to finish.
+func (d *App) waitServiceDeployment(ctx context.Context, done func(*types.ServiceDeployment) bool) error {
 	deploymentArn, err := d.findActiveECSDeploymentArn(ctx, time.Second*10)
 	if err != nil {
 		if errors.As(err, &errNotFound) {
@@ -284,6 +374,17 @@ func (d *App) WaitServiceDeployCompleted(ctx context.Context, sv *Service) error
 			return fmt.Errorf("Service deployment failed %s", status)
 		default:
 			d.LogDebug("Deployment %s, waiting...", status)
+		}
+
+		// A lifecycle stage target is only meaningful while the deployment is
+		// progressing. During a rollback the stage can still read as the target,
+		// so keep waiting for the rollback to reach a terminal status instead.
+		switch status {
+		case types.ServiceDeploymentStatusPending, types.ServiceDeploymentStatusInProgress:
+			if done != nil && done(&dp) {
+				d.LogInfo("service deployment reached the lifecycle stage", "stage", string(dp.LifecycleStage))
+				return nil
+			}
 		}
 	}
 }

--- a/wait_test.go
+++ b/wait_test.go
@@ -1,0 +1,99 @@
+package ecspresso_test
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	"github.com/kayac/ecspresso/v2"
+)
+
+func TestLifecycleStageIndex(t *testing.T) {
+	// The waiter compares positions instead of equality, so the ordering of the
+	// stages within the deployment lifecycle is what matters.
+	stages := types.ServiceDeploymentLifecycleStage("").Values()
+	for i, stage := range stages {
+		if got := ecspresso.LifecycleStageIndex(stage); got != i {
+			t.Errorf("lifecycleStageIndex(%s) = %d, expected %d", stage, got, i)
+		}
+	}
+
+	if scaleUp, bakeTime := ecspresso.LifecycleStageIndex(types.ServiceDeploymentLifecycleStageScaleUp),
+		ecspresso.LifecycleStageIndex(types.ServiceDeploymentLifecycleStageBakeTime); scaleUp >= bakeTime {
+		t.Errorf("SCALE_UP (%d) must come before BAKE_TIME (%d)", scaleUp, bakeTime)
+	}
+
+	// A rolling deployment reports no lifecycle stage, which must never satisfy
+	// a target stage.
+	for _, stage := range []types.ServiceDeploymentLifecycleStage{"", "NO_SUCH_STAGE"} {
+		if got := ecspresso.LifecycleStageIndex(stage); got != -1 {
+			t.Errorf("lifecycleStageIndex(%q) = %d, expected -1", stage, got)
+		}
+	}
+}
+
+func TestValidateLifecycleStageSupported(t *testing.T) {
+	stage := types.ServiceDeploymentLifecycleStageBakeTime
+
+	for _, strategy := range []types.DeploymentStrategy{
+		types.DeploymentStrategyBlueGreen,
+		types.DeploymentStrategyLinear,
+		types.DeploymentStrategyCanary,
+		"",
+	} {
+		sv := &ecspresso.Service{
+			Service: types.Service{
+				DeploymentConfiguration: &types.DeploymentConfiguration{Strategy: strategy},
+			},
+		}
+		if err := ecspresso.ValidateLifecycleStageSupported(sv, stage); err != nil {
+			t.Errorf("strategy %q should be supported, got %v", strategy, err)
+		}
+	}
+
+	// ROLLING never reports a lifecycle stage, so waiting for one would block
+	// until the timeout expires. Fail fast instead.
+	sv := &ecspresso.Service{
+		Service: types.Service{
+			DeploymentConfiguration: &types.DeploymentConfiguration{
+				Strategy: types.DeploymentStrategyRolling,
+			},
+		},
+	}
+	if err := ecspresso.ValidateLifecycleStageSupported(sv, stage); err == nil {
+		t.Error("ROLLING strategy should not be supported")
+	}
+
+	if err := ecspresso.ValidateLifecycleStageSupported(nil, stage); err != nil {
+		t.Errorf("nil service should be allowed, got %v", err)
+	}
+}
+
+func TestWaitFuncForECSLifecycleStage(t *testing.T) {
+	app := &ecspresso.App{}
+	sv := &ecspresso.Service{
+		Service: types.Service{
+			DeploymentController: &types.DeploymentController{
+				Type: types.DeploymentControllerTypeEcs,
+			},
+		},
+	}
+
+	if _, err := app.WaitFunc(sv, nil, "ecs:BAKE_TIME"); err != nil {
+		t.Errorf("ecs:BAKE_TIME should be supported by the ECS deployment controller, got %v", err)
+	}
+	if _, err := app.WaitFunc(sv, nil, "ecs:CLEAN_UP"); err != nil {
+		t.Errorf("ecs:CLEAN_UP should be supported by the ECS deployment controller, got %v", err)
+	}
+
+	// The lifecycle stage of an ECS deployment has no meaning for CodeDeploy.
+	cd := &ecspresso.Service{
+		Service: types.Service{
+			DeploymentController: &types.DeploymentController{
+				Type: types.DeploymentControllerTypeCodeDeploy,
+			},
+		},
+	}
+	if _, err := app.WaitFunc(cd, nil, "ecs:BAKE_TIME"); err == nil {
+		t.Error("ecs:* should not be accepted for the CodeDeploy deployment controller")
+	}
+}


### PR DESCRIPTION
## Problem

With the ECS deployment controller, `--wait-until` accepts only `stable` or `deployed`, and both wait for the whole deployment to finish.

That becomes a problem for a `BLUE_GREEN` service that sets a long `bakeTimeInMinutes` to keep a rollback window open. We migrated a service from CodeDeploy blue/green, where `termination_wait_time_in_minutes = 1380` (23 hours) had kept the blue tasks around for an instant rollback. Carrying that window over means `bakeTimeInMinutes: 1380`, and then:

- `deployed` → `WaitServiceDeployCompleted` returns only on a terminal status, and the service deployment stays `IN_PROGRESS` for the whole bake
- `stable` → blue and green are both running during the bake, so the service is not stable either

So a CI job either blocks for 23 hours or gives up waiting entirely and reports success before traffic has shifted. Under CodeDeploy this was solved by `--wait-until codedeploy:AllowTraffic`; the ECS deployment controller has no equivalent.

The information is already there. `lifecycleStage` is part of the `DescribeServiceDeployments` response that `WaitServiceDeployCompleted` polls on every tick, and it was unused.

## Change

Accept `ecs:<stage>` for `deploy --wait-until`, mirroring the existing `codedeploy:<event>` support. `ecs:BAKE_TIME` returns once production traffic has fully shifted to green — the ECS equivalent of `codedeploy:AllowTraffic`.

```console
$ ecspresso deploy --wait-until ecs:BAKE_TIME
```

`WaitServiceDeployCompleted` is refactored into `waitServiceDeployment(ctx, done)` taking an optional predicate, so the terminal-status handling stays in one place. A `nil` predicate is the existing behavior.

Scoped to `deploy`, the same as `codedeploy:*` — `rollback` and `wait` keep their `enum:"stable,deployed"`.

## Details worth reviewing

- **Stages are compared by position, not equality.** `PRODUCTION_TRAFFIC_SHIFT` and similar stages are transient and can be skipped between polls, so an equality check would hang. The target is compared against `ServiceDeploymentLifecycleStage.Values()`, which is in lifecycle order. `TestLifecycleStageIndex` pins that ordering, since the approach depends on it.
- **A rollback must not satisfy the target.** The stage can still read as `BAKE_TIME` while a rollback is running, so the predicate is only consulted while the status is `PENDING` or `IN_PROGRESS`. Otherwise a circuit breaker rollback would be reported as a successful deploy, which is exactly what the wait is supposed to catch.
- **`ROLLING` is rejected up front.** A rolling deployment reports no lifecycle stage, so `ecs:BAKE_TIME` would silently wait until the timeout. An empty strategy is still allowed, since the service definition may not set one.
- **`ecs:*` with the CodeDeploy controller is now an error** rather than silently falling back to `WaitForCodeDeploy`. This matches how `codedeploy:*` is already rejected for the ECS controller — happy to drop this if you would rather keep it separate.

An invalid stage reports the accepted values:

```console
$ ecspresso deploy --wait-until ecs:bake_time
[ERROR] FAILED. failed to parse args: deploy: invalid waitUntil value: ecs:bake_time (expected one of ecs:RECONCILE_SERVICE, ecs:PRE_SCALE_UP, ecs:SCALE_UP, ecs:POST_SCALE_UP, ecs:TEST_TRAFFIC_SHIFT, ecs:POST_TEST_TRAFFIC_SHIFT, ecs:PRODUCTION_TRAFFIC_SHIFT, ecs:POST_PRODUCTION_TRAFFIC_SHIFT, ecs:BAKE_TIME, ecs:CLEAN_UP)
```

## Testing

`go test ./...` passes, `gofmt` and `go vet` are clean. Added `wait_test.go` for the stage ordering and the strategy validation, plus `--wait-until=ecs:*` cases in `cli_test.go` alongside the existing `codedeploy:` ones. The README help block is regenerated.
