### PR TITLE
Harden --wait-until ecs:<lifecycle stage>

### DIFF
--- a/deploy.go
+++ b/deploy.go
@@ -162,6 +162,15 @@ func (d *App) Deploy(ctx context.Context, opt DeployOption) error {
 		d.LogInfo("desired count: unchanged")
 	}
 
+	// fail fast before mutating anything: at this point sv reflects the service
+	// definition to be deployed, so the strategy check sees the effective value
+	if until := waitUntil(opt.WaitUntil); until.forECSLifecycleStage() {
+		stage := types.ServiceDeploymentLifecycleStage(until.ecsLifecycleStage())
+		if err := validateLifecycleStageSupported(sv, stage); err != nil {
+			return err
+		}
+	}
+
 	// manage auto scaling
 	if err := d.modifyAutoScaling(ctx, opt); err != nil {
 		return err

--- a/export_test.go
+++ b/export_test.go
@@ -38,6 +38,15 @@ var (
 
 	LifecycleStageIndex             = lifecycleStageIndex
 	ValidateLifecycleStageSupported = validateLifecycleStageSupported
+	EvaluateDeploymentStatus        = evaluateDeploymentStatus
+)
+
+type WaitDeploymentResult = waitDeploymentResult
+
+const (
+	WaitDeploymentContinue     = waitDeploymentContinue
+	WaitDeploymentCompleted    = waitDeploymentCompleted
+	WaitDeploymentReachedStage = waitDeploymentReachedStage
 )
 
 type ModifyAutoScalingParams = modifyAutoScalingParams

--- a/wait.go
+++ b/wait.go
@@ -70,9 +70,13 @@ func (u waitUntil) ecsLifecycleStage() string {
 }
 
 // lifecycleStages are the deployment lifecycle stages in the order they occur
-// during a deployment. The waiter compares stage positions, so this must not
-// be derived from types.ServiceDeploymentLifecycleStage.Values(), whose
-// ordering is documented as not guaranteed to be stable across SDK updates.
+// during a deployment, as documented in "Deployment lifecycle stages" at
+// https://docs.aws.amazon.com/AmazonECS/latest/developerguide/blue-green-deployment-how-it-works.html#blue-green-deployment-stages
+// The waiter compares stage positions, so this must not be derived from
+// types.ServiceDeploymentLifecycleStage.Values(), whose ordering is documented
+// as not guaranteed to be stable across SDK updates. When the SDK introduces a
+// new stage (TestLifecycleStageIndex fails), insert it here at the position
+// the document above describes.
 var lifecycleStages = []types.ServiceDeploymentLifecycleStage{
 	types.ServiceDeploymentLifecycleStageReconcileService,
 	types.ServiceDeploymentLifecycleStagePreScaleUp,

--- a/wait.go
+++ b/wait.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -68,21 +69,33 @@ func (u waitUntil) ecsLifecycleStage() string {
 	return ""
 }
 
+// lifecycleStages are the deployment lifecycle stages in the order they occur
+// during a deployment. The waiter compares stage positions, so this must not
+// be derived from types.ServiceDeploymentLifecycleStage.Values(), whose
+// ordering is documented as not guaranteed to be stable across SDK updates.
+var lifecycleStages = []types.ServiceDeploymentLifecycleStage{
+	types.ServiceDeploymentLifecycleStageReconcileService,
+	types.ServiceDeploymentLifecycleStagePreScaleUp,
+	types.ServiceDeploymentLifecycleStageScaleUp,
+	types.ServiceDeploymentLifecycleStagePostScaleUp,
+	types.ServiceDeploymentLifecycleStageTestTrafficShift,
+	types.ServiceDeploymentLifecycleStagePostTestTrafficShift,
+	types.ServiceDeploymentLifecycleStageProductionTrafficShift,
+	types.ServiceDeploymentLifecycleStagePostProductionTrafficShift,
+	types.ServiceDeploymentLifecycleStageBakeTime,
+	types.ServiceDeploymentLifecycleStageCleanUp,
+}
+
 // lifecycleStageIndex returns the position of the stage in the deployment
 // lifecycle, or -1 when the stage is unknown (including an empty stage, which
 // is what a rolling deployment reports).
 func lifecycleStageIndex(stage types.ServiceDeploymentLifecycleStage) int {
-	for i, s := range stage.Values() {
-		if s == stage {
-			return i
-		}
-	}
-	return -1
+	return slices.Index(lifecycleStages, stage)
 }
 
 func lifecycleStageNames() []string {
-	var names []string
-	for _, s := range types.ServiceDeploymentLifecycleStage("").Values() {
+	names := make([]string, 0, len(lifecycleStages))
+	for _, s := range lifecycleStages {
 		names = append(names, waitUntilECSPrefix+string(s))
 	}
 	return names
@@ -106,7 +119,17 @@ func (confirm confirmFunc) wrap(wait waitFunc) waitFunc {
 
 func (d *App) WaitFunc(sv *Service, confirm confirmFunc, until waitUntil) (waitFunc, error) {
 	defaultFunc := confirm.wrap(d.WaitServiceStable)
-	if sv == nil || sv.DeploymentController == nil {
+	if sv == nil {
+		return defaultFunc, nil
+	}
+	if sv.DeploymentController == nil {
+		// ECS is the default deployment controller when the service doesn't set
+		// one explicitly, so a lifecycle stage target must not fall back to the
+		// service-stable waiter silently.
+		if until.forECSLifecycleStage() {
+			stage := types.ServiceDeploymentLifecycleStage(until.ecsLifecycleStage())
+			return d.WaitServiceDeployLifecycleStage(stage), nil
+		}
 		return defaultFunc, nil
 	}
 	if dc := sv.DeploymentController; dc != nil {
@@ -277,8 +300,16 @@ func (d *App) WaitServiceDeployCompleted(ctx context.Context, sv *Service) error
 // allows returning before a long bakeTimeInMinutes elapses.
 func (d *App) WaitServiceDeployLifecycleStage(stage types.ServiceDeploymentLifecycleStage) waitFunc {
 	return func(ctx context.Context, sv *Service) error {
+		if lifecycleStageIndex(stage) < 0 {
+			// An unknown stage would index to -1 and be satisfied by any
+			// deployment state immediately, so reject it up front.
+			return fmt.Errorf("unknown lifecycle stage: %s (expected one of %s)", stage, strings.Join(lifecycleStageNames(), ", "))
+		}
 		if err := validateLifecycleStageSupported(sv, stage); err != nil {
 			return err
+		}
+		if sv == nil || sv.DeploymentConfiguration == nil || sv.DeploymentConfiguration.Strategy == "" {
+			d.LogWarn("deployment strategy is not set; a ROLLING deployment reports no lifecycle stage, so this waits until the deployment completes")
 		}
 		d.LogInfo("Waiting for service deployment lifecycle stage...", "stage", string(stage))
 		target := lifecycleStageIndex(stage)
@@ -366,27 +397,57 @@ func (d *App) waitServiceDeployment(ctx context.Context, done func(*types.Servic
 			d.LogInfo("service deployment status", "status", string(status))
 			prevStatus = status
 		}
-		switch status {
-		case types.ServiceDeploymentStatusSuccessful, types.ServiceDeploymentStatusRollbackSuccessful:
+		result, err := evaluateDeploymentStatus(&dp, done)
+		if err != nil {
+			return err
+		}
+		switch result {
+		case waitDeploymentCompleted:
 			d.LogInfo("service deployment completed", "status", string(status))
 			return nil
-		case types.ServiceDeploymentStatusStopped, types.ServiceDeploymentStatusRollbackFailed, types.ServiceDeploymentStatusStopRequested:
-			return fmt.Errorf("Service deployment failed %s", status)
+		case waitDeploymentReachedStage:
+			d.LogInfo("service deployment reached the lifecycle stage", "stage", string(dp.LifecycleStage))
+			return nil
 		default:
 			d.LogDebug("Deployment %s, waiting...", status)
 		}
+	}
+}
 
-		// A lifecycle stage target is only meaningful while the deployment is
-		// progressing. During a rollback the stage can still read as the target,
-		// so keep waiting for the rollback to reach a terminal status instead.
-		switch status {
-		case types.ServiceDeploymentStatusPending, types.ServiceDeploymentStatusInProgress:
-			if done != nil && done(&dp) {
-				d.LogInfo("service deployment reached the lifecycle stage", "stage", string(dp.LifecycleStage))
-				return nil
+type waitDeploymentResult int
+
+const (
+	waitDeploymentContinue waitDeploymentResult = iota
+	waitDeploymentCompleted
+	waitDeploymentReachedStage
+)
+
+// evaluateDeploymentStatus decides whether polling the service deployment can
+// stop. A non-nil done means the caller waits for a lifecycle stage of this
+// deployment, so a rollback is a failure instead of a terminal success.
+func evaluateDeploymentStatus(dp *types.ServiceDeployment, done func(*types.ServiceDeployment) bool) (waitDeploymentResult, error) {
+	switch dp.Status {
+	case types.ServiceDeploymentStatusSuccessful:
+		return waitDeploymentCompleted, nil
+	case types.ServiceDeploymentStatusRollbackSuccessful:
+		if done != nil {
+			if reason := aws.ToString(dp.StatusReason); reason != "" {
+				return waitDeploymentContinue, fmt.Errorf("service deployment has been rolled back before reaching the target lifecycle stage: %s", reason)
 			}
+			return waitDeploymentContinue, fmt.Errorf("service deployment has been rolled back before reaching the target lifecycle stage")
+		}
+		return waitDeploymentCompleted, nil
+	case types.ServiceDeploymentStatusStopped, types.ServiceDeploymentStatusRollbackFailed, types.ServiceDeploymentStatusStopRequested:
+		return waitDeploymentContinue, fmt.Errorf("Service deployment failed %s", dp.Status)
+	case types.ServiceDeploymentStatusPending, types.ServiceDeploymentStatusInProgress:
+		// A lifecycle stage target is only meaningful while the deployment is
+		// progressing. During a rollback the stage can still read as the
+		// target, so keep waiting for the rollback to reach a terminal status.
+		if done != nil && done(dp) {
+			return waitDeploymentReachedStage, nil
 		}
 	}
+	return waitDeploymentContinue, nil
 }
 
 func (d *App) getCodeDeployDeploymentID(ctx context.Context) (string, error) {

--- a/wait_test.go
+++ b/wait_test.go
@@ -8,18 +8,33 @@ import (
 )
 
 func TestLifecycleStageIndex(t *testing.T) {
-	// The waiter compares positions instead of equality, so the ordering of the
-	// stages within the deployment lifecycle is what matters.
-	stages := types.ServiceDeploymentLifecycleStage("").Values()
-	for i, stage := range stages {
+	// The waiter compares positions instead of equality, so pin the full
+	// ordering of the stages within the deployment lifecycle.
+	expected := []types.ServiceDeploymentLifecycleStage{
+		"RECONCILE_SERVICE",
+		"PRE_SCALE_UP",
+		"SCALE_UP",
+		"POST_SCALE_UP",
+		"TEST_TRAFFIC_SHIFT",
+		"POST_TEST_TRAFFIC_SHIFT",
+		"PRODUCTION_TRAFFIC_SHIFT",
+		"POST_PRODUCTION_TRAFFIC_SHIFT",
+		"BAKE_TIME",
+		"CLEAN_UP",
+	}
+	for i, stage := range expected {
 		if got := ecspresso.LifecycleStageIndex(stage); got != i {
 			t.Errorf("lifecycleStageIndex(%s) = %d, expected %d", stage, got, i)
 		}
 	}
 
-	if scaleUp, bakeTime := ecspresso.LifecycleStageIndex(types.ServiceDeploymentLifecycleStageScaleUp),
-		ecspresso.LifecycleStageIndex(types.ServiceDeploymentLifecycleStageBakeTime); scaleUp >= bakeTime {
-		t.Errorf("SCALE_UP (%d) must come before BAKE_TIME (%d)", scaleUp, bakeTime)
+	// Every stage known to the SDK must have a position, so that an SDK update
+	// introducing a new stage fails this test instead of silently indexing to
+	// -1 (which never satisfies a target).
+	for _, stage := range types.ServiceDeploymentLifecycleStage("").Values() {
+		if got := ecspresso.LifecycleStageIndex(stage); got < 0 {
+			t.Errorf("lifecycleStageIndex(%s) = %d; add the new stage to lifecycleStages in its lifecycle position", stage, got)
+		}
 	}
 
 	// A rolling deployment reports no lifecycle stage, which must never satisfy
@@ -95,5 +110,121 @@ func TestWaitFuncForECSLifecycleStage(t *testing.T) {
 	}
 	if _, err := app.WaitFunc(cd, nil, "ecs:BAKE_TIME"); err == nil {
 		t.Error("ecs:* should not be accepted for the CodeDeploy deployment controller")
+	}
+
+	// ECS is the default deployment controller: a service without an explicit
+	// one must not fall back to the service-stable waiter silently.
+	noController := &ecspresso.Service{Service: types.Service{}}
+	doWait, err := app.WaitFunc(noController, nil, "ecs:BAKE_TIME")
+	if err != nil {
+		t.Errorf("ecs:BAKE_TIME should be supported without an explicit deployment controller, got %v", err)
+	}
+	// The returned waiter must reject a rolling service before polling AWS.
+	rolling := &ecspresso.Service{
+		Service: types.Service{
+			DeploymentConfiguration: &types.DeploymentConfiguration{
+				Strategy: types.DeploymentStrategyRolling,
+			},
+		},
+	}
+	if err := doWait(t.Context(), rolling); err == nil {
+		t.Error("waiting for a lifecycle stage on a ROLLING service should fail")
+	}
+}
+
+func TestWaitServiceDeployLifecycleStageUnknownStage(t *testing.T) {
+	app := &ecspresso.App{}
+	sv := &ecspresso.Service{
+		Service: types.Service{
+			DeploymentConfiguration: &types.DeploymentConfiguration{
+				Strategy: types.DeploymentStrategyBlueGreen,
+			},
+		},
+	}
+	// An unknown stage would index to -1 and be satisfied immediately, so the
+	// waiter must reject it before polling anything.
+	for _, stage := range []types.ServiceDeploymentLifecycleStage{"", "NO_SUCH_STAGE"} {
+		if err := app.WaitServiceDeployLifecycleStage(stage)(t.Context(), sv); err == nil {
+			t.Errorf("unknown lifecycle stage %q should be rejected", stage)
+		}
+	}
+}
+
+func TestEvaluateDeploymentStatus(t *testing.T) {
+	reached := func(dp *types.ServiceDeployment) bool {
+		return ecspresso.LifecycleStageIndex(dp.LifecycleStage) >= ecspresso.LifecycleStageIndex(types.ServiceDeploymentLifecycleStageBakeTime)
+	}
+	tests := []struct {
+		name    string
+		dp      types.ServiceDeployment
+		done    func(*types.ServiceDeployment) bool
+		want    ecspresso.WaitDeploymentResult
+		wantErr bool
+	}{
+		{
+			name: "successful",
+			dp:   types.ServiceDeployment{Status: types.ServiceDeploymentStatusSuccessful},
+			want: ecspresso.WaitDeploymentCompleted,
+		},
+		{
+			name: "rollback is completed when waiting for the deployment",
+			dp:   types.ServiceDeployment{Status: types.ServiceDeploymentStatusRollbackSuccessful},
+			want: ecspresso.WaitDeploymentCompleted,
+		},
+		{
+			name:    "rollback fails when waiting for a lifecycle stage",
+			dp:      types.ServiceDeployment{Status: types.ServiceDeploymentStatusRollbackSuccessful},
+			done:    reached,
+			wantErr: true,
+		},
+		{
+			name:    "stopped",
+			dp:      types.ServiceDeployment{Status: types.ServiceDeploymentStatusStopped},
+			wantErr: true,
+		},
+		{
+			name: "in progress before the target stage",
+			dp: types.ServiceDeployment{
+				Status:         types.ServiceDeploymentStatusInProgress,
+				LifecycleStage: types.ServiceDeploymentLifecycleStageScaleUp,
+			},
+			done: reached,
+			want: ecspresso.WaitDeploymentContinue,
+		},
+		{
+			name: "in progress at the target stage",
+			dp: types.ServiceDeployment{
+				Status:         types.ServiceDeploymentStatusInProgress,
+				LifecycleStage: types.ServiceDeploymentLifecycleStageBakeTime,
+			},
+			done: reached,
+			want: ecspresso.WaitDeploymentReachedStage,
+		},
+		{
+			name: "the stage during a rollback does not satisfy the target",
+			dp: types.ServiceDeployment{
+				Status:         types.ServiceDeploymentStatusRollbackInProgress,
+				LifecycleStage: types.ServiceDeploymentLifecycleStageBakeTime,
+			},
+			done: reached,
+			want: ecspresso.WaitDeploymentContinue,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ecspresso.EvaluateDeploymentStatus(&tt.dp, tt.done)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected an error")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("evaluateDeploymentStatus = %v, expected %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Follow-up to #1063, addressing review findings on the merged feature.

## What

- Fail the deploy when the deployment is rolled back before reaching the target lifecycle stage. Previously ROLLBACK_SUCCESSFUL was treated as a terminal success, so `deploy --wait-until ecs:BAKE_TIME` exited 0 while the old revision was still serving. The `deployed` target and the standalone `wait` command keep their existing behavior (rollback exits 0; `wait` cannot know what the user intends to wait for).
- Validate the deployment strategy before calling UpdateService, so an invalid combination (e.g. `ecs:*` on a ROLLING service) fails before triggering a deployment. The check runs after the local service definition is applied to `sv`, so a deploy that switches the strategy to blue/green is not rejected.
- Route `ecs:*` to the stage waiter when the service has no explicit deployment controller (ECS is the default), instead of silently falling back to the service-stable waiter.
- Reject unknown lifecycle stages in the waiter: an unknown stage indexes to -1 and would be satisfied by any deployment state immediately.
- Warn when the deployment strategy is not set, since a ROLLING deployment reports no lifecycle stage and the wait degrades to full deployment completion.
- Hardcode the lifecycle stage order instead of relying on `ServiceDeploymentLifecycleStage.Values()`, whose ordering the SDK documents as not guaranteed to be stable. The order follows the [Deployment lifecycle stages](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/blue-green-deployment-how-it-works.html#blue-green-deployment-stages) table in the ECS Developer Guide. A test pins the order and fails when the SDK introduces a stage not in the list, so a new stage (e.g. PRE_PRODUCTION_TRAFFIC_SHIFT, currently documented and defined for lifecycle hooks but not yet reported as a ServiceDeploymentLifecycleStage) gets inserted at its documented position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)