### PR TITLE
Support --wait-until ecs:<lifecycle stage> for deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,8 +485,10 @@ Events:
   --revision=0                           revision of the task definition to run when --skip-task-definition
   --force-new-deployment                 force a new deployment of the service
   --[no-]wait                            wait for service stable
-  --wait-until="deployed"                Choose whether to wait for service stable or the deployment finishes. For
-                                         ECS deployment controller: "(stable|deployed)"; For CodeDeploy deployment
+  --wait-until="deployed"                Choose whether to wait for service stable, the deployment finishes, or a
+                                         lifecycle hook pauses. For ECS deployment controller:
+                                         "(stable|deployed|paused)", or "ecs:*", this accepts a deployment
+                                         lifecycle stage (e.g., "ecs:BAKE_TIME"); For CodeDeploy deployment
                                          controller: "codedeploy:*", this accepts CodeDeploy lifecycle event (e.g.,
                                          "codedeploy:AfterAllowTraffic")
   --suspend-auto-scaling                 suspend application auto-scaling attached with the ECS service
@@ -1082,6 +1084,14 @@ $ ecspresso rollback
 `ecspresso continue` also accepts `--wait-until` to wait after continuing (default: `deployed`). Use `--wait-until=paused` to wait for the next pause hook if multiple hooks are configured.
 
 For linear and canary deployments, pause hooks at `PRE_PRODUCTION_TRAFFIC_SHIFT` are invoked at each traffic shift step. Each step generates a unique `hookId`, so you need to run `ecspresso continue --wait-until=paused` repeatedly for each step.
+
+Use `--wait-until=ecs:<lifecycle stage>` (e.g., `ecs:BAKE_TIME`) with `ecspresso deploy` to return when the deployment reaches the specified [lifecycle stage](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/blue-green-deployment-how-it-works.html#blue-green-deployment-stages), instead of waiting for the whole deployment to finish. This is useful to finish a CI job without waiting for a long bake time.
+
+```console
+$ ecspresso deploy --wait-until=ecs:BAKE_TIME
+```
+
+This option requires a traffic shifting deployment strategy (blue/green, linear, or canary). If the deployment is rolled back before reaching the target stage, `ecspresso deploy` exits with a non-zero status.
 
 ### ECS Express mode support
 

--- a/cli_test.go
+++ b/cli_test.go
@@ -231,6 +231,24 @@ var cliTests = []struct {
 		},
 	},
 	{
+		args: []string{"deploy", "--wait-until=ecs:BAKE_TIME"},
+		sub:  "deploy",
+		subOption: &ecspresso.DeployOption{
+			SuspendAutoScaling:   nil,
+			ResumeAutoScaling:    nil,
+			DryRun:               false,
+			DesiredCount:         ptr(int32(-1)),
+			SkipTaskDefinition:   false,
+			Revision:             0,
+			ForceNewDeployment:   false,
+			Wait:                 true,
+			WaitUntil:            "ecs:BAKE_TIME",
+			RollbackEvents:       "",
+			UpdateService:        true,
+			LatestTaskDefinition: false,
+		},
+	},
+	{
 		args: []string{"scale", "--tasks=5"},
 		sub:  "scale",
 		subOption: &ecspresso.ScaleOption{
@@ -1061,6 +1079,18 @@ func TestParseCLIWithInvalidWaitUntilOption(t *testing.T) {
 		t.Errorf("invalid wait-until should return error")
 	}
 	_, _, _, err = ecspresso.ParseCLI([]string{"deploy", "--wait-until=codedeploy:"}) // lifecycle event name is empty (i.e., prefix only)
+	if err == nil {
+		t.Errorf("invalid wait-until should return error")
+	}
+	_, _, _, err = ecspresso.ParseCLI([]string{"deploy", "--wait-until=ecs:"}) // lifecycle stage is empty (i.e., prefix only)
+	if err == nil {
+		t.Errorf("invalid wait-until should return error")
+	}
+	_, _, _, err = ecspresso.ParseCLI([]string{"deploy", "--wait-until=ecs:NO_SUCH_STAGE"})
+	if err == nil {
+		t.Errorf("invalid wait-until should return error")
+	}
+	_, _, _, err = ecspresso.ParseCLI([]string{"deploy", "--wait-until=ecs:bake_time"}) // lifecycle stage is case sensitive
 	if err == nil {
 		t.Errorf("invalid wait-until should return error")
 	}

--- a/deploy.go
+++ b/deploy.go
@@ -31,7 +31,7 @@ type DeployOption struct {
 	Revision             int64  `help:"revision of the task definition to run when --skip-task-definition" default:"0"`
 	ForceNewDeployment   bool   `help:"force a new deployment of the service" default:"false"`
 	Wait                 bool   `help:"wait for service stable" default:"true" negatable:""`
-	WaitUntil            string `help:"Choose whether to wait for service stable, the deployment finishes, or a lifecycle hook pauses. For ECS deployment controller: \"(stable|deployed|paused)\"; For CodeDeploy deployment controller: \"codedeploy:*\", this accepts CodeDeploy lifecycle event (e.g., \"codedeploy:AfterAllowTraffic\")" default:"deployed"`
+	WaitUntil            string `help:"Choose whether to wait for service stable, the deployment finishes, or a lifecycle hook pauses. For ECS deployment controller: \"(stable|deployed|paused)\", or \"ecs:*\", this accepts a deployment lifecycle stage (e.g., \"ecs:BAKE_TIME\"); For CodeDeploy deployment controller: \"codedeploy:*\", this accepts CodeDeploy lifecycle event (e.g., \"codedeploy:AfterAllowTraffic\")" default:"deployed"`
 	SuspendAutoScaling   *bool  `help:"suspend application auto-scaling attached with the ECS service"`
 	ResumeAutoScaling    *bool  `help:"resume application auto-scaling attached with the ECS service"`
 	AutoScalingMin       *int32 `help:"set minimum capacity of application auto-scaling attached with the ECS service"`
@@ -160,6 +160,15 @@ func (d *App) Deploy(ctx context.Context, opt DeployOption) error {
 		d.LogInfo("desired count", "desired_count", *count)
 	} else {
 		d.LogInfo("desired count: unchanged")
+	}
+
+	// fail fast before mutating anything: at this point sv reflects the service
+	// definition to be deployed, so the strategy check sees the effective value
+	if until := waitUntil(opt.WaitUntil); until.forECSLifecycleStage() {
+		stage := types.ServiceDeploymentLifecycleStage(until.ecsLifecycleStage())
+		if err := validateLifecycleStageSupported(sv, stage); err != nil {
+			return err
+		}
 	}
 
 	// manage auto scaling

--- a/deploy.go
+++ b/deploy.go
@@ -162,8 +162,9 @@ func (d *App) Deploy(ctx context.Context, opt DeployOption) error {
 		d.LogInfo("desired count: unchanged")
 	}
 
-	// fail fast before mutating anything: at this point sv reflects the service
-	// definition to be deployed, so the strategy check sees the effective value
+	// fail fast before starting the deployment: at this point sv reflects the
+	// service definition to be deployed, so the strategy check sees the
+	// effective value
 	if until := waitUntil(opt.WaitUntil); until.forECSLifecycleStage() {
 		stage := types.ServiceDeploymentLifecycleStage(until.ecsLifecycleStage())
 		if err := validateLifecycleStageSupported(sv, stage); err != nil {

--- a/export_test.go
+++ b/export_test.go
@@ -36,7 +36,23 @@ var (
 	ParseSections          = parseSections
 	ReadmeContent          = readmeContent
 	GetArticle             = getArticle
+
+	LifecycleStageIndex             = lifecycleStageIndex
+	ValidateLifecycleStageSupported = validateLifecycleStageSupported
+	EvaluateDeploymentStatus        = evaluateDeploymentStatus
 )
+
+type WaitDeploymentResult = waitDeploymentResult
+
+const (
+	WaitDeploymentContinue  = waitDeploymentContinue
+	WaitDeploymentCompleted = waitDeploymentCompleted
+	WaitDeploymentDone      = waitDeploymentDone
+)
+
+func (d *App) DeploymentPaused(dp *types.ServiceDeployment) bool {
+	return d.deploymentPaused(dp)
+}
 
 type ModifyAutoScalingParams = modifyAutoScalingParams
 type IAMPolicyDocument = iamPolicyDocument

--- a/wait.go
+++ b/wait.go
@@ -442,7 +442,10 @@ func evaluateDeploymentStatus(dp *types.ServiceDeployment, done func(*types.Serv
 		}
 		return waitDeploymentCompleted, nil
 	case types.ServiceDeploymentStatusStopped, types.ServiceDeploymentStatusRollbackFailed, types.ServiceDeploymentStatusStopRequested:
-		return waitDeploymentContinue, fmt.Errorf("Service deployment failed %s", dp.Status)
+		if reason := aws.ToString(dp.StatusReason); reason != "" {
+			return waitDeploymentContinue, fmt.Errorf("service deployment failed: %s (%s)", dp.Status, reason)
+		}
+		return waitDeploymentContinue, fmt.Errorf("service deployment failed: %s", dp.Status)
 	case types.ServiceDeploymentStatusPending, types.ServiceDeploymentStatusInProgress:
 		// The done condition is only meaningful while the deployment is
 		// progressing. During a rollback a lifecycle stage can still read as

--- a/wait.go
+++ b/wait.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -27,6 +28,7 @@ const (
 	waitUntilDeployed         waitUntil = "deployed"
 	waitUntilPaused           waitUntil = "paused"
 	waitUntilCodeDeployPrefix           = "codedeploy:"
+	waitUntilECSPrefix                  = "ecs:"
 )
 
 func (u waitUntil) Validate() error {
@@ -36,7 +38,14 @@ func (u waitUntil) Validate() error {
 	if u.forCodeDeployLifecycle() && len(u) > len(waitUntilCodeDeployPrefix) {
 		return nil
 	}
-	return fmt.Errorf("invalid waitUntil value: %s (expected: stable, deployed, paused, or codedeploy:*)", u)
+	if u.forECSLifecycleStage() {
+		stage := types.ServiceDeploymentLifecycleStage(u.ecsLifecycleStage())
+		if lifecycleStageIndex(stage) < 0 {
+			return fmt.Errorf("invalid waitUntil value: %s (expected one of %s)", u, strings.Join(lifecycleStageNames(), ", "))
+		}
+		return nil
+	}
+	return fmt.Errorf("invalid waitUntil value: %s (expected: stable, deployed, paused, codedeploy:*, or ecs:*)", u)
 }
 
 func (u waitUntil) forECSDeployment() bool {
@@ -49,8 +58,8 @@ func (u waitUntil) forCodeDeployLifecycle() bool {
 
 func (u waitUntil) doneMessage() string {
 	switch {
-	case u == waitUntilPaused:
-		// waitServiceDeployment logs the actual result (paused or completed)
+	case u == waitUntilPaused, u.forECSLifecycleStage():
+		// waitServiceDeployment logs the actual result
 		return ""
 	case u.forECSDeployment():
 		return "service deployment completed"
@@ -66,6 +75,53 @@ func (u waitUntil) codeDeployLifecycleEvent() string {
 		return strings.TrimPrefix(string(u), waitUntilCodeDeployPrefix)
 	}
 	return ""
+}
+
+func (u waitUntil) forECSLifecycleStage() bool {
+	return strings.HasPrefix(string(u), waitUntilECSPrefix)
+}
+
+func (u waitUntil) ecsLifecycleStage() string {
+	if u.forECSLifecycleStage() {
+		return strings.TrimPrefix(string(u), waitUntilECSPrefix)
+	}
+	return ""
+}
+
+// lifecycleStages are the deployment lifecycle stages in the order they occur
+// during a deployment, as documented in "Deployment lifecycle stages" at
+// https://docs.aws.amazon.com/AmazonECS/latest/developerguide/blue-green-deployment-how-it-works.html#blue-green-deployment-stages
+// The waiter compares stage positions, so this must not be derived from
+// types.ServiceDeploymentLifecycleStage.Values(), whose ordering is documented
+// as not guaranteed to be stable across SDK updates. When the SDK introduces a
+// new stage (TestLifecycleStageIndex fails), insert it here at the position
+// the document above describes.
+var lifecycleStages = []types.ServiceDeploymentLifecycleStage{
+	types.ServiceDeploymentLifecycleStageReconcileService,
+	types.ServiceDeploymentLifecycleStagePreScaleUp,
+	types.ServiceDeploymentLifecycleStageScaleUp,
+	types.ServiceDeploymentLifecycleStagePostScaleUp,
+	types.ServiceDeploymentLifecycleStageTestTrafficShift,
+	types.ServiceDeploymentLifecycleStagePostTestTrafficShift,
+	types.ServiceDeploymentLifecycleStageProductionTrafficShift,
+	types.ServiceDeploymentLifecycleStagePostProductionTrafficShift,
+	types.ServiceDeploymentLifecycleStageBakeTime,
+	types.ServiceDeploymentLifecycleStageCleanUp,
+}
+
+// lifecycleStageIndex returns the position of the stage in the deployment
+// lifecycle, or -1 when the stage is unknown (including an empty stage, which
+// is what a rolling deployment reports).
+func lifecycleStageIndex(stage types.ServiceDeploymentLifecycleStage) int {
+	return slices.Index(lifecycleStages, stage)
+}
+
+func lifecycleStageNames() []string {
+	names := make([]string, 0, len(lifecycleStages))
+	for _, s := range lifecycleStages {
+		names = append(names, waitUntilECSPrefix+string(s))
+	}
+	return names
 }
 
 type waitFunc func(ctx context.Context, sv *Service) error
@@ -86,12 +142,22 @@ func (confirm confirmFunc) wrap(wait waitFunc) waitFunc {
 
 func (d *App) WaitFunc(sv *Service, confirm confirmFunc, until waitUntil, deploymentArn ...string) (waitFunc, error) {
 	defaultFunc := confirm.wrap(d.WaitServiceStable)
-	if sv == nil || sv.DeploymentController == nil {
-		return defaultFunc, nil
-	}
 	var knownArn string
 	if len(deploymentArn) > 0 {
 		knownArn = deploymentArn[0]
+	}
+	if sv == nil {
+		return defaultFunc, nil
+	}
+	if sv.DeploymentController == nil {
+		// ECS is the default deployment controller when the service doesn't set
+		// one explicitly, so a lifecycle stage target must not fall back to the
+		// service-stable waiter silently.
+		if until.forECSLifecycleStage() {
+			stage := types.ServiceDeploymentLifecycleStage(until.ecsLifecycleStage())
+			return d.WaitServiceDeployLifecycleStage(stage, knownArn), nil
+		}
+		return defaultFunc, nil
 	}
 	if dc := sv.DeploymentController; dc != nil {
 		switch dc.Type {
@@ -99,16 +165,25 @@ func (d *App) WaitFunc(sv *Service, confirm confirmFunc, until waitUntil, deploy
 			if until.forCodeDeployLifecycle() {
 				return d.WaitForCodeDeployLifecycle(until.codeDeployLifecycleEvent()), nil
 			}
+			if until.forECSLifecycleStage() {
+				return nil, fmt.Errorf("unsupported waitUntil: %s (a deployment lifecycle stage is only reported by the ECS deployment controller)", until)
+			}
 			return d.WaitForCodeDeploy, nil
 		case types.DeploymentControllerTypeEcs:
+			if until.forECSLifecycleStage() {
+				stage := types.ServiceDeploymentLifecycleStage(until.ecsLifecycleStage())
+				return d.WaitServiceDeployLifecycleStage(stage, knownArn), nil
+			}
 			switch until {
 			case waitUntilDeployed:
 				return confirm.wrap(func(ctx context.Context, sv *Service) error {
-					return d.waitServiceDeployment(ctx, knownArn, false)
+					d.LogInfo("Waiting for service deployed...(it will take a few minutes)")
+					return d.waitServiceDeployment(ctx, knownArn, nil)
 				}), nil
 			case waitUntilPaused:
 				return func(ctx context.Context, sv *Service) error {
-					return d.waitServiceDeployment(ctx, knownArn, true)
+					d.LogInfo("Waiting for service deployment paused...(it will take a few minutes)")
+					return d.waitServiceDeployment(ctx, knownArn, d.deploymentPaused)
 				}, nil
 			case waitUntilStable, "":
 				return defaultFunc, nil
@@ -252,12 +327,11 @@ func serviceRevisionsSummaries(dp *types.ServiceDeployment) []string {
 	return lines
 }
 
-func (d *App) waitServiceDeployment(ctx context.Context, knownDeploymentArn string, waitForPause bool) error {
-	if waitForPause {
-		d.LogInfo("Waiting for service deployment paused...(it will take a few minutes)")
-	} else {
-		d.LogInfo("Waiting for service deployed...(it will take a few minutes)")
-	}
+// waitServiceDeployment polls the active service deployment until done reports
+// true, or until the deployment reaches a terminal status. A nil done waits for
+// the deployment to finish. done implementations log their own reason when
+// returning true.
+func (d *App) waitServiceDeployment(ctx context.Context, knownDeploymentArn string, done func(*types.ServiceDeployment) bool) error {
 	deploymentArn := knownDeploymentArn
 	if deploymentArn == "" {
 		var err error
@@ -272,13 +346,13 @@ func (d *App) waitServiceDeployment(ctx context.Context, knownDeploymentArn stri
 	}
 	d.LogInfo("waiting for service deployment", "deployment", arnToName(deploymentArn))
 
-	if waitForPause {
+	if done != nil {
 		initResp, err := d.ecs.DescribeServiceDeployments(ctx, &ecs.DescribeServiceDeploymentsInput{
 			ServiceDeploymentArns: []string{deploymentArn},
 		})
 		if err == nil && len(initResp.ServiceDeployments) > 0 {
 			if dc := initResp.ServiceDeployments[0].DeploymentConfiguration; dc != nil && dc.Strategy == types.DeploymentStrategyRolling {
-				d.LogWarn("--wait-until=paused is not effective for rolling deployments. Pause lifecycle hooks are only supported with blue/green, linear, and canary strategies. Falling back to waiting for deployment completion.")
+				d.LogWarn("the deployment strategy is ROLLING. Pause lifecycle hooks and deployment lifecycle stages are only supported with blue/green, linear, and canary strategies. Falling back to waiting for deployment completion.")
 			}
 		}
 	}
@@ -320,44 +394,140 @@ func (d *App) waitServiceDeployment(ctx context.Context, knownDeploymentArn stri
 			prevRevisionSummaryOutput = revisionSummaryOutput
 		}
 
-		// check if a pause lifecycle hook is awaiting action
-		if waitForPause {
-			for _, hook := range dp.LifecycleHookDetails {
-				if hook.TargetType == types.DeploymentLifecycleHookTargetTypePause &&
-					hook.Status == types.DeploymentLifecycleHookStatusAwaitingAction {
-					d.LogInfo("deployment paused at lifecycle hook",
-						"hook_id", aws.ToString(hook.HookId),
-						"lifecycle_stage", string(dp.LifecycleStage),
-					)
-					return nil
-				}
-			}
-		}
-
 		// check deployment status
 		status := dp.Status
 		if status != prevStatus {
 			d.LogInfo("service deployment status", "status", string(status))
 			prevStatus = status
 		}
-		switch status {
-		case types.ServiceDeploymentStatusSuccessful, types.ServiceDeploymentStatusRollbackSuccessful:
+		result, err := evaluateDeploymentStatus(&dp, done)
+		if err != nil {
+			return err
+		}
+		switch result {
+		case waitDeploymentCompleted:
 			d.LogInfo("service deployment completed", "status", string(status))
 			return nil
-		case types.ServiceDeploymentStatusStopped, types.ServiceDeploymentStatusRollbackFailed, types.ServiceDeploymentStatusStopRequested:
-			return fmt.Errorf("Service deployment failed %s", status)
+		case waitDeploymentDone:
+			// the done func has already logged the reason
+			return nil
 		default:
 			d.LogDebug("Deployment %s, waiting...", status)
 		}
 	}
 }
 
+type waitDeploymentResult int
+
+const (
+	waitDeploymentContinue waitDeploymentResult = iota
+	waitDeploymentCompleted
+	waitDeploymentDone
+)
+
+// evaluateDeploymentStatus decides whether polling the service deployment can
+// stop. A non-nil done means the caller waits for a condition of this
+// deployment (a pause or a lifecycle stage), so a rollback is a failure
+// instead of a terminal success: the condition will never be met.
+func evaluateDeploymentStatus(dp *types.ServiceDeployment, done func(*types.ServiceDeployment) bool) (waitDeploymentResult, error) {
+	switch dp.Status {
+	case types.ServiceDeploymentStatusSuccessful:
+		return waitDeploymentCompleted, nil
+	case types.ServiceDeploymentStatusRollbackSuccessful:
+		if done != nil {
+			if reason := aws.ToString(dp.StatusReason); reason != "" {
+				return waitDeploymentContinue, fmt.Errorf("service deployment has been rolled back: %s", reason)
+			}
+			return waitDeploymentContinue, fmt.Errorf("service deployment has been rolled back")
+		}
+		return waitDeploymentCompleted, nil
+	case types.ServiceDeploymentStatusStopped, types.ServiceDeploymentStatusRollbackFailed, types.ServiceDeploymentStatusStopRequested:
+		return waitDeploymentContinue, fmt.Errorf("Service deployment failed %s", dp.Status)
+	case types.ServiceDeploymentStatusPending, types.ServiceDeploymentStatusInProgress:
+		// The done condition is only meaningful while the deployment is
+		// progressing. During a rollback a lifecycle stage can still read as
+		// the target, so keep waiting for a terminal status instead.
+		if done != nil && done(dp) {
+			return waitDeploymentDone, nil
+		}
+	}
+	return waitDeploymentContinue, nil
+}
+
+// deploymentPaused reports whether a pause lifecycle hook of the deployment is
+// awaiting action.
+func (d *App) deploymentPaused(dp *types.ServiceDeployment) bool {
+	for _, hook := range dp.LifecycleHookDetails {
+		if hook.TargetType == types.DeploymentLifecycleHookTargetTypePause &&
+			hook.Status == types.DeploymentLifecycleHookStatusAwaitingAction {
+			d.LogInfo("deployment paused at lifecycle hook",
+				"hook_id", aws.ToString(hook.HookId),
+				"lifecycle_stage", string(dp.LifecycleStage),
+			)
+			return true
+		}
+	}
+	return false
+}
+
+// WaitServiceDeployLifecycleStage returns a waitFunc that waits until the
+// deployment reaches the target lifecycle stage, instead of waiting for the
+// whole deployment to finish. This allows returning before a long
+// bakeTimeInMinutes elapses.
+func (d *App) WaitServiceDeployLifecycleStage(stage types.ServiceDeploymentLifecycleStage, knownDeploymentArn string) waitFunc {
+	return func(ctx context.Context, sv *Service) error {
+		target := lifecycleStageIndex(stage)
+		if target < 0 {
+			// An unknown stage would index to -1 and be satisfied by any
+			// deployment state immediately, so reject it up front.
+			return fmt.Errorf("unknown lifecycle stage: %s (expected one of %s)", stage, strings.Join(lifecycleStageNames(), ", "))
+		}
+		if err := validateLifecycleStageSupported(sv, stage); err != nil {
+			return err
+		}
+		if sv == nil || sv.DeploymentConfiguration == nil || sv.DeploymentConfiguration.Strategy == "" {
+			d.LogWarn("deployment strategy is not set; a ROLLING deployment reports no lifecycle stage, so this waits until the deployment completes")
+		}
+		d.LogInfo("Waiting for service deployment lifecycle stage...", "stage", string(stage))
+		// Stages such as PRODUCTION_TRAFFIC_SHIFT are transient and can be
+		// skipped between polls, so compare positions rather than equality.
+		return d.waitServiceDeployment(ctx, knownDeploymentArn, func(dp *types.ServiceDeployment) bool {
+			if lifecycleStageIndex(dp.LifecycleStage) >= target {
+				d.LogInfo("service deployment reached the lifecycle stage", "stage", string(dp.LifecycleStage))
+				return true
+			}
+			return false
+		})
+	}
+}
+
+// validateLifecycleStageSupported rejects a lifecycle stage target on a service
+// whose deployment never reports one, which would otherwise wait until timeout.
+func validateLifecycleStageSupported(sv *Service, stage types.ServiceDeploymentLifecycleStage) error {
+	if sv == nil || sv.DeploymentConfiguration == nil {
+		return nil
+	}
+	switch strategy := sv.DeploymentConfiguration.Strategy; strategy {
+	case types.DeploymentStrategyBlueGreen, types.DeploymentStrategyLinear, types.DeploymentStrategyCanary:
+		return nil
+	case "":
+		return nil // not set by the service definition, let the deployment decide
+	default:
+		return fmt.Errorf(
+			"waiting for lifecycle stage %s requires a traffic shifting deployment strategy, but the service uses %s",
+			stage, strategy,
+		)
+	}
+}
+
 func (d *App) WaitServiceDeployCompleted(ctx context.Context, sv *Service) error {
-	return d.waitServiceDeployment(ctx, "", false)
+	d.LogInfo("Waiting for service deployed...(it will take a few minutes)")
+	return d.waitServiceDeployment(ctx, "", nil)
 }
 
 func (d *App) WaitServiceDeployPaused(ctx context.Context, sv *Service) error {
-	return d.waitServiceDeployment(ctx, "", true)
+	d.LogInfo("Waiting for service deployment paused...(it will take a few minutes)")
+	return d.waitServiceDeployment(ctx, "", d.deploymentPaused)
 }
 
 func (d *App) getCodeDeployDeploymentID(ctx context.Context) (string, error) {

--- a/wait_test.go
+++ b/wait_test.go
@@ -1,0 +1,290 @@
+package ecspresso_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	"github.com/kayac/ecspresso/v2"
+)
+
+func TestLifecycleStageIndex(t *testing.T) {
+	// The waiter compares positions instead of equality, so pin the full
+	// ordering of the stages within the deployment lifecycle.
+	expected := []types.ServiceDeploymentLifecycleStage{
+		"RECONCILE_SERVICE",
+		"PRE_SCALE_UP",
+		"SCALE_UP",
+		"POST_SCALE_UP",
+		"TEST_TRAFFIC_SHIFT",
+		"POST_TEST_TRAFFIC_SHIFT",
+		"PRODUCTION_TRAFFIC_SHIFT",
+		"POST_PRODUCTION_TRAFFIC_SHIFT",
+		"BAKE_TIME",
+		"CLEAN_UP",
+	}
+	for i, stage := range expected {
+		if got := ecspresso.LifecycleStageIndex(stage); got != i {
+			t.Errorf("lifecycleStageIndex(%s) = %d, expected %d", stage, got, i)
+		}
+	}
+
+	// Every stage known to the SDK must have a position, so that an SDK update
+	// introducing a new stage fails this test instead of silently indexing to
+	// -1 (which never satisfies a target).
+	for _, stage := range types.ServiceDeploymentLifecycleStage("").Values() {
+		if got := ecspresso.LifecycleStageIndex(stage); got < 0 {
+			t.Errorf("lifecycleStageIndex(%s) = %d; add the new stage to lifecycleStages in its lifecycle position", stage, got)
+		}
+	}
+
+	// A rolling deployment reports no lifecycle stage, which must never satisfy
+	// a target stage.
+	for _, stage := range []types.ServiceDeploymentLifecycleStage{"", "NO_SUCH_STAGE"} {
+		if got := ecspresso.LifecycleStageIndex(stage); got != -1 {
+			t.Errorf("lifecycleStageIndex(%q) = %d, expected -1", stage, got)
+		}
+	}
+}
+
+func TestValidateLifecycleStageSupported(t *testing.T) {
+	stage := types.ServiceDeploymentLifecycleStageBakeTime
+
+	for _, strategy := range []types.DeploymentStrategy{
+		types.DeploymentStrategyBlueGreen,
+		types.DeploymentStrategyLinear,
+		types.DeploymentStrategyCanary,
+		"",
+	} {
+		sv := &ecspresso.Service{
+			Service: types.Service{
+				DeploymentConfiguration: &types.DeploymentConfiguration{Strategy: strategy},
+			},
+		}
+		if err := ecspresso.ValidateLifecycleStageSupported(sv, stage); err != nil {
+			t.Errorf("strategy %q should be supported, got %v", strategy, err)
+		}
+	}
+
+	// ROLLING never reports a lifecycle stage, so waiting for one would block
+	// until the timeout expires. Fail fast instead.
+	sv := &ecspresso.Service{
+		Service: types.Service{
+			DeploymentConfiguration: &types.DeploymentConfiguration{
+				Strategy: types.DeploymentStrategyRolling,
+			},
+		},
+	}
+	if err := ecspresso.ValidateLifecycleStageSupported(sv, stage); err == nil {
+		t.Error("ROLLING strategy should not be supported")
+	}
+
+	if err := ecspresso.ValidateLifecycleStageSupported(nil, stage); err != nil {
+		t.Errorf("nil service should be allowed, got %v", err)
+	}
+}
+
+func TestWaitFuncForECSLifecycleStage(t *testing.T) {
+	app := &ecspresso.App{}
+	app.SetLogger(ecspresso.NewLogger(new(bytes.Buffer)))
+	sv := &ecspresso.Service{
+		Service: types.Service{
+			DeploymentController: &types.DeploymentController{
+				Type: types.DeploymentControllerTypeEcs,
+			},
+		},
+	}
+
+	if _, err := app.WaitFunc(sv, nil, "ecs:BAKE_TIME"); err != nil {
+		t.Errorf("ecs:BAKE_TIME should be supported by the ECS deployment controller, got %v", err)
+	}
+	if _, err := app.WaitFunc(sv, nil, "ecs:CLEAN_UP"); err != nil {
+		t.Errorf("ecs:CLEAN_UP should be supported by the ECS deployment controller, got %v", err)
+	}
+
+	// The lifecycle stage of an ECS deployment has no meaning for CodeDeploy.
+	cd := &ecspresso.Service{
+		Service: types.Service{
+			DeploymentController: &types.DeploymentController{
+				Type: types.DeploymentControllerTypeCodeDeploy,
+			},
+		},
+	}
+	if _, err := app.WaitFunc(cd, nil, "ecs:BAKE_TIME"); err == nil {
+		t.Error("ecs:* should not be accepted for the CodeDeploy deployment controller")
+	}
+
+	// ECS is the default deployment controller: a service without an explicit
+	// one must not fall back to the service-stable waiter silently.
+	noController := &ecspresso.Service{Service: types.Service{}}
+	doWait, err := app.WaitFunc(noController, nil, "ecs:BAKE_TIME")
+	if err != nil {
+		t.Errorf("ecs:BAKE_TIME should be supported without an explicit deployment controller, got %v", err)
+	}
+	// The returned waiter must reject a rolling service before polling AWS.
+	rolling := &ecspresso.Service{
+		Service: types.Service{
+			DeploymentConfiguration: &types.DeploymentConfiguration{
+				Strategy: types.DeploymentStrategyRolling,
+			},
+		},
+	}
+	if err := doWait(t.Context(), rolling); err == nil {
+		t.Error("waiting for a lifecycle stage on a ROLLING service should fail")
+	}
+}
+
+func TestWaitServiceDeployLifecycleStageUnknownStage(t *testing.T) {
+	app := &ecspresso.App{}
+	sv := &ecspresso.Service{
+		Service: types.Service{
+			DeploymentConfiguration: &types.DeploymentConfiguration{
+				Strategy: types.DeploymentStrategyBlueGreen,
+			},
+		},
+	}
+	// An unknown stage would index to -1 and be satisfied immediately, so the
+	// waiter must reject it before polling anything.
+	for _, stage := range []types.ServiceDeploymentLifecycleStage{"", "NO_SUCH_STAGE"} {
+		if err := app.WaitServiceDeployLifecycleStage(stage, "")(t.Context(), sv); err == nil {
+			t.Errorf("unknown lifecycle stage %q should be rejected", stage)
+		}
+	}
+}
+
+func TestDeploymentPaused(t *testing.T) {
+	app := &ecspresso.App{}
+	app.SetLogger(ecspresso.NewLogger(new(bytes.Buffer)))
+
+	tests := []struct {
+		name  string
+		hooks []types.DeploymentLifecycleHookDetail
+		want  bool
+	}{
+		{
+			name: "no hooks",
+			want: false,
+		},
+		{
+			name: "pause hook awaiting action",
+			hooks: []types.DeploymentLifecycleHookDetail{
+				{
+					HookId:     aws.String("hook-1"),
+					TargetType: types.DeploymentLifecycleHookTargetTypePause,
+					Status:     types.DeploymentLifecycleHookStatusAwaitingAction,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "pause hook not awaiting action yet",
+			hooks: []types.DeploymentLifecycleHookDetail{
+				{
+					HookId:     aws.String("hook-1"),
+					TargetType: types.DeploymentLifecycleHookTargetTypePause,
+					Status:     types.DeploymentLifecycleHookStatusInProgress,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "non-pause hook awaiting action",
+			hooks: []types.DeploymentLifecycleHookDetail{
+				{
+					HookId:     aws.String("hook-1"),
+					TargetType: types.DeploymentLifecycleHookTargetTypeAwsLambda,
+					Status:     types.DeploymentLifecycleHookStatusAwaitingAction,
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dp := &types.ServiceDeployment{LifecycleHookDetails: tt.hooks}
+			if got := app.DeploymentPaused(dp); got != tt.want {
+				t.Errorf("deploymentPaused = %v, expected %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEvaluateDeploymentStatus(t *testing.T) {
+	reached := func(dp *types.ServiceDeployment) bool {
+		return ecspresso.LifecycleStageIndex(dp.LifecycleStage) >= ecspresso.LifecycleStageIndex(types.ServiceDeploymentLifecycleStageBakeTime)
+	}
+	tests := []struct {
+		name    string
+		dp      types.ServiceDeployment
+		done    func(*types.ServiceDeployment) bool
+		want    ecspresso.WaitDeploymentResult
+		wantErr bool
+	}{
+		{
+			name: "successful",
+			dp:   types.ServiceDeployment{Status: types.ServiceDeploymentStatusSuccessful},
+			want: ecspresso.WaitDeploymentCompleted,
+		},
+		{
+			name: "rollback is completed when waiting for the deployment",
+			dp:   types.ServiceDeployment{Status: types.ServiceDeploymentStatusRollbackSuccessful},
+			want: ecspresso.WaitDeploymentCompleted,
+		},
+		{
+			name:    "rollback fails when waiting for a done condition",
+			dp:      types.ServiceDeployment{Status: types.ServiceDeploymentStatusRollbackSuccessful},
+			done:    reached,
+			wantErr: true,
+		},
+		{
+			name:    "stopped",
+			dp:      types.ServiceDeployment{Status: types.ServiceDeploymentStatusStopped},
+			wantErr: true,
+		},
+		{
+			name: "in progress before the target stage",
+			dp: types.ServiceDeployment{
+				Status:         types.ServiceDeploymentStatusInProgress,
+				LifecycleStage: types.ServiceDeploymentLifecycleStageScaleUp,
+			},
+			done: reached,
+			want: ecspresso.WaitDeploymentContinue,
+		},
+		{
+			name: "in progress at the target stage",
+			dp: types.ServiceDeployment{
+				Status:         types.ServiceDeploymentStatusInProgress,
+				LifecycleStage: types.ServiceDeploymentLifecycleStageBakeTime,
+			},
+			done: reached,
+			want: ecspresso.WaitDeploymentDone,
+		},
+		{
+			name: "the stage during a rollback does not satisfy the target",
+			dp: types.ServiceDeployment{
+				Status:         types.ServiceDeploymentStatusRollbackInProgress,
+				LifecycleStage: types.ServiceDeploymentLifecycleStageBakeTime,
+			},
+			done: reached,
+			want: ecspresso.WaitDeploymentContinue,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ecspresso.EvaluateDeploymentStatus(&tt.dp, tt.done)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected an error")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("evaluateDeploymentStatus = %v, expected %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Port of #1063 and #1064 (v2) to pre-v3.

## What

- `deploy --wait-until ecs:<lifecycle stage>` (e.g. `ecs:BAKE_TIME`) returns when the deployment reaches the target [lifecycle stage](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/blue-green-deployment-how-it-works.html#blue-green-deployment-stages), instead of waiting for the whole deployment to finish. Requires a traffic shifting strategy (blue/green, linear, or canary); validated before calling UpdateService.
- The ECS deployment waiter now takes a done predicate instead of a `waitForPause` bool, so `--wait-until=paused` (pause hook awaiting action) and `ecs:<stage>` (stage position reached) share the same polling loop. The terminal-status decision is extracted into `evaluateDeploymentStatus` for testing.
- A rollback before satisfying a done condition is an error: the condition will never be met, so exiting 0 would mislead CI. This also applies to `--wait-until=paused`, which previously exited 0 when the deployment rolled back before pausing. `deployed` and the standalone `wait` command keep exiting 0 on a rollback.
- The lifecycle stage order is hardcoded following the documented order instead of relying on `ServiceDeploymentLifecycleStage.Values()`, whose ordering the SDK documents as unstable. A test pins the order and fails when the SDK introduces an unknown stage.

`ecs:*` is accepted only by `deploy` for now. `continue`/`rollback`/`wait` keep their enum-restricted `--wait-until`, but the known deployment ARN plumbing is preserved so extending them later is trivial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)