### PR TITLE
Add documentation for --wait-until to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ ecspresso also supports ECS Express mode for simplified deployments and provides
 - [Template syntax](#template-syntax)
 - [Deployment](#example-of-deployment)
   - [Rolling deployment](#rolling-deployment)
+  - [Waiting for the deployment](#waiting-for-the-deployment)
   - [Blue/Green deployment (ECS)](#bluegreen-deployment-with-ecs-deployment-controller)
   - [Blue/Green deployment (CodeDeploy)](#bluegreen-deployment-with-aws-codedeploy)
 - [Scale out/in](#scale-outin)
@@ -442,6 +443,23 @@ Events:
   --[no-]update-service                  update service attributes by service definition
   --latest-task-definition               deploy with the latest task definition without registering a new task definition
 ```
+
+### Waiting for the deployment
+
+`ecspresso deploy` waits until the deployment completes by default. Use `--no-wait` to return immediately after starting the deployment, or `--wait-until` to choose what to wait for.
+
+For the ECS deployment controller:
+- `deployed` (default): Waits until the service deployment completes.
+- `stable`: Waits until the service becomes stable (same as `aws ecs wait services-stable`).
+- `ecs:<lifecycle stage>` (e.g., `ecs:BAKE_TIME`): Waits until the deployment reaches the specified [deployment lifecycle stage](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/blue-green-deployment-how-it-works.html#blue-green-deployment-stages). This is useful to finish a CI job without waiting for a long bake time. Requires a traffic shifting deployment strategy (e.g., `BLUE_GREEN`).
+
+For the CodeDeploy deployment controller:
+- `codedeploy:<lifecycle event>` (e.g., `codedeploy:AfterAllowTraffic`): Waits until the specified CodeDeploy lifecycle event completes.
+- Other values wait until the CodeDeploy deployment succeeds.
+
+In all cases, `ecspresso deploy` exits with a non-zero status when the deployment fails or is rolled back before the wait condition is met.
+
+The `ecspresso wait` command also accepts `--wait-until` (`stable` or `deployed`) to wait for an ongoing deployment without deploying.
 
 ### Blue/Green deployment (with ECS deployment controller)
 


### PR DESCRIPTION
## What

Add a "Waiting for the deployment" section to README, explaining the `--wait-until` values for each deployment controller (`stable` / `deployed` / `ecs:<lifecycle stage>` / `codedeploy:<lifecycle event>`), the exit status on failure or rollback, and the `ecspresso wait` command.

## Why

`--wait-until` was documented only through the generated help text; the accepted values and their semantics (especially `ecs:<lifecycle stage>` added by #1063/#1064) had no prose explanation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)