### PR TITLE
Note that a pause hook at an earlier stage blocks the ecs:* wait

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,7 +451,7 @@ Events:
 For the ECS deployment controller:
 - `deployed` (default): Waits until the service deployment completes.
 - `stable`: Waits until the service becomes stable (same as `aws ecs wait services-stable`).
-- `ecs:<lifecycle stage>` (e.g., `ecs:BAKE_TIME`): Waits until the deployment reaches the specified [deployment lifecycle stage](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/blue-green-deployment-how-it-works.html#blue-green-deployment-stages). This is useful to finish a CI job without waiting for a long bake time. Requires a traffic shifting deployment strategy (e.g., `BLUE_GREEN`).
+- `ecs:<lifecycle stage>` (e.g., `ecs:BAKE_TIME`): Waits until the deployment reaches the specified [deployment lifecycle stage](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/blue-green-deployment-how-it-works.html#blue-green-deployment-stages). This is useful to finish a CI job without waiting for a long bake time. Requires a traffic shifting deployment strategy (e.g., `BLUE_GREEN`). Note that if a pause lifecycle hook is configured at an earlier stage, the wait continues until the deployment is resumed (e.g., by `aws ecs continue-service-deployment`) or times out.
 
 For the CodeDeploy deployment controller:
 - `codedeploy:<lifecycle event>` (e.g., `codedeploy:AfterAllowTraffic`): Waits until the specified CodeDeploy lifecycle event completes.


### PR DESCRIPTION
Follow-up to #1066.

Pause lifecycle hooks pause the deployment on the ECS side regardless of ecspresso support, so `deploy --wait-until ecs:<stage>` keeps waiting when a pause hook at an earlier stage is awaiting action. Add a note to the `ecs:<lifecycle stage>` description, mentioning `aws ecs continue-service-deployment` as the way to resume (v2 has no `continue` command).

🤖 Generated with [Claude Code](https://claude.com/claude-code)