### PR TITLE
Warn when a pause hook blocks the ecs:* lifecycle stage wait

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -39,6 +39,7 @@ var (
 	LifecycleStageIndex             = lifecycleStageIndex
 	ValidateLifecycleStageSupported = validateLifecycleStageSupported
 	EvaluateDeploymentStatus        = evaluateDeploymentStatus
+	PausedHookIDs                   = pausedHookIDs
 )
 
 type WaitDeploymentResult = waitDeploymentResult

--- a/wait.go
+++ b/wait.go
@@ -317,12 +317,42 @@ func (d *App) WaitServiceDeployLifecycleStage(stage types.ServiceDeploymentLifec
 		}
 		d.LogInfo("Waiting for service deployment lifecycle stage...", "stage", string(stage))
 		target := lifecycleStageIndex(stage)
+		notified := map[string]struct{}{}
 		// Stages such as PRODUCTION_TRAFFIC_SHIFT are transient and can be
 		// skipped between polls, so compare positions rather than equality.
 		return d.waitServiceDeployment(ctx, func(dp *types.ServiceDeployment) bool {
-			return lifecycleStageIndex(dp.LifecycleStage) >= target
+			if lifecycleStageIndex(dp.LifecycleStage) >= target {
+				return true
+			}
+			// A pause lifecycle hook awaiting action blocks the deployment, so
+			// the target stage never arrives until the deployment is continued.
+			for _, id := range pausedHookIDs(dp) {
+				if _, ok := notified[id]; ok {
+					continue
+				}
+				notified[id] = struct{}{}
+				d.LogWarn("deployment is paused at a lifecycle hook; the target lifecycle stage will not be reached until the deployment is continued (e.g., by `aws ecs continue-service-deployment`)",
+					"hook_id", id,
+					"lifecycle_stage", string(dp.LifecycleStage),
+					"target_stage", string(stage),
+				)
+			}
+			return false
 		})
 	}
+}
+
+// pausedHookIDs returns the IDs of pause lifecycle hooks of the deployment
+// that are awaiting action.
+func pausedHookIDs(dp *types.ServiceDeployment) []string {
+	var ids []string
+	for _, hook := range dp.LifecycleHookDetails {
+		if hook.TargetType == types.DeploymentLifecycleHookTargetTypePause &&
+			hook.Status == types.DeploymentLifecycleHookStatusAwaitingAction {
+			ids = append(ids, aws.ToString(hook.HookId))
+		}
+	}
+	return ids
 }
 
 // validateLifecycleStageSupported rejects a lifecycle stage target on a service

--- a/wait_test.go
+++ b/wait_test.go
@@ -3,9 +3,41 @@ package ecspresso_test
 import (
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	"github.com/google/go-cmp/cmp"
 	"github.com/kayac/ecspresso/v2"
 )
+
+func TestPausedHookIDs(t *testing.T) {
+	dp := &types.ServiceDeployment{
+		LifecycleHookDetails: []types.DeploymentLifecycleHookDetail{
+			{
+				HookId:     aws.String("hook-awaiting"),
+				TargetType: types.DeploymentLifecycleHookTargetTypePause,
+				Status:     types.DeploymentLifecycleHookStatusAwaitingAction,
+			},
+			{
+				HookId:     aws.String("hook-in-progress"),
+				TargetType: types.DeploymentLifecycleHookTargetTypePause,
+				Status:     types.DeploymentLifecycleHookStatusInProgress,
+			},
+			{
+				HookId:     aws.String("hook-lambda"),
+				TargetType: types.DeploymentLifecycleHookTargetTypeAwsLambda,
+				Status:     types.DeploymentLifecycleHookStatusAwaitingAction,
+			},
+		},
+	}
+	want := []string{"hook-awaiting"}
+	if diff := cmp.Diff(want, ecspresso.PausedHookIDs(dp)); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+
+	if got := ecspresso.PausedHookIDs(&types.ServiceDeployment{}); got != nil {
+		t.Errorf("expected nil for no hooks, got %v", got)
+	}
+}
 
 func TestLifecycleStageIndex(t *testing.T) {
 	// The waiter compares positions instead of equality, so pin the full


### PR DESCRIPTION
## What

While `deploy --wait-until ecs:<stage>` is polling, if a pause lifecycle hook is awaiting action, log a warning (once per hook) with the hook ID, the current stage, the target stage, and a hint to resume via `aws ecs continue-service-deployment`.

## Why

A pause hook configured at a stage earlier than the target blocks the deployment until it is continued, so the wait looks like a hang. The warning tells the operator what is happening and what to do at the moment it matters, instead of speculatively warning at deploy start (pausing is an intentional configuration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)