### PR TITLE
Warn when a pause hook blocks the ecs:* lifecycle stage wait

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -40,6 +40,7 @@ var (
 	LifecycleStageIndex             = lifecycleStageIndex
 	ValidateLifecycleStageSupported = validateLifecycleStageSupported
 	EvaluateDeploymentStatus        = evaluateDeploymentStatus
+	PausedHookIDs                   = pausedHookIDs
 )
 
 type WaitDeploymentResult = waitDeploymentResult

--- a/wait.go
+++ b/wait.go
@@ -460,17 +460,27 @@ func evaluateDeploymentStatus(dp *types.ServiceDeployment, done func(*types.Serv
 // deploymentPaused reports whether a pause lifecycle hook of the deployment is
 // awaiting action.
 func (d *App) deploymentPaused(dp *types.ServiceDeployment) bool {
+	ids := pausedHookIDs(dp)
+	for _, id := range ids {
+		d.LogInfo("deployment paused at lifecycle hook",
+			"hook_id", id,
+			"lifecycle_stage", string(dp.LifecycleStage),
+		)
+	}
+	return len(ids) > 0
+}
+
+// pausedHookIDs returns the IDs of pause lifecycle hooks of the deployment
+// that are awaiting action.
+func pausedHookIDs(dp *types.ServiceDeployment) []string {
+	var ids []string
 	for _, hook := range dp.LifecycleHookDetails {
 		if hook.TargetType == types.DeploymentLifecycleHookTargetTypePause &&
 			hook.Status == types.DeploymentLifecycleHookStatusAwaitingAction {
-			d.LogInfo("deployment paused at lifecycle hook",
-				"hook_id", aws.ToString(hook.HookId),
-				"lifecycle_stage", string(dp.LifecycleStage),
-			)
-			return true
+			ids = append(ids, aws.ToString(hook.HookId))
 		}
 	}
-	return false
+	return ids
 }
 
 // WaitServiceDeployLifecycleStage returns a waitFunc that waits until the
@@ -492,12 +502,26 @@ func (d *App) WaitServiceDeployLifecycleStage(stage types.ServiceDeploymentLifec
 			d.LogWarn("deployment strategy is not set; a ROLLING deployment reports no lifecycle stage, so this waits until the deployment completes")
 		}
 		d.LogInfo("Waiting for service deployment lifecycle stage...", "stage", string(stage))
+		notified := map[string]struct{}{}
 		// Stages such as PRODUCTION_TRAFFIC_SHIFT are transient and can be
 		// skipped between polls, so compare positions rather than equality.
 		return d.waitServiceDeployment(ctx, knownDeploymentArn, func(dp *types.ServiceDeployment) bool {
 			if lifecycleStageIndex(dp.LifecycleStage) >= target {
 				d.LogInfo("service deployment reached the lifecycle stage", "stage", string(dp.LifecycleStage))
 				return true
+			}
+			// A pause lifecycle hook awaiting action blocks the deployment, so
+			// the target stage never arrives until the deployment is continued.
+			for _, id := range pausedHookIDs(dp) {
+				if _, ok := notified[id]; ok {
+					continue
+				}
+				notified[id] = struct{}{}
+				d.LogWarn("deployment is paused at a lifecycle hook; the target lifecycle stage will not be reached until the deployment is continued (run `ecspresso continue`)",
+					"hook_id", id,
+					"lifecycle_stage", string(dp.LifecycleStage),
+					"target_stage", string(stage),
+				)
 			}
 			return false
 		})

--- a/wait_test.go
+++ b/wait_test.go
@@ -6,8 +6,39 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	"github.com/google/go-cmp/cmp"
 	"github.com/kayac/ecspresso/v2"
 )
+
+func TestPausedHookIDs(t *testing.T) {
+	dp := &types.ServiceDeployment{
+		LifecycleHookDetails: []types.DeploymentLifecycleHookDetail{
+			{
+				HookId:     aws.String("hook-awaiting"),
+				TargetType: types.DeploymentLifecycleHookTargetTypePause,
+				Status:     types.DeploymentLifecycleHookStatusAwaitingAction,
+			},
+			{
+				HookId:     aws.String("hook-in-progress"),
+				TargetType: types.DeploymentLifecycleHookTargetTypePause,
+				Status:     types.DeploymentLifecycleHookStatusInProgress,
+			},
+			{
+				HookId:     aws.String("hook-lambda"),
+				TargetType: types.DeploymentLifecycleHookTargetTypeAwsLambda,
+				Status:     types.DeploymentLifecycleHookStatusAwaitingAction,
+			},
+		},
+	}
+	want := []string{"hook-awaiting"}
+	if diff := cmp.Diff(want, ecspresso.PausedHookIDs(dp)); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+
+	if got := ecspresso.PausedHookIDs(&types.ServiceDeployment{}); got != nil {
+		t.Errorf("expected nil for no hooks, got %v", got)
+	}
+}
 
 func TestLifecycleStageIndex(t *testing.T) {
 	// The waiter compares positions instead of equality, so pin the full


### PR DESCRIPTION
Port of #1069 to pre-v3.

## What

While `deploy --wait-until ecs:<stage>` is polling, if a pause lifecycle hook is awaiting action, log a warning (once per hook) with the hook ID, the current stage, the target stage, and a hint to run `ecspresso continue`. The pause detection is extracted into `pausedHookIDs`, shared with `deploymentPaused` (the `--wait-until=paused` path).

## Why

A pause hook configured at a stage earlier than the target blocks the deployment until it is continued, so the wait looks like a hang. The warning tells the operator what is happening and what to do at the moment it matters, instead of speculatively warning at deploy start (pausing is an intentional configuration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)