### PR TITLE
Fill deploymentConfiguration defaults in diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,8 @@ The `ecspresso wait` command also accepts `--wait-until` (`stable` or `deployed`
 
 `ecspresso deploy` returns as soon as the deployment completes (with the default `--wait-until=deployed`), and `ecspresso verify` validates `earlySuccessCriteria` before deploying.
 
+To turn it off on a service that already has it, set `"enable": false` explicitly. Omitting `earlySuccessCriteria` keeps the current setting of the service, and ECS rejects switching to another deployment strategy while it is enabled.
+
 ```console
 $ ecspresso deploy --config ecspresso.yml
 ...

--- a/diff.go
+++ b/diff.go
@@ -422,6 +422,7 @@ func ServiceDefinitionForDiff(sv *Service) *ServiceForDiff {
 			MinimumHealthyPercent: aws.Int32(0),
 		}
 	}
+	fillDeploymentConfigurationDefaults(sv.DeploymentConfiguration)
 
 	if nc := sv.NetworkConfiguration; nc != nil {
 		if ac := nc.AwsvpcConfiguration; ac != nil {
@@ -449,6 +450,41 @@ func ServiceDefinitionForDiff(sv *Service) *ServiceForDiff {
 		}
 	}
 	return sfd
+}
+
+// fillDeploymentConfigurationDefaults fills the fields that DescribeServices
+// returns with their default values when the service definition omits them,
+// so that they don't appear as differences.
+func fillDeploymentConfigurationDefaults(dc *types.DeploymentConfiguration) {
+	if dc == nil {
+		return
+	}
+	if cb := dc.DeploymentCircuitBreaker; cb != nil {
+		if cb.ResetOnHealthyTask == nil {
+			cb.ResetOnHealthyTask = aws.Bool(true)
+		}
+		if cb.ThresholdConfiguration == nil {
+			cb.ThresholdConfiguration = &types.ThresholdConfiguration{
+				Type:  types.ThresholdTypeBoundedPercent,
+				Value: 50,
+			}
+		}
+	}
+	for i := range dc.LifecycleHooks {
+		hook := &dc.LifecycleHooks[i]
+		if hook.TargetType == "" {
+			hook.TargetType = types.DeploymentLifecycleHookTargetTypeAwsLambda
+		}
+		if hook.TimeoutConfiguration == nil {
+			hook.TimeoutConfiguration = &types.DeploymentLifecycleHookTimeoutConfiguration{}
+		}
+		if hook.TimeoutConfiguration.Action == "" {
+			hook.TimeoutConfiguration.Action = types.DeploymentLifecycleHookActionRollback
+		}
+		if hook.TimeoutConfiguration.TimeoutInMinutes == nil {
+			hook.TimeoutConfiguration.TimeoutInMinutes = aws.Int32(1440)
+		}
+	}
 }
 
 func sortTaskDefinition(td *TaskDefinitionInput) {

--- a/diff.go
+++ b/diff.go
@@ -470,6 +470,14 @@ func fillDeploymentConfigurationDefaults(dc *types.DeploymentConfiguration) {
 			}
 		}
 	}
+	if esc := dc.EarlySuccessCriteria; esc != nil {
+		if esc.HealthyPercent == nil {
+			esc.HealthyPercent = aws.Int32(100)
+		}
+		if esc.SourceServiceRevisionCleanup == "" {
+			esc.SourceServiceRevisionCleanup = types.ServiceRevisionCleanupBlocking
+		}
+	}
 	for i := range dc.LifecycleHooks {
 		hook := &dc.LifecycleHooks[i]
 		if hook.TargetType == "" {

--- a/diff_test.go
+++ b/diff_test.go
@@ -786,9 +786,9 @@ func TestDiffServicesMonitoring(t *testing.T) {
 	})
 }
 
-// DescribeServices fills deploymentCircuitBreaker and lifecycleHooks with
-// default values that a service definition usually omits, so they must not
-// be reported as differences.
+// DescribeServices fills deploymentCircuitBreaker, earlySuccessCriteria and
+// lifecycleHooks with default values that a service definition usually
+// omits, so they must not be reported as differences.
 func TestDiffServicesDeploymentConfigurationDefaults(t *testing.T) {
 	ctx := t.Context()
 	color.NoColor = true
@@ -798,6 +798,9 @@ func TestDiffServicesDeploymentConfigurationDefaults(t *testing.T) {
 				DeploymentCircuitBreaker: &types.DeploymentCircuitBreaker{
 					Enable:   false,
 					Rollback: false,
+				},
+				EarlySuccessCriteria: &types.DeploymentEarlySuccessCriteria{
+					Enable: false,
 				},
 				LifecycleHooks: []types.DeploymentLifecycleHook{
 					{
@@ -827,6 +830,11 @@ func TestDiffServicesDeploymentConfigurationDefaults(t *testing.T) {
 						Type:  types.ThresholdTypeBoundedPercent,
 						Value: 50,
 					},
+				},
+				EarlySuccessCriteria: &types.DeploymentEarlySuccessCriteria{
+					Enable:                       false,
+					HealthyPercent:               aws.Int32(100),
+					SourceServiceRevisionCleanup: types.ServiceRevisionCleanupBlocking,
 				},
 				LifecycleHooks: []types.DeploymentLifecycleHook{
 					{

--- a/diff_test.go
+++ b/diff_test.go
@@ -785,3 +785,105 @@ func TestDiffServicesMonitoring(t *testing.T) {
 		}
 	})
 }
+
+// DescribeServices fills deploymentCircuitBreaker and lifecycleHooks with
+// default values that a service definition usually omits, so they must not
+// be reported as differences.
+func TestDiffServicesDeploymentConfigurationDefaults(t *testing.T) {
+	ctx := t.Context()
+	color.NoColor = true
+	local := &ecspresso.Service{
+		Service: types.Service{
+			DeploymentConfiguration: &types.DeploymentConfiguration{
+				DeploymentCircuitBreaker: &types.DeploymentCircuitBreaker{
+					Enable:   false,
+					Rollback: false,
+				},
+				LifecycleHooks: []types.DeploymentLifecycleHook{
+					{
+						HookTargetArn:   aws.String("arn:aws:lambda:ap-northeast-1:123456789012:function:hook"),
+						RoleArn:         aws.String("arn:aws:iam::123456789012:role/ECSServiceRole"),
+						LifecycleStages: []types.DeploymentLifecycleHookStage{types.DeploymentLifecycleHookStagePostScaleUp},
+					},
+					{
+						TargetType:      types.DeploymentLifecycleHookTargetTypePause,
+						LifecycleStages: []types.DeploymentLifecycleHookStage{types.DeploymentLifecycleHookStagePostTestTrafficShift},
+						TimeoutConfiguration: &types.DeploymentLifecycleHookTimeoutConfiguration{
+							TimeoutInMinutes: aws.Int32(30),
+						},
+					},
+				},
+			},
+		},
+	}
+	remote := &ecspresso.Service{
+		Service: types.Service{
+			DeploymentConfiguration: &types.DeploymentConfiguration{
+				DeploymentCircuitBreaker: &types.DeploymentCircuitBreaker{
+					Enable:             false,
+					Rollback:           false,
+					ResetOnHealthyTask: aws.Bool(true),
+					ThresholdConfiguration: &types.ThresholdConfiguration{
+						Type:  types.ThresholdTypeBoundedPercent,
+						Value: 50,
+					},
+				},
+				LifecycleHooks: []types.DeploymentLifecycleHook{
+					{
+						TargetType:      types.DeploymentLifecycleHookTargetTypeAwsLambda,
+						HookTargetArn:   aws.String("arn:aws:lambda:ap-northeast-1:123456789012:function:hook"),
+						RoleArn:         aws.String("arn:aws:iam::123456789012:role/ECSServiceRole"),
+						LifecycleStages: []types.DeploymentLifecycleHookStage{types.DeploymentLifecycleHookStagePostScaleUp},
+						TimeoutConfiguration: &types.DeploymentLifecycleHookTimeoutConfiguration{
+							Action:           types.DeploymentLifecycleHookActionRollback,
+							TimeoutInMinutes: aws.Int32(1440),
+						},
+					},
+					{
+						TargetType:      types.DeploymentLifecycleHookTargetTypePause,
+						LifecycleStages: []types.DeploymentLifecycleHookStage{types.DeploymentLifecycleHookStagePostTestTrafficShift},
+						TimeoutConfiguration: &types.DeploymentLifecycleHookTimeoutConfiguration{
+							Action:           types.DeploymentLifecycleHookActionRollback,
+							TimeoutInMinutes: aws.Int32(30),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("defaults are not reported", func(t *testing.T) {
+		b := new(bytes.Buffer)
+		opt := &ecspresso.DiffOption{Unified: true}
+		opt.SetWriter(b)
+		diff, err := ecspresso.DiffServices(ctx, local, remote, "file", opt)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if diff {
+			t.Errorf("unexpected diff:\n%s", b.String())
+		}
+	})
+
+	t.Run("explicit non-default values are reported", func(t *testing.T) {
+		b := new(bytes.Buffer)
+		opt := &ecspresso.DiffOption{Unified: true}
+		opt.SetWriter(b)
+		local.DeploymentConfiguration.DeploymentCircuitBreaker.ResetOnHealthyTask = aws.Bool(false)
+		local.DeploymentConfiguration.LifecycleHooks[0].TimeoutConfiguration = &types.DeploymentLifecycleHookTimeoutConfiguration{
+			Action: types.DeploymentLifecycleHookActionContinue,
+		}
+		diff, err := ecspresso.DiffServices(ctx, local, remote, "file", opt)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !diff {
+			t.Fatal("diff must be detected")
+		}
+		for _, want := range []string{`+      "resetOnHealthyTask": false`, `+          "action": "CONTINUE"`} {
+			if !strings.Contains(b.String(), want) {
+				t.Errorf("diff must contain %q:\n%s", want, b.String())
+			}
+		}
+	})
+}


### PR DESCRIPTION
## What

`ecspresso diff` no longer reports the following fields as differences when the service definition omits them:

- `deploymentCircuitBreaker.resetOnHealthyTask` (default `true`)
- `deploymentCircuitBreaker.thresholdConfiguration` (default `{"type": "BOUNDED_PERCENT", "value": 50}`)
- `earlySuccessCriteria.healthyPercent` / `sourceServiceRevisionCleanup` (default `100` / `BLOCKING`, returned for `{"enable": false}`)
- `lifecycleHooks[].targetType` (default `AWS_LAMBDA`)
- `lifecycleHooks[].timeoutConfiguration` (default `{"action": "ROLLBACK", "timeoutInMinutes": 1440}`, also for `PAUSE` hooks)

The defaults are filled on both the local and remote side in `ServiceDefinitionForDiff`, in the same way as the existing `deploymentCircuitBreaker` / `bakeTimeInMinutes` handling. Explicit non-default values are still reported.

README: note that turning early success criteria off requires an explicit `"enable": false`, because omitting `earlySuccessCriteria` keeps the current setting and ECS rejects switching to another strategy while it is enabled ("Early success criteria not supported for BLUE_GREEN deployment strategy").

## Why

`DescribeServices` returns these fields with their default values, so a typical service definition that only sets `enable` / `rollback` for the circuit breaker or omits the hook timeout always showed a spurious diff like:

```
     "deploymentCircuitBreaker": {
       "enable": false,
-      "resetOnHealthyTask": true,
-      "rollback": false,
-      "thresholdConfiguration": {
-        "type": "BOUNDED_PERCENT",
-        "value": 50
-      }
+      "rollback": false
     },
```

The default values are taken from the API reference for [DeploymentCircuitBreaker](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_DeploymentCircuitBreaker.html), [ThresholdConfiguration](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ThresholdConfiguration.html), [DeploymentLifecycleHook](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_DeploymentLifecycleHook.html), and [DeploymentLifecycleHookTimeoutConfiguration](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_DeploymentLifecycleHookTimeoutConfiguration.html), and match what a real service returns for both `AWS_LAMBDA` and `PAUSE` hooks and for a disabled `earlySuccessCriteria`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)